### PR TITLE
Remove Sync trait from into_boxed_err method signature in DeriveReply

### DIFF
--- a/crates/kameo_macros/src/derive_reply.rs
+++ b/crates/kameo_macros/src/derive_reply.rs
@@ -27,7 +27,7 @@ impl ToTokens for DeriveReply {
                 }
 
                 #[inline]
-                fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + ::std::marker::Sync + 'static>> {
+                fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + 'static>> {
                     ::std::option::Option::None
                 }
 


### PR DESCRIPTION
The derive Reply include Sync trait, but BoxDebug doesn't include it.

```rust
#[inline]
fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + ::std::marker::Sync + 'static>> {
    ::std::option::Option::None
}
```