### PR TITLE
feat: implement internal buffering whilst actor is starting up

### DIFF
--- a/crates/kameo/src/actor.rs
+++ b/crates/kameo/src/actor.rs
@@ -22,6 +22,7 @@
 //! of concurrency and parallelism.
 
 mod actor_ref;
+mod kind;
 mod pool;
 mod spawn;
 
@@ -79,6 +80,12 @@ pub trait Actor: Sized {
     }
 
     /// Hook that is called before the actor starts processing messages.
+    ///
+    /// # Guarantees
+    /// Messages sent internally by the actor during `on_start` are prioritized and processed before any externally
+    /// sent messages, even if external messages are received before `on_start` completes.
+    /// This is ensured by an internal buffering mechanism that holds external messages until after `on_start` has
+    /// finished executing.
     ///
     /// # Returns
     /// A result indicating successful initialization or an error if initialization fails.

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -103,7 +103,6 @@
 #![deny(unused_must_use)]
 
 pub mod actor;
-mod actor_kind;
 pub mod error;
 pub mod message;
 pub mod reply;


### PR DESCRIPTION
Previously, there was no guarantee that messages sent to an actors self within `Actor::on_start` would be processed first.

This PR implements internal buffering, introducing the guarantee that on_start messages will be processed first.

Eg:
```rust
impl Actor for MyActor {
    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
        tokio::time::sleep(Duration::from_secs(1)).await; // Wait 1 second
        actor_ref.send_async(Say("hi from on_start"))?;
        Ok(())
    }
}

struct Say(&'static str);
impl Message<Say> for MyActor {
    type Reply = ();

    async fn handle(&mut self, Say(msg): Say, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
        println!("{msg}");
    }
}

async fn main() {
    let my_actor_ref = kameo::spawn(MyActor::default());
    my_actor_ref.send(Say("hi from main fn")).await?;
}
```
Would print:
```
hi from on_start
hi from main fn
```