### PR TITLE
feat!: impl `Message` and `Query` for message type instead of actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ impl Actor for Counter {}
 // Define messages
 struct Inc { amount: u32 }
 
-impl Message<Inc> for Counter {
+impl Message<Counter> for Inc {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Counter) -> Self::Reply {
-        self.count += msg.0 as i64;
-        self.count
+    async fn handle(state: &mut Counter, msg: Inc) -> Self::Reply {
+        state.count += msg.0 as i64;
+        state.count
     }
 }
 ```
@@ -89,11 +89,11 @@ impl kameo::Actor for Counter {
 // Messages
 struct Inc { amount: u32 }
 
-impl kameo::Message<Inc> for Counter {
+impl kameo::Message<Counter> for Inc {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: &mut Inc) -> Self::Reply {
-        self.inc(msg.amount)
+    async fn handle(state: &mut Counter, msg: &mut Inc) -> Self::Reply {
+        state.inc(msg.amount)
     }
 }
 ```

--- a/crates/kameo/benches/fibonacci.rs
+++ b/crates/kameo/benches/fibonacci.rs
@@ -9,18 +9,18 @@ impl Actor for FibActor {}
 
 struct Fib(u64);
 
-impl Message<Fib> for FibActor {
+impl Message<FibActor> for Fib {
     type Reply = u64;
 
-    async fn handle(&mut self, msg: Fib) -> Self::Reply {
+    async fn handle(_state: &mut FibActor, msg: Fib) -> Self::Reply {
         fibonacci(msg.0)
     }
 }
 
-impl Query<Fib> for FibActor {
+impl Query<FibActor> for Fib {
     type Reply = u64;
 
-    async fn handle(&self, msg: Fib) -> Self::Reply {
+    async fn handle(_state: &FibActor, msg: Fib) -> Self::Reply {
         fibonacci(msg.0)
     }
 }

--- a/crates/kameo/examples/basic.rs
+++ b/crates/kameo/examples/basic.rs
@@ -18,22 +18,22 @@ pub struct Inc {
     amount: u32,
 }
 
-impl Message<Inc> for MyActor {
+impl Message<MyActor> for Inc {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc) -> Self::Reply {
-        self.count += msg.amount as i64;
-        self.count
+    async fn handle(state: &mut MyActor, msg: Inc) -> Self::Reply {
+        state.count += msg.amount as i64;
+        state.count
     }
 }
 
 // Always returns an error
 pub struct ForceErr;
 
-impl Message<ForceErr> for MyActor {
+impl Message<MyActor> for ForceErr {
     type Reply = Result<(), i32>;
 
-    async fn handle(&mut self, _msg: ForceErr) -> Self::Reply {
+    async fn handle(_state: &mut MyActor, _msg: ForceErr) -> Self::Reply {
         Err(3)
     }
 }
@@ -41,11 +41,11 @@ impl Message<ForceErr> for MyActor {
 // Queries the current count
 pub struct Count;
 
-impl Query<Count> for MyActor {
+impl Query<MyActor> for Count {
     type Reply = i64;
 
-    async fn handle(&self, _msg: Count) -> Self::Reply {
-        self.count
+    async fn handle(state: &MyActor, _msg: Count) -> Self::Reply {
+        state.count
     }
 }
 

--- a/crates/kameo/examples/stateless.rs
+++ b/crates/kameo/examples/stateless.rs
@@ -1,10 +1,10 @@
-use kameo::spawn_stateless;
+// use kameo::spawn_stateless;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let actor_ref = spawn_stateless(|n: i32| async move { n * n });
-    let res = actor_ref.send(10).await?;
-    println!("{res}");
+    // let actor_ref = spawn_stateless(|n: i32| async move { n * n });
+    // let res = actor_ref.send(10).await?;
+    // println!("{res}");
 
     Ok(())
 }

--- a/crates/kameo/src/actor.rs
+++ b/crates/kameo/src/actor.rs
@@ -5,7 +5,6 @@ use futures::Future;
 use crate::{
     actor_ref::ActorRef,
     error::{ActorStopReason, BoxError, PanicError},
-    message::{Message, Reply},
 };
 
 /// Functionality for an actor including lifecycle hooks.
@@ -146,17 +145,19 @@ pub trait Actor: Sized {
     }
 }
 
-impl<M, R> Actor for fn(M) -> R {}
+// struct StatelessActor<M, R>(fn(M) -> R);
 
-impl<M, Fu, R> Message<fn(M) -> Fu> for M
-where
-    M: Send + 'static,
-    Fu: Future<Output = R> + Send + 'static,
-    R: Reply + Send + 'static,
-{
-    type Reply = R;
+// impl<M, R> Actor for StatelessActor<M, R> {}
 
-    async fn handle(state: &mut fn(M) -> Fu, msg: M) -> Self::Reply {
-        state(msg).await
-    }
-}
+// impl<M, Fu, R> Message<StatelessActor<M, R>> for M
+// where
+//     M: Send + 'static,
+//     Fu: Future<Output = R> + Send + 'static,
+//     R: Reply + Send + 'static,
+// {
+//     type Reply = R;
+
+//     async fn handle(state: &mut fn(M) -> Fu, msg: M) -> Self::Reply {
+//         state(msg).await
+//     }
+// }

--- a/crates/kameo/src/actor.rs
+++ b/crates/kameo/src/actor.rs
@@ -148,7 +148,7 @@ pub trait Actor: Sized {
 
 impl<M, R> Actor for fn(M) -> R {}
 
-impl<M, Fu, R> Message<M> for fn(M) -> Fu
+impl<M, Fu, R> Message<fn(M) -> Fu> for M
 where
     M: Send + 'static,
     Fu: Future<Output = R> + Send + 'static,
@@ -156,7 +156,7 @@ where
 {
     type Reply = R;
 
-    async fn handle(&mut self, msg: M) -> Self::Reply {
-        self(msg).await
+    async fn handle(state: &mut fn(M) -> Fu, msg: M) -> Self::Reply {
+        state(msg).await
     }
 }

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -109,6 +109,6 @@ pub use actor::Actor;
 pub use actor_ref::ActorRef;
 pub use error::{ActorStopReason, BoxError, PanicError, SendError};
 pub use kameo_macros::{actor, Actor, Reply};
-pub use message::{Message, Query, Reply};
+pub use message::{Message, Query, Reply, ReplyFuture};
 pub use pool::ActorPool;
-pub use spawn::{spawn, spawn_stateless, spawn_unsync};
+pub use spawn::{spawn, spawn_unsync};

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -28,12 +28,12 @@
 //! // Define messages
 //! struct Inc(u32);
 //!
-//! impl Message<Inc> for Counter {
+//! impl Message<Counter> for Inc {
 //!     type Reply = i64;
 //!
-//!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
-//!         self.count += msg.0 as i64;
-//!         self.count
+//!     async fn handle(state: &mut Counter, msg: Inc) -> Self::Reply {
+//!         state.count += msg.0 as i64;
+//!         state.count
 //!     }
 //! }
 //! ```
@@ -72,11 +72,11 @@
 //! // Messages
 //! struct Inc { amount: u32 }
 //!
-//! impl kameo::Message<Inc> for Counter {
+//! impl kameo::Message<Counter> for Inc {
 //!     type Reply = i64;
 //!
-//!     async fn handle(&mut self, msg: Counter) -> Self::Reply {
-//!         self.inc(msg.amount)
+//!     async fn handle(state: &mut Counter, msg: Inc) -> Self::Reply {
+//!         state.inc(msg.amount)
 //!     }
 //! }
 //! ```

--- a/crates/kameo/src/spawn.rs
+++ b/crates/kameo/src/spawn.rs
@@ -62,24 +62,24 @@ where
     spawn_inner::<A, UnsyncActor<A>>(actor)
 }
 
-/// Spawns a stateless anonymous actor in a `tokio::task` using a function which processes messages of a single type.
-///
-/// # Example
-///
-/// ```no_run
-/// use kameo::spawn_stateless;
-///
-/// let actor_ref = kameo::spawn_stateless(|n: i32| async move { n * n });
-/// let res = actor_ref.send(10).await?;
-/// assert_eq!(res, 100);
-/// ```
-pub fn spawn_stateless<M, R>(f: fn(M) -> R) -> ActorRef<fn(M) -> R>
-where
-    M: 'static,
-    R: 'static,
-{
-    spawn_unsync(f as fn(_) -> _)
-}
+// /// Spawns a stateless anonymous actor in a `tokio::task` using a function which processes messages of a single type.
+// ///
+// /// # Example
+// ///
+// /// ```no_run
+// /// use kameo::spawn_stateless;
+// ///
+// /// let actor_ref = kameo::spawn_stateless(|n: i32| async move { n * n });
+// /// let res = actor_ref.send(10).await?;
+// /// assert_eq!(res, 100);
+// /// ```
+// pub fn spawn_stateless<M, R>(f: fn(M) -> R) -> ActorRef<fn(M) -> R>
+// where
+//     M: 'static,
+//     R: 'static,
+// {
+//     spawn_unsync(f as fn(_) -> _)
+// }
 
 #[inline]
 fn spawn_inner<A, S>(actor: A) -> ActorRef<A>

--- a/crates/kameo_macros/src/lib.rs
+++ b/crates/kameo_macros/src/lib.rs
@@ -54,32 +54,32 @@ use syn::parse_macro_input;
 ///     pub amount: u32,
 /// }
 ///
-/// impl kameo::Message<Inc> for Counter {
+/// impl kameo::Message<Counter> for Inc {
 ///     type Reply = i64;
 ///
-///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
-///         self.inc(msg.amount)
+///     async fn handle(state: &mut Counter, msg: Inc) -> Self::Reply {
+///         state.inc(msg.amount)
 ///     }
 /// }
 ///
 /// pub struct Count;
 ///
-/// impl kameo::Query<Count> for Counter {
+/// impl kameo::Query<Counter> for Count {
 ///     type Reply = i64;
 ///
-///     async fn handle(&self, msg: Counter) -> Self::Reply {
-///         self.count()
+///     async fn handle(state: &Counter, msg: Count) -> Self::Reply {
+///         state.count()
 ///     }
 /// }
 ///
 /// #[derive(Clone, Copy)]
 /// pub struct Dec;
 ///
-/// impl kameo::Message<Dec> for Counter {
+/// impl kameo::Message<Counter> for Dec {
 ///     type Reply = ();
 ///
-///     async fn handle(&mut self, msg: Counter) -> Self::Reply {
-///         self.dec(msg.amount)
+///     async fn handle(state: &mut Counter, msg: Dec) -> Self::Reply {
+///         state.dec(msg.amount)
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
This reverts PR #6 

After some time working with the trait switched around (`impl Message<Msg> for Actor`), one big problem has arisen: You can no longer implement a message for all actors.

This doesn't work:
```rust
struct GlobalMessage { ... }
impl<A> Message<GlobalMessage> for A { ... }
```

Rust errors with:
> type parameter `A` must be covered by another type when it appears before the first local type (`GlobalMessage`)

The only way to solve this as far as I know is to switch the impl, so you `impl Message<Actor> for Msg`.
This works:
```rust
struct GlobalMessage { ... }
impl<A> Message<A> for GlobalMessage { ... }
```