### PR TITLE
Handler error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,17 @@
 
 ### Installing
 
-**Stable**
+Install using `cargo add`:
+
+```bash
+cargo add kameo
+```
+
+or adding to your dependencies manually:
 
 ```toml
 [dependencies]
 kameo = "*"
-```
-
-**Nightly**
-
-Nightly allows for some cleaner apis thanks to specialization.
-
-Notably,
-
-- `Message::Reply` and `Query::Reply` can be any type, not just `Result` types.
-- `spawn_unsync` and other `_unsync` methods are not required - `!Sync` actors are inferred automatically.
-
-
-```toml
-[dependencies]
-kameo = { version = "*", features = ["nightly"] }
 ```
 
 ### Defining an Actor without Macros
@@ -55,11 +46,11 @@ impl Actor for Counter {}
 struct Inc { amount: u32 }
 
 impl Message<Inc> for Counter {
-    type Reply = Result<i64, Infallible>;
+    type Reply = i64;
 
     async fn handle(&mut self, msg: Counter) -> Self::Reply {
         self.count += msg.0 as i64;
-        Ok(self.count)
+        self.count
     }
 }
 ```
@@ -77,9 +68,9 @@ struct Counter {
 #[actor]
 impl Counter {
     #[message]
-    fn inc(&mut self, amount: u32) -> Result<i64, Infallible> {
+    fn inc(&mut self, amount: u32) -> i64 {
         self.count += amount as i64;
-        Ok(self.count)
+        self.count
     }
 }
 ```
