### PR TITLE
feat!: impl `Message` and `Query` for actor instead of message type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ impl Actor for Counter {}
 // Define messages
 struct Inc { amount: u32 }
 
-impl Message<Counter> for Inc {
+impl Message<Inc> for Counter {
     type Reply = Result<i64, Infallible>;
 
-    async fn handle(self, state: &mut Counter) -> Self::Reply {
-        state.count += self.0 as i64;
-        Ok(state.count)
+    async fn handle(&mut self, msg: Counter) -> Self::Reply {
+        self.count += msg.0 as i64;
+        Ok(self.count)
     }
 }
 ```
@@ -98,11 +98,11 @@ impl kameo::Actor for Counter {
 // Messages
 struct Inc { amount: u32 }
 
-impl kameo::Message<Counter> for Inc {
+impl kameo::Message<Inc> for Counter {
     type Reply = Result<i64, Infallible>;
 
-    async fn handle(self, state: &mut Counter) -> Self::Reply {
-        state.inc(self.amount)
+    async fn handle(&mut self, msg: &mut Inc) -> Self::Reply {
+        self.inc(msg.amount)
     }
 }
 ```

--- a/crates/kameo/benches/fibonacci.rs
+++ b/crates/kameo/benches/fibonacci.rs
@@ -11,19 +11,19 @@ impl Actor for FibActor {}
 
 struct Fib(u64);
 
-impl Message<FibActor> for Fib {
+impl Message<Fib> for FibActor {
     type Reply = Result<u64, Infallible>;
 
-    async fn handle(self, _state: &mut FibActor) -> Self::Reply {
-        Ok(fibonacci(self.0))
+    async fn handle(&mut self, msg: Fib) -> Self::Reply {
+        Ok(fibonacci(msg.0))
     }
 }
 
-impl Query<FibActor> for Fib {
+impl Query<Fib> for FibActor {
     type Reply = Result<u64, Infallible>;
 
-    async fn handle(self, _state: &FibActor) -> Self::Reply {
-        Ok(fibonacci(self.0))
+    async fn handle(&self, msg: Fib) -> Self::Reply {
+        Ok(fibonacci(msg.0))
     }
 }
 

--- a/crates/kameo/examples/basic.rs
+++ b/crates/kameo/examples/basic.rs
@@ -20,22 +20,22 @@ pub struct Inc {
     amount: u32,
 }
 
-impl Message<MyActor> for Inc {
+impl Message<Inc> for MyActor {
     type Reply = Result<i64, Infallible>;
 
-    async fn handle(self, state: &mut MyActor) -> Self::Reply {
-        state.count += self.amount as i64;
-        Ok(state.count)
+    async fn handle(&mut self, msg: Inc) -> Self::Reply {
+        self.count += msg.amount as i64;
+        Ok(self.count)
     }
 }
 
 // Always returns an error
 pub struct ForceErr;
 
-impl Message<MyActor> for ForceErr {
+impl Message<ForceErr> for MyActor {
     type Reply = Result<(), i32>;
 
-    async fn handle(self, _state: &mut MyActor) -> Self::Reply {
+    async fn handle(&mut self, _msg: ForceErr) -> Self::Reply {
         Err(3)
     }
 }
@@ -43,11 +43,11 @@ impl Message<MyActor> for ForceErr {
 // Queries the current count
 pub struct Count;
 
-impl Query<MyActor> for Count {
+impl Query<Count> for MyActor {
     type Reply = Result<i64, Infallible>;
 
-    async fn handle(self, state: &MyActor) -> Self::Reply {
-        Ok(state.count)
+    async fn handle(&self, _msg: Count) -> Self::Reply {
+        Ok(self.count)
     }
 }
 

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -47,12 +47,12 @@
 //! // Define messages
 //! struct Inc(u32);
 //!
-//! impl Message<Counter> for Inc {
+//! impl Message<Inc> for Counter {
 //!     type Reply = Result<i64, Infallible>;
 //!
-//!     async fn handle(self, state: &mut Counter) -> Self::Reply {
-//!         state.count += self.0 as i64;
-//!         Ok(state.count)
+//!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
+//!         self.count += msg.0 as i64;
+//!         Ok(self.count)
 //!     }
 //! }
 //! ```
@@ -93,11 +93,11 @@
 //! // Messages
 //! struct Inc { amount: u32 }
 //!
-//! impl kameo::Message<Counter> for Inc {
+//! impl kameo::Message<Inc> for Counter {
 //!     type Reply = Result<i64, Infallible>;
 //!
-//!     async fn handle(self, state: &mut Counter) -> Self::Reply {
-//!         state.inc(self.amount)
+//!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
+//!         self.inc(msg.amount)
 //!     }
 //! }
 //! ```

--- a/crates/kameo_macros/src/lib.rs
+++ b/crates/kameo_macros/src/lib.rs
@@ -52,32 +52,32 @@ use syn::parse_macro_input;
 ///     pub amount: u32,
 /// }
 ///
-/// impl kameo::Message<Counter> for Inc {
+/// impl kameo::Message<Inc> for Counter {
 ///     type Reply = Result<i64, Infallible>;
 ///
-///     async fn handle(self, state: &mut Counter) -> Self::Reply {
-///         state.inc(self.amount)
+///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
+///         self.inc(msg.amount)
 ///     }
 /// }
 ///
 /// pub struct Count;
 ///
-/// impl kameo::Query<Counter> for Count {
+/// impl kameo::Query<Count> for Counter {
 ///     type Reply = Result<i64, Infallible>;
 ///
-///     async fn handle(self, state: &Counter) -> Self::Reply {
-///         state.count()
+///     async fn handle(&self, msg: Counter) -> Self::Reply {
+///         self.count()
 ///     }
 /// }
 ///
 /// #[derive(Clone, Copy)]
 /// pub struct Dec;
 ///
-/// impl kameo::Message<Counter> for Dec {
+/// impl kameo::Message<Dec> for Counter {
 ///     type Reply = Result<(), Infallible>;
 ///
-///     async fn handle(self, state: &mut Counter) -> Self::Reply {
-///         state.dec(self.amount)
+///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
+///         self.dec(msg.amount)
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
Previously, implementing `Message` and `Actor` were done on the message type itself.
```rust
impl Message<A> for M {
    type Reply;
    async fn handle(self, state: &mut A) -> Self::Reply;
}
```
This is quite confusing and unintuative to work with.

This PR changes the position of the actor and message type in the implementations so that `self` becomes the actor state.
```rust
impl Message<M> for A {
    type Reply;
    async fn handle(&mut self, msg: M) -> Self::Reply;
}
```