### PR TITLE
feat!: remove `Spawn` trait and use spawn functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,13 @@ impl kameo::Message<Inc> for Counter {
 ### Spawning an Actor & Messaging
 
 ```rust
-use kameo::{Spawn, ActorRef};
-
-let counter_ref: ActorRef<Counter> = Counter { count: 0 }.spawn();
+let counter_ref = kameo::spawn(Counter { count: 0 });
 
 let count = counter_ref.send(Inc(42)).await?;
 println!("Count is {count}");
 ```
 
 <sup>
-<a href="https://docs.rs/kameo/latest/kameo/trait.Spawn.html#method.spawn" target="_blank">Spawn::spawn</a>
- • 
 <a href="https://docs.rs/kameo/latest/kameo/trait.ActorRef.html#method.send" target="_blank">ActorRef::send</a>
 </sup>
 

--- a/crates/kameo/benches/fibonacci.rs
+++ b/crates/kameo/benches/fibonacci.rs
@@ -1,7 +1,7 @@
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
-use kameo::{Actor, Message, Query, Spawn};
+use kameo::{Actor, Message, Query};
 
 struct FibActor {}
 
@@ -39,8 +39,8 @@ fn concurrent_reads(c: &mut Criterion) {
         .unwrap();
     let _guard = rt.enter();
     let size: usize = 1024;
-    let unsync_actor_ref = FibActor {}.spawn_unsync();
-    let sync_actor_ref = FibActor {}.spawn();
+    let unsync_actor_ref = kameo::spawn_unsync(FibActor {});
+    let sync_actor_ref = kameo::spawn(FibActor {});
 
     c.bench_with_input(
         BenchmarkId::new("unsync_messages_instant", size),

--- a/crates/kameo/examples/basic.rs
+++ b/crates/kameo/examples/basic.rs
@@ -1,4 +1,4 @@
-use kameo::{Actor, Message, Query, Spawn};
+use kameo::{Actor, Message, Query};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .init();
 
-    let my_actor_ref = MyActor::default().spawn();
+    let my_actor_ref = kameo::spawn(MyActor::default());
 
     // Increment the count by 3
     let count = my_actor_ref.send(Inc { amount: 3 }).await?;

--- a/crates/kameo/examples/macro.rs
+++ b/crates/kameo/examples/macro.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .init();
 
-    let my_actor_ref = MyActor::new().spawn();
+    let my_actor_ref = kameo::spawn(MyActor::new());
 
     // Increment the count by 3
     let count = my_actor_ref.send(Inc { amount: 3 }).await?;

--- a/crates/kameo/examples/pool.rs
+++ b/crates/kameo/examples/pool.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use kameo::{actor, Actor, ActorPool, Spawn};
+use kameo::{actor, Actor, ActorPool};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Actor, Default)]
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .init();
 
-    let mut pool = ActorPool::new(5, || MyActor.spawn());
+    let mut pool = ActorPool::new(5, || kameo::spawn(MyActor));
     for _ in 0..10 {
         pool.send(PrintActorId).await?;
     }

--- a/crates/kameo/examples/stateless.rs
+++ b/crates/kameo/examples/stateless.rs
@@ -1,0 +1,10 @@
+use kameo::spawn_stateless;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let actor_ref = spawn_stateless(|n: i32| async move { n * n });
+    let res = actor_ref.send(10).await?;
+    println!("{res}");
+
+    Ok(())
+}

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -85,9 +85,7 @@
 //! ## Spawning an Actor & Messaging
 //!
 //! ```
-//! use kameo::{Spawn, ActorRef};
-//!
-//! let counter_ref: ActorRef<Counter> = Counter { count: 0 }.spawn();
+//! let counter_ref = kameo::spawn(Counter { count: 0 });
 //!
 //! let count = counter_ref.send(Inc(42)).await?;
 //! println!("Count is {count}");
@@ -113,4 +111,4 @@ pub use error::{ActorStopReason, BoxError, PanicError, SendError};
 pub use kameo_macros::{actor, Actor, Reply};
 pub use message::{Message, Query, Reply};
 pub use pool::ActorPool;
-pub use spawn::Spawn;
+pub use spawn::{spawn, spawn_stateless, spawn_unsync};

--- a/crates/kameo/src/message.rs
+++ b/crates/kameo/src/message.rs
@@ -19,7 +19,7 @@ use std::{
 
 use futures::{future::BoxFuture, Future, FutureExt};
 
-use crate::SendError;
+use crate::error::SendError;
 
 pub(crate) type BoxDebug = Box<dyn fmt::Debug + Send + Sync + 'static>;
 pub(crate) type BoxReply = Box<dyn any::Any + Send>;

--- a/crates/kameo/src/pool.rs
+++ b/crates/kameo/src/pool.rs
@@ -3,7 +3,12 @@ use std::fmt;
 use futures::future::join_all;
 use tracing::warn;
 
-use crate::{actor::Actor, actor_ref::ActorRef, error::SendError, message::Message, Reply};
+use crate::{
+    actor::Actor,
+    actor_ref::ActorRef,
+    error::SendError,
+    message::{Message, Reply},
+};
 
 /// A pool of actor workers designed to distribute tasks among a fixed set of actors.
 ///
@@ -34,7 +39,7 @@ use crate::{actor::Actor, actor_ref::ActorRef, error::SendError, message::Messag
 ///
 /// // Create a pool with 5 workers.
 /// let pool = ActorPool::new(5, || {
-///     MyActor.spawn()
+///     kameo::spawn(MyActor)
 /// });
 ///
 /// pool.send(MyMessage).await?;


### PR DESCRIPTION
Removes the `Spawn` trait and replaces spawn functionality with:
- `kameo::spawn(...)`
- `kameo::spawn_unsync(...)`
- `kameo::spawn_stateless(...)`