### PR TITLE
feat: add `Context::blocking` method for blocking actor code

### DIFF
--- a/crates/kameo/examples/blocking.rs
+++ b/crates/kameo/examples/blocking.rs
@@ -1,0 +1,49 @@
+use kameo::{
+    message::{Context, Message},
+    reply::DelegatedReply,
+    Actor,
+};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Default)]
+pub struct MyActor {
+    count: i64,
+}
+
+impl Actor for MyActor {
+    fn name() -> &'static str {
+        "MyActor"
+    }
+}
+
+// A simple increment message, returning the new count
+pub struct Inc {
+    amount: u32,
+}
+
+impl Message<Inc> for MyActor {
+    type Reply = DelegatedReply<i64>;
+
+    async fn handle(&mut self, msg: Inc, mut ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+        ctx.blocking(self, move |state| {
+            state.count += msg.amount as i64;
+            state.count
+        })
+        .await
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("trace".parse::<EnvFilter>().unwrap())
+        .without_time()
+        .with_target(false)
+        .init();
+
+    let my_actor_ref = kameo::spawn(MyActor::default());
+    let res = my_actor_ref.send(Inc { amount: 10 }).await?;
+    dbg!(res);
+
+    Ok(())
+}

--- a/crates/kameo/src/actor/spawn.rs
+++ b/crates/kameo/src/actor/spawn.rs
@@ -190,6 +190,11 @@ where
                         return reason;
                     }
                 }
+                Some(Signal::BlockingMessage { message, actor_ref, reply, sent_within_actor }) => {
+                    if let Some(reason) = state.handle_blocking_message(message, actor_ref, reply, sent_within_actor).await {
+                        return reason;
+                    }
+                }
                 Some(Signal::Query { query, actor_ref, reply, sent_within_actor }) => {
                     if let Some(reason) = state.handle_query(query, actor_ref, reply, sent_within_actor).await {
                         return reason;

--- a/crates/kameo/src/message.rs
+++ b/crates/kameo/src/message.rs
@@ -14,10 +14,10 @@
 //! (Command Query Responsibility Segregation) principle and enhancing the clarity and maintainability of actor
 //! interactions. It also provides some performance benefits in that sequential queries can be processed concurrently.
 
-use std::{any, fmt, mem};
+use std::{any, fmt, ops::DerefMut};
 
 use futures::{future::BoxFuture, Future, FutureExt};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, OwnedRwLockWriteGuard};
 
 use crate::{
     actor::ActorRef,
@@ -43,6 +43,20 @@ pub trait Message<T>: Send + 'static {
         msg: T,
         ctx: Context<'_, Self, Self::Reply>,
     ) -> impl Future<Output = Self::Reply> + Send;
+}
+
+/// A blocking message that can modify an actors state. This trait is for handling messages which are not async and may
+/// block the current thread.
+///
+/// Messages are processed sequentially one at a time, with exclusive mutable access to the actors state.
+///
+/// The reply type must implement [Reply].
+pub trait BlockingMessage<T>: Send + 'static {
+    /// The reply sent back to the message caller.
+    type Reply: Reply + Send + 'static;
+
+    /// Handler for this message.
+    fn handle(&mut self, msg: T, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply;
 }
 
 /// Queries the actor for some data.
@@ -106,48 +120,6 @@ where
     /// Returns the current actor's ref, allowing messages to be sent to itself.
     pub fn actor_ref(&self) -> ActorRef<A> {
         self.actor_ref.clone()
-    }
-
-    /// Runs blocking code in a tokio theadpool where blocking code is acceptable.
-    ///
-    /// Typically you want to yield back to the async runtime frequently, and blocking code
-    /// can often be an issue since it hogs the main thread. This function executes the closure
-    /// in a threadpool mitigating this issue.
-    ///
-    /// See <https://docs.rs/tokio/1/tokio/task/fn.spawn_blocking.html>.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// impl Message<Inc> for MyActor {
-    ///     type Reply = DelegatedReply<i64>;
-    ///
-    ///     async fn handle(&mut self, msg: Inc, mut ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
-    ///         ctx.blocking(self, move |state| {
-    ///             state.count += msg.amount as i64;
-    ///             state.count
-    ///         })
-    ///         .await
-    ///     }
-    /// }
-    /// ```
-    pub async fn blocking<F>(&mut self, state: &mut A, f: F) -> DelegatedReply<R::Value>
-    where
-        A: Send + 'static,
-        F: FnOnce(&mut A) -> R::Value + Send + 'static,
-    {
-        let (delegated_reply, reply_sender) = self.reply_sender();
-        /// SAFETY: Since we await the spawn_blocking task, we know the state
-        /// will not be disposed of whilst it's processing it.
-        let state: &'static mut A = unsafe { mem::transmute(state) };
-        let handle = tokio::task::spawn_blocking(move || {
-            let reply = f(state);
-            if let Some(tx) = reply_sender {
-                tx.send(reply);
-            }
-        });
-        let _ = handle.await;
-        delegated_reply
     }
 
     /// Extracts the reply sender, providing a mechanism for delegated responses and an optional reply sender.
@@ -255,6 +227,60 @@ where
             let ctx: Context<'_, A, <A as Message<T>>::Reply> =
                 Context::new(actor_ref, &mut reply_sender);
             let reply = Message::handle(state, *self, ctx).await;
+            if let Some(tx) = reply_sender.take() {
+                tx.send(reply.into_value());
+                None
+            } else {
+                reply.into_boxed_err()
+            }
+        }
+        .boxed()
+    }
+
+    fn as_any(self: Box<Self>) -> Box<dyn any::Any> {
+        self
+    }
+}
+
+pub(crate) trait DynBlockingMessage<A>
+where
+    Self: Send,
+{
+    fn handle_dyn(
+        self: Box<Self>,
+        state: OwnedRwLockWriteGuard<A>,
+        actor_ref: ActorRef<A>,
+        tx: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+    ) -> BoxFuture<'static, Option<BoxDebug>>
+    where
+        A: Send;
+    fn as_any(self: Box<Self>) -> Box<dyn any::Any>;
+}
+
+impl<A, T> DynBlockingMessage<A> for T
+where
+    A: BlockingMessage<T> + Send + Sync,
+    T: Send + 'static,
+{
+    fn handle_dyn(
+        self: Box<Self>,
+        mut state: OwnedRwLockWriteGuard<A>,
+        actor_ref: ActorRef<A>,
+        tx: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+    ) -> BoxFuture<'static, Option<BoxDebug>>
+    where
+        A: Send,
+    {
+        async move {
+            let (mut reply_sender, reply) = tokio::task::spawn_blocking(move || {
+                let mut reply_sender = tx.map(ReplySender::new);
+                let ctx: Context<'_, A, <A as BlockingMessage<T>>::Reply> =
+                    Context::new(actor_ref, &mut reply_sender);
+                let reply = BlockingMessage::handle(state.deref_mut(), *self, ctx);
+                (reply_sender, reply)
+            })
+            .await
+            .unwrap();
             if let Some(tx) = reply_sender.take() {
                 tx.send(reply.into_value());
                 None


### PR DESCRIPTION
Closes https://github.com/tqwewe/kameo/issues/25.

Adds a method `Context::blocking` to execute blocking code within an actors handler.

https://github.com/tqwewe/kameo/blob/f89de4becc214b4652d923e7592ab2bd00fec4e9/crates/kameo/examples/blocking.rs#L23-L30