@@ -99,7 +90,7 @@ impl kameo::Actor for Counter {
 struct Inc { amount: u32 }
 
 impl kameo::Message<Inc> for Counter {
-    type Reply = Result<i64, Infallible>;
+    type Reply = i64;
 
     async fn handle(&mut self, msg: &mut Inc) -> Self::Reply {
         self.inc(msg.amount)

--- a/crates/kameo/Cargo.toml
+++ b/crates/kameo/Cargo.toml
@@ -24,10 +24,6 @@ criterion = { version = "0.4", features = ["async_tokio"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[features]
-default = []
-nightly = []
-
 [[bench]]
 name = "fibonacci"
 harness = false

--- a/crates/kameo/benches/fibonacci.rs
+++ b/crates/kameo/benches/fibonacci.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
@@ -12,18 +10,18 @@ impl Actor for FibActor {}
 struct Fib(u64);
 
 impl Message<Fib> for FibActor {
-    type Reply = Result<u64, Infallible>;
+    type Reply = u64;
 
     async fn handle(&mut self, msg: Fib) -> Self::Reply {
-        Ok(fibonacci(msg.0))
+        fibonacci(msg.0)
     }
 }
 
 impl Query<Fib> for FibActor {
-    type Reply = Result<u64, Infallible>;
+    type Reply = u64;
 
     async fn handle(&self, msg: Fib) -> Self::Reply {
-        Ok(fibonacci(msg.0))
+        fibonacci(msg.0)
     }
 }
 

--- a/crates/kameo/examples/basic.rs
+++ b/crates/kameo/examples/basic.rs
@@ -62,14 +62,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let my_actor_ref = MyActor::default().spawn();
 
     // Increment the count by 3
-    let count = my_actor_ref.send(Inc { amount: 3 }).await??;
+    let count = my_actor_ref.send(Inc { amount: 3 }).await?;
     info!("Count is {count}");
 
     // Increment the count by 50 in the background
     my_actor_ref.send_async(Inc { amount: 50 })?;
 
     // Increment the count by 2
-    let count = my_actor_ref.send(Inc { amount: 2 }).await??;
+    let count = my_actor_ref.send(Inc { amount: 2 }).await?;
     info!("Count is {count}");
 
     // Async messages that return an Err will cause the actor to panic

--- a/crates/kameo/examples/basic.rs
+++ b/crates/kameo/examples/basic.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use kameo::{Actor, Message, Query, Spawn};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -21,11 +19,11 @@ pub struct Inc {
 }
 
 impl Message<Inc> for MyActor {
-    type Reply = Result<i64, Infallible>;
+    type Reply = i64;
 
     async fn handle(&mut self, msg: Inc) -> Self::Reply {
         self.count += msg.amount as i64;
-        Ok(self.count)
+        self.count
     }
 }
 
@@ -44,10 +42,10 @@ impl Message<ForceErr> for MyActor {
 pub struct Count;
 
 impl Query<Count> for MyActor {
-    type Reply = Result<i64, Infallible>;
+    type Reply = i64;
 
     async fn handle(&self, _msg: Count) -> Self::Reply {
-        Ok(self.count)
+        self.count
     }
 }
 

--- a/crates/kameo/examples/macro.rs
+++ b/crates/kameo/examples/macro.rs
@@ -55,14 +55,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let my_actor_ref = MyActor::new().spawn();
 
     // Increment the count by 3
-    let count = my_actor_ref.send(Inc { amount: 3 }).await??;
+    let count = my_actor_ref.send(Inc { amount: 3 }).await?;
     info!("Count is {count}");
 
     // Increment the count by 50 in the background
     my_actor_ref.send_async(Inc { amount: 50 })?;
 
     // Query the count
-    let count = my_actor_ref.query(Count).await??;
+    let count = my_actor_ref.query(Count).await?;
     info!("Count is {count}");
 
     // Generic message
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .send(Print {
             msg: "Generics work!",
         })
-        .await??;
+        .await?;
 
     // Async messages that return an Err will cause the actor to panic
     my_actor_ref.send_async(ForceErr)?;

--- a/crates/kameo/examples/macro.rs
+++ b/crates/kameo/examples/macro.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, fmt};
+use std::fmt;
 
 use kameo::*;
 use tracing::info;
@@ -16,9 +16,9 @@ impl MyActor {
     }
 
     #[message(derive(Clone))]
-    fn inc(&mut self, amount: u32) -> Result<i64, Infallible> {
+    fn inc(&mut self, amount: u32) -> i64 {
         self.count += amount as i64;
-        Ok(self.count)
+        self.count
     }
 
     #[message]
@@ -27,8 +27,8 @@ impl MyActor {
     }
 
     #[query]
-    fn count(&self) -> Result<i64, Infallible> {
-        Ok(self.count)
+    fn count(&self) -> i64 {
+        self.count
     }
 
     /// Prints a message

--- a/crates/kameo/examples/pool.rs
+++ b/crates/kameo/examples/pool.rs
@@ -31,14 +31,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut pool = ActorPool::new(5, || MyActor.spawn());
     for _ in 0..10 {
-        pool.send(PrintActorId).await??;
+        pool.send(PrintActorId).await?;
     }
 
     pool.broadcast(ForceStop).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     for _ in 0..10 {
-        pool.send(PrintActorId).await??;
+        pool.send(PrintActorId).await?;
     }
 
     Ok(())

--- a/crates/kameo/src/actor_kind.rs
+++ b/crates/kameo/src/actor_kind.rs
@@ -26,7 +26,11 @@ pub(crate) trait ActorState<A: Actor>: Sized {
     async fn handle_query(
         &mut self,
         query: Box<dyn DynQuery<A>>,
-        reply: Option<oneshot::Sender<Result<BoxReply, SendError<Box<dyn any::Any + Send>>>>>,
+        reply: Option<
+            oneshot::Sender<
+                Result<BoxReply, SendError<Box<dyn any::Any + Send>, Box<dyn any::Any + Send>>>,
+            >,
+        >,
     ) -> Option<ActorStopReason>;
 
     async fn handle_link_died(
@@ -125,7 +129,11 @@ where
     async fn handle_query(
         &mut self,
         query: Box<dyn DynQuery<A>>,
-        reply: Option<oneshot::Sender<Result<BoxReply, SendError<Box<dyn any::Any + Send>>>>>,
+        reply: Option<
+            oneshot::Sender<
+                Result<BoxReply, SendError<Box<dyn any::Any + Send>, Box<dyn any::Any + Send>>>,
+            >,
+        >,
     ) -> Option<ActorStopReason> {
         let permit = self.semaphore.clone().acquire_owned().await;
         let state = self.state.clone();
@@ -292,14 +300,18 @@ where
     async fn handle_query(
         &mut self,
         _query: Box<dyn DynQuery<A>>,
-        reply: Option<oneshot::Sender<Result<BoxReply, SendError<Box<dyn any::Any + Send>>>>>,
+        reply: Option<
+            oneshot::Sender<
+                Result<BoxReply, SendError<Box<dyn any::Any + Send>, Box<dyn any::Any + Send>>>,
+            >,
+        >,
     ) -> Option<ActorStopReason> {
         match reply {
             Some(reply) => {
                 let _ = reply.send(Err(SendError::QueriesNotSupported));
                 None
             }
-            None => panic_any(SendError::<()>::QueriesNotSupported),
+            None => panic_any(SendError::<(), ()>::QueriesNotSupported),
         }
     }
 

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -10,29 +10,10 @@
 //!
 //! ## Installing
 //!
-//! **Stable**
-//!
 //! ```toml
 //! [dependencies]
 //! kameo = "*"
 //! ```
-//!
-//! **Nightly**
-//!
-//! ```toml
-//! [dependencies]
-//! kameo = { version = "*", features = ["nightly"] }
-//! ```
-//!
-//! ## `nightly` feature flag
-//!
-//! The `nightly` feature flag allows for any type to be used in a [Message] or [Query]'s reply.
-//! It also removes the need for `spawn_unsend` and other `_unsend` methods, since actor "sendness" can be inferred.
-//! This is done though specialization, which requires nightly rust.
-//!
-//! Without the nightly feature flag, all replies must be a `Result<T, E>`, where `E: Debug + Send + Sync + 'static`.
-//! This is to ensure that asyncronous messages that fail will cause the actor to panic,
-//! since otherwise the error would be silently ignored.
 //!
 //! ## Defining an Actor without Macros
 //!
@@ -48,16 +29,14 @@
 //! struct Inc(u32);
 //!
 //! impl Message<Inc> for Counter {
-//!     type Reply = Result<i64, Infallible>;
+//!     type Reply = i64;
 //!
 //!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
 //!         self.count += msg.0 as i64;
-//!         Ok(self.count)
+//!         self.count
 //!     }
 //! }
 //! ```
-//!
-//! Note, with the `nightly` feature flag enabled, this reply type can be `i64` directly without the result.
 //!
 //! ## Defining an Actor with Macros
 //!
@@ -72,9 +51,9 @@
 //! #[actor]
 //! impl Counter {
 //!     #[message]
-//!     fn inc(&mut self, amount: u32) -> Result<i64, Infallible> {
+//!     fn inc(&mut self, amount: u32) -> i64 {
 //!         self.count += amount as i64;
-//!         Ok(self.count)
+//!         self.count
 //!     }
 //! }
 //! ```
@@ -94,7 +73,7 @@
 //! struct Inc { amount: u32 }
 //!
 //! impl kameo::Message<Inc> for Counter {
-//!     type Reply = Result<i64, Infallible>;
+//!     type Reply = i64;
 //!
 //!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
 //!         self.inc(msg.amount)
@@ -114,8 +93,6 @@
 //! println!("Count is {count}");
 //! ```
 
-#![cfg_attr(feature = "nightly", feature(specialization))]
-#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
@@ -133,7 +110,7 @@ mod spawn;
 pub use actor::Actor;
 pub use actor_ref::ActorRef;
 pub use error::{ActorStopReason, BoxError, PanicError, SendError};
-pub use kameo_macros::{actor, Actor};
+pub use kameo_macros::{actor, Actor, Reply};
 pub use message::{Message, Query, Reply};
 pub use pool::ActorPool;
 pub use spawn::Spawn;

--- a/crates/kameo/src/message.rs
+++ b/crates/kameo/src/message.rs
@@ -1,4 +1,21 @@
-use std::{any, fmt};
+use std::{
+    any,
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    fmt,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+        NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    },
+    sync::{
+        atomic::{
+            AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr,
+            AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
+        },
+        Arc, Mutex, Once, RwLock,
+    },
+    thread::Thread,
+};
 
 use futures::{future::BoxFuture, Future, FutureExt};
 
@@ -11,8 +28,7 @@ pub(crate) type BoxReply = Box<dyn any::Any + Send>;
 ///
 /// Messages are processed sequentially one at a time, with exclusive mutable access to the actors state.
 ///
-/// The reply type must implement [Reply], which has different implementations based on the `nightly` feature flag.
-/// See the Reply docs for more information on this.
+/// The reply type must implement [Reply].
 pub trait Message<T>: Send + 'static {
     /// The reply sent back to the message caller.
     type Reply: Reply + Send + 'static;
@@ -27,8 +43,7 @@ pub trait Message<T>: Send + 'static {
 /// if multiple queries are sent in sequence. This means queries only have read access
 /// to the actors state.
 ///
-/// The reply type must implement [Reply], which has different implementations based on the `nightly` feature flag.
-/// See the Reply docs for more information on this.
+/// The reply type must implement [Reply].
 pub trait Query<T>: Send + 'static {
     /// The reply sent back to the query caller.
     type Reply: Reply + Send + 'static;
@@ -39,16 +54,11 @@ pub trait Query<T>: Send + 'static {
 
 /// A reply value.
 ///
-/// If an Err is returned by a handler, and is unhandled by the caller (ie, the message was sent async),
+/// If an Err is returned by a hadler, and is unhandled by the caller (ie, the message was sent async),
 /// then the error is treated as a panic in the actor.
 ///
-/// ### On Stable
-///
-/// This is implemented for all `Result<T, E>` types, where `E: Debug + Send + Sync + 'static`.
-///
-/// ### On Nightly
-///
-/// This is implemented for all types, and uses specialization to recognize errors, which are any `Result` types.
+/// This is implemented for all many std lib types, and can be implemented on custom types manually or with the derive
+/// macro.
 pub trait Reply {
     /// The success type in the reply.
     type Ok;
@@ -77,6 +87,150 @@ where
         self.map_err(|err| Box::new(err) as BoxDebug).err()
     }
 }
+
+macro_rules! impl_infallible_reply {
+    ([
+        $(
+            $( {
+                $( $generics:tt )*
+             } )?
+            $ty:ty
+        ),* $(,)?
+    ]) => {
+        $(
+            impl_infallible_reply!(
+                $( {
+                    $( $generics )*
+                 } )?
+                $ty
+            );
+        )*
+    };
+    (
+        $( {
+            $( $generics:tt )*
+         } )?
+        $ty:ty
+    ) => {
+        impl $( < $($generics)* > )? Reply for $ty {
+            type Ok = Self;
+            type Error = ();
+
+            fn to_send_error<Msg>(self) -> Result<Self, SendError<Msg, ()>> {
+                Ok(self)
+            }
+
+            fn into_boxed_err(self) -> Option<BoxDebug> {
+                None
+            }
+        }
+    };
+}
+
+impl_infallible_reply!([
+    (),
+    usize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    isize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    f32,
+    f64,
+    char,
+    bool,
+    &'static str,
+    String,
+    {T} Option<T>,
+    {'a, T: Clone} Cow<'a, T>,
+    {T} Arc<T>,
+    {T} Mutex<T>,
+    {T} RwLock<T>,
+    {'a, const N: usize, T} &'a [T; N],
+    {const N: usize, T} [T; N],
+    {'a, T} &'a [T],
+    {'a, T} &'a mut T,
+    {T} Vec<T>,
+    {T} Box<T>,
+    {K, V} HashMap<K, V>,
+    {T} HashSet<T>,
+    NonZeroI8,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroI128,
+    NonZeroIsize,
+    NonZeroU8,
+    NonZeroU16,
+    NonZeroU32,
+    NonZeroU64,
+    NonZeroU128,
+    NonZeroUsize,
+    AtomicBool,
+    AtomicI8,
+    AtomicI16,
+    AtomicI32,
+    AtomicI64,
+    AtomicIsize,
+    {T} AtomicPtr<T>,
+    AtomicU8,
+    AtomicU16,
+    AtomicU32,
+    AtomicU64,
+    AtomicUsize,
+    Once,
+    Thread,
+    {T} std::cell::OnceCell<T>,
+    {T} std::sync::mpsc::Sender<T>,
+    {T} std::sync::mpsc::Receiver<T>,
+    {T} tokio::sync::OnceCell<T>,
+    tokio::sync::Semaphore,
+    tokio::sync::Notify,
+    {T} tokio::sync::mpsc::Sender<T>,
+    {T} tokio::sync::mpsc::Receiver<T>,
+    {T} tokio::sync::mpsc::UnboundedSender<T>,
+    {T} tokio::sync::mpsc::UnboundedReceiver<T>,
+    {T} tokio::sync::watch::Sender<T>,
+    {T} tokio::sync::watch::Receiver<T>,
+    {T} tokio::sync::broadcast::Sender<T>,
+    {T} tokio::sync::broadcast::Receiver<T>,
+    {T} tokio::sync::oneshot::Sender<T>,
+    {T} tokio::sync::oneshot::Receiver<T>,
+    {T} tokio::sync::Mutex<T>,
+    {T} tokio::sync::RwLock<T>,
+    {A} (A,),
+    {A, B} (A, B),
+    {A, B, C} (A, B, C),
+    {A, B, C, D} (A, B, C, D),
+    {A, B, C, D, E} (A, B, C, D, E),
+    {A, B, C, D, E, F} (A, B, C, D, E, F),
+    {A, B, C, D, E, F, G} (A, B, C, D, E, F, G),
+    {A, B, C, D, E, F, G, H} (A, B, C, D, E, F, G, H),
+    {A, B, C, D, E, F, G, H, I} (A, B, C, D, E, F, G, H, I),
+    {A, B, C, D, E, F, G, H, I, J} (A, B, C, D, E, F, G, H, I, J),
+    {A, B, C, D, E, F, G, H, I, J, K} (A, B, C, D, E, F, G, H, I, J, K),
+    {A, B, C, D, E, F, G, H, I, J, K, L} (A, B, C, D, E, F, G, H, I, J, K, L),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M} (A, B, C, D, E, F, G, H, I, J, K, L, M),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N} (A, B, C, D, E, F, G, H, I, J, K, L, M, N),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y),
+    {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z} (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z),
+]);
 
 pub(crate) trait DynMessage<A>: Send {
     fn handle_dyn(self: Box<Self>, state: &mut A) -> BoxFuture<'_, BoxReply>

--- a/crates/kameo/src/pool.rs
+++ b/crates/kameo/src/pool.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use futures::future::join_all;
 use tracing::warn;
 
-use crate::{actor::Actor, actor_ref::ActorRef, error::SendError, message::Message};
+use crate::{actor::Actor, actor_ref::ActorRef, error::SendError, message::Message, Reply};
 
 /// A pool of actor workers designed to distribute tasks among a fixed set of actors.
 ///
@@ -81,7 +81,10 @@ impl<A> ActorPool<A> {
     }
 
     /// Sends a message to a worker in the pool, waiting for a reply.
-    pub async fn send<M>(&mut self, mut msg: M) -> Result<A::Reply, SendError<M>>
+    pub async fn send<M>(
+        &mut self,
+        mut msg: M,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>>
     where
         A: Actor + Message<M>,
         M: Send + 'static,
@@ -123,7 +126,10 @@ impl<A> ActorPool<A> {
     }
 
     /// Broadcasts a message to all workers.
-    pub async fn broadcast<M>(&mut self, msg: M) -> Vec<Result<A::Reply, SendError<M>>>
+    pub async fn broadcast<M>(
+        &mut self,
+        msg: M,
+    ) -> Vec<Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>>>
     where
         A: Actor + Message<M>,
         M: Clone + Send + 'static,

--- a/crates/kameo/src/spawn.rs
+++ b/crates/kameo/src/spawn.rs
@@ -53,21 +53,9 @@ pub trait Spawn: Sized {
     /// and finally calls the `Actor::on_stop` hook.
     ///
     /// Messages are sent to the actor through a `mpsc::unbounded_channel`.
-    #[cfg(not(feature = "nightly"))]
     fn spawn(self) -> ActorRef<Self>
     where
         Self: Send + Sync;
-
-    /// Spawns an actor in a `tokio::task`.
-    ///
-    /// This calls the `Actor::on_start` hook, then processes messages/queries/signals in a loop,
-    /// and finally calls the `Actor::on_stop` hook.
-    ///
-    /// Messages are sent to the actor through a `mpsc::unbounded_channel`.
-    #[cfg(feature = "nightly")]
-    fn spawn(self) -> ActorRef<Self>
-    where
-        Self: Send;
 
     /// Spawns an `!Sync` actor in a `tokio::task`.
     ///
@@ -75,7 +63,6 @@ pub trait Spawn: Sized {
     /// and finally calls the `Actor::on_stop` hook.
     ///
     /// Messages are sent to the actor through a `mpsc::unbounded_channel`.
-    #[cfg(not(feature = "nightly"))]
     fn spawn_unsync(self) -> ActorRef<Self>
     where
         Self: Send;
@@ -90,7 +77,6 @@ pub trait Spawn: Sized {
     /// Spawns an `!Sync` actor with a bidirectional link between the current actor and the one being spawned.
     ///
     /// If either actor dies, [Actor::on_link_died] will be called on the other actor.
-    #[cfg(not(feature = "nightly"))]
     fn spawn_unsync_link(self) -> ActorRef<Self>
     where
         Self: Send;
@@ -107,126 +93,92 @@ pub trait Spawn: Sized {
     ///
     /// If the current actor dies, [Actor::on_link_died] will be called on the spawned one,
     /// however if the spawned actor dies, Actor::on_link_died will not be called.
-    #[cfg(not(feature = "nightly"))]
     fn spawn_unsync_child(self) -> ActorRef<Self>
     where
         Self: Send;
 }
 
-macro_rules! impl_spawn {
-    (
-        main_bounds = ($($main_bounds:tt)*),
-        spawn_bounds = ($($spawn_bounds:tt)?),
-        default = ($($default:tt)*),
-        kind = $kind:ident,
-    ) => {
-        impl<T> Spawn for T where T: Actor + 'static $(+ $main_bounds)* {
-            $($default)* fn actor_ref(&self) -> ActorRef<Self> {
-                match Self::try_actor_ref() {
-                    Some(actor_ref) => actor_ref,
-                    None => panic!("actor_ref called outside the scope of an actor"),
-                }
-            }
-
-            $($default)* fn try_actor_ref() -> Option<ActorRef<Self>> {
-                ActorRef::current()
-            }
-
-            $($default)* fn spawn(self) -> ActorRef<Self>
-            where
-                Self: Send $(+ $spawn_bounds)?,
-            {
-                spawn(|ctx, id, mailbox_rx, abort_registration, links| {
-                    tokio::spawn(CURRENT_CTX.scope(ctx, async move {
-                        run_actor_lifecycle(
-                            id,
-                            self,
-                            $kind::new,
-                            mailbox_rx,
-                            abort_registration,
-                            links,
-                        )
-                        .await
-                    }));
-                })
-            }
-
-            #[cfg(not(feature = "nightly"))]
-            fn spawn_unsync(self) -> ActorRef<Self>
-            where
-                Self: Send,
-            {
-                spawn(|ctx, id, mailbox_rx, abort_registration, links| {
-                    tokio::spawn(CURRENT_CTX.scope(ctx, async move {
-                        run_actor_lifecycle(
-                            id,
-                            self,
-                            UnsyncActor::new,
-                            mailbox_rx,
-                            abort_registration,
-                            links,
-                        )
-                        .await
-                    }));
-                })
-            }
-
-            $($default)* fn spawn_link(self) -> ActorRef<Self>
-            where
-                Self: Send $(+ $spawn_bounds)?,
-            {
-                spawn_link(|| self.spawn())
-            }
-
-            #[cfg(not(feature = "nightly"))]
-            fn spawn_unsync_link(self) -> ActorRef<Self>
-            where
-                Self: Send,
-            {
-                spawn_link(|| self.spawn_unsync())
-            }
-
-            $($default)* fn spawn_child(self) -> ActorRef<Self>
-            where
-                Self: Send $(+ $spawn_bounds)?,
-            {
-                spawn_child(|| self.spawn())
-            }
-
-            #[cfg(not(feature = "nightly"))]
-            fn spawn_unsync_child(self) -> ActorRef<Self>
-            where
-                Self: Send,
-            {
-                spawn_child(|| self.spawn_unsync())
-            }
+impl<T> Spawn for T
+where
+    T: Actor + 'static,
+{
+    fn actor_ref(&self) -> ActorRef<Self> {
+        match Self::try_actor_ref() {
+            Some(actor_ref) => actor_ref,
+            None => panic!("actor_ref called outside the scope of an actor"),
         }
-    };
+    }
+
+    fn try_actor_ref() -> Option<ActorRef<Self>> {
+        ActorRef::current()
+    }
+
+    fn spawn(self) -> ActorRef<Self>
+    where
+        Self: Send + Sync,
+    {
+        spawn(|ctx, id, mailbox_rx, abort_registration, links| {
+            tokio::spawn(CURRENT_CTX.scope(ctx, async move {
+                run_actor_lifecycle(
+                    id,
+                    self,
+                    SyncActor::new,
+                    mailbox_rx,
+                    abort_registration,
+                    links,
+                )
+                .await
+            }));
+        })
+    }
+
+    fn spawn_unsync(self) -> ActorRef<Self>
+    where
+        Self: Send,
+    {
+        spawn(|ctx, id, mailbox_rx, abort_registration, links| {
+            tokio::spawn(CURRENT_CTX.scope(ctx, async move {
+                run_actor_lifecycle(
+                    id,
+                    self,
+                    UnsyncActor::new,
+                    mailbox_rx,
+                    abort_registration,
+                    links,
+                )
+                .await
+            }));
+        })
+    }
+
+    fn spawn_link(self) -> ActorRef<Self>
+    where
+        Self: Send + Sync,
+    {
+        spawn_link(|| self.spawn())
+    }
+
+    fn spawn_unsync_link(self) -> ActorRef<Self>
+    where
+        Self: Send,
+    {
+        spawn_link(|| self.spawn_unsync())
+    }
+
+    fn spawn_child(self) -> ActorRef<Self>
+    where
+        Self: Send + Sync,
+    {
+        spawn_child(|| self.spawn())
+    }
+
+    fn spawn_unsync_child(self) -> ActorRef<Self>
+    where
+        Self: Send,
+    {
+        spawn_child(|| self.spawn_unsync())
+    }
 }
-
-#[cfg(not(feature = "nightly"))]
-impl_spawn!(
-    main_bounds = (),
-    spawn_bounds = (Sync),
-    default = (),
-    kind = SyncActor,
-);
-
-#[cfg(feature = "nightly")]
-impl_spawn!(
-    main_bounds = (),
-    spawn_bounds = (),
-    default = (default),
-    kind = UnsyncActor,
-);
-
-#[cfg(feature = "nightly")]
-impl_spawn!(
-    main_bounds = (Sync),
-    spawn_bounds = (),
-    default = (),
-    kind = SyncActor,
-);
 
 #[inline]
 fn spawn<A>(

--- a/crates/kameo_macros/src/actor.rs
+++ b/crates/kameo_macros/src/actor.rs
@@ -326,7 +326,7 @@ impl Actor {
                 let fn_ident = &sig.ident;
                 let reply = match sig.output.clone() {
                     ReturnType::Default => parse_quote_spanned! {sig.output.span()=>
-                        ::std::result::Result<(), ::std::convert::Infallible>
+                        ()
                     },
                     ReturnType::Type(_, ty) => ty,
                 };
@@ -341,19 +341,13 @@ impl Actor {
                     }
                 });
 
-                let mut handle_body = quote_spanned! {sig.span()=>
-                    self.#fn_ident(#( #params ),*) #await_tokens
-                };
-                if matches!(sig.output, ReturnType::Default) {
-                    handle_body = quote! { Ok(#handle_body) }
-                }
                 quote_spanned! {sig.span()=>
                     #[automatically_derived]
                     impl #impl_generics ::kameo::#trait_name<#msg_ident #msg_ty_generics> for #actor_ident #actor_ty_generics #where_clause {
                         type Reply = #reply;
 
                         async fn handle(#self_ref, #[allow(unused_variables)] #msg) -> Self::Reply {
-                            #handle_body
+                            self.#fn_ident(#( #params ),*) #await_tokens
                         }
                     }
                 }

--- a/crates/kameo_macros/src/derive_actor.rs
+++ b/crates/kameo_macros/src/derive_actor.rs
@@ -1,21 +1,23 @@
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    DeriveInput, Ident,
+    DeriveInput, Generics, Ident,
 };
 
 pub struct DeriveActor {
     ident: Ident,
+    generics: Generics,
 }
 
 impl ToTokens for DeriveActor {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let ident = &self.ident;
+        let Self { ident, generics } = self;
         let name = ident.to_string();
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         tokens.extend(quote! {
             #[automatically_derived]
-            impl ::kameo::Actor for #ident {
+            impl #impl_generics ::kameo::Actor for #ident #ty_generics #where_clause {
                 fn name() -> &'static str {
                     #name
                 }
@@ -28,7 +30,8 @@ impl Parse for DeriveActor {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let input: DeriveInput = input.parse()?;
         let ident = input.ident;
+        let generics = input.generics;
 
-        Ok(DeriveActor { ident })
+        Ok(DeriveActor { ident, generics })
     }
 }

--- a/crates/kameo_macros/src/derive_reply.rs
+++ b/crates/kameo_macros/src/derive_reply.rs
@@ -1,0 +1,43 @@
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    DeriveInput, Generics, Ident,
+};
+
+pub struct DeriveReply {
+    ident: Ident,
+    generics: Generics,
+}
+
+impl ToTokens for DeriveReply {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self { ident, generics } = self;
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl #impl_generics ::kameo::Reply for #ident #ty_generics #where_clause {
+                type Ok = Self;
+                type Error = ();
+
+                fn to_send_error<Msg>(self) -> ::std::result::Result<Self, ::kameo::SendError<Msg, ()>> {
+                    ::std::result::Result::Ok(self)
+                }
+
+                fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + ::std::marker::Sync + 'static>> {
+                    ::std::option::Option::None
+                }
+            }
+        });
+    }
+}
+
+impl Parse for DeriveReply {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let input: DeriveInput = input.parse()?;
+        let ident = input.ident;
+        let generics = input.generics;
+
+        Ok(DeriveReply { ident, generics })
+    }
+}

--- a/crates/kameo_macros/src/lib.rs
+++ b/crates/kameo_macros/src/lib.rs
@@ -39,9 +39,9 @@ use syn::parse_macro_input;
 ///     }
 /// }
 ///
-/// counter_ref.send(Inc { amount: 5 }).await??;
-/// counter_ref.query(Count).await??;
-/// counter_ref.send(Dec { amount: 2 }.clone()).await??;
+/// counter_ref.send(Inc { amount: 5 }).await?;
+/// counter_ref.query(Count).await?;
+/// counter_ref.send(Dec { amount: 2 }.clone()).await?;
 /// ```
 ///
 /// <details>

--- a/crates/kameo_macros/src/lib.rs
+++ b/crates/kameo_macros/src/lib.rs
@@ -1,8 +1,10 @@
 mod actor;
 mod derive_actor;
+mod derive_reply;
 
 use actor::Actor;
 use derive_actor::DeriveActor;
+use derive_reply::DeriveReply;
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::parse_macro_input;
@@ -21,15 +23,15 @@ use syn::parse_macro_input;
 /// impl Counter {
 ///     /// Regular message
 ///     #[message]
-///     pub fn inc(&mut self, amount: u32) -> Result<i64, Infallible> {
+///     pub fn inc(&mut self, amount: u32) -> i64 {
 ///         self.count += amount as i64;
-///         Ok(self.count)
+///         self.count
 ///     }
 ///
 ///     /// Regular query
 ///     #[query]
-///     pub fn count(&self) -> Result<i64, Infallible> {
-///         Ok(self.count)
+///     pub fn count(&self) -> i64 {
+///         self.count
 ///     }
 ///
 ///     /// Derives on the message
@@ -53,7 +55,7 @@ use syn::parse_macro_input;
 /// }
 ///
 /// impl kameo::Message<Inc> for Counter {
-///     type Reply = Result<i64, Infallible>;
+///     type Reply = i64;
 ///
 ///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
 ///         self.inc(msg.amount)
@@ -63,7 +65,7 @@ use syn::parse_macro_input;
 /// pub struct Count;
 ///
 /// impl kameo::Query<Count> for Counter {
-///     type Reply = Result<i64, Infallible>;
+///     type Reply = i64;
 ///
 ///     async fn handle(&self, msg: Counter) -> Self::Reply {
 ///         self.count()
@@ -74,7 +76,7 @@ use syn::parse_macro_input;
 /// pub struct Dec;
 ///
 /// impl kameo::Message<Dec> for Counter {
-///     type Reply = Result<(), Infallible>;
+///     type Reply = ();
 ///
 ///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
 ///         self.dec(msg.amount)
@@ -106,4 +108,20 @@ pub fn actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn derive_actor(input: TokenStream) -> TokenStream {
     let derive_actor = parse_macro_input!(input as DeriveActor);
     TokenStream::from(derive_actor.into_token_stream())
+}
+
+/// Derive macro implementing the [Reply](https://docs.rs/kameo/latest/kameo/trait.Reply.html) trait as an infallible reply.
+///
+/// # Example
+///
+/// ```
+/// use kameo::Reply;
+///
+/// #[derive(Reply)]
+/// struct Foo { }
+/// ```
+#[proc_macro_derive(Reply)]
+pub fn derive_reply(input: TokenStream) -> TokenStream {
+    let derive_reply = parse_macro_input!(input as DeriveReply);
+    TokenStream::from(derive_reply.into_token_stream())
 }


### PR DESCRIPTION
Merges the actors reply error into the `SendError` type, avoiding the need for `.await??` with double `?`'s.

Additionally removes the `nightly` feature flag, and implements `Reply` on many common types within the std lib, and provides a `Reply` derive macro.