### PR TITLE
feat!: add support for bounded/unbounded mailboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - **Async**: Built on tokio, actors run asyncronously in their own isolated spawned tasks.
 - **Supervision**: Link actors, creating dependencies through child/parent/sibbling relationships.
-- **MPSC Unbounded Channels**: Uses mpsc channels for messaging between actors.
+- **MPSC Bounded/Unbounded Channels**: Uses mpsc channels for messaging between actors with boundedness configurable.
 - **Concurrent Queries**: Support concurrent processing of queries when mutable state isn't necessary.
 - **Panic Safe**: Catches panics internally, allowing actors to be restarted.
 
@@ -86,6 +86,8 @@ impl Counter {
 ```rust
 // Derive Actor
 impl kameo::actor::Actor for Counter {
+    type Mailbox = kameo::actor::UnboundedMailbox<Self>;
+
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed("Counter")
     }
@@ -116,12 +118,12 @@ impl kameo::message::Message<Inc> for Counter {
 ```rust
 let counter_ref = kameo::spawn(Counter { count: 0 });
 
-let count = counter_ref.send(Inc(42)).await?;
+let count = counter_ref.ask(Inc(42)).send().await?;
 println!("Count is {count}");
 ```
 
 <sup>
-<a href="https://docs.rs/kameo/latest/kameo/trait.ActorRef.html#method.send" target="_blank">ActorRef::send</a>
+<a href="https://docs.rs/kameo/latest/kameo/trait.ActorRef.html#method.ask" target="_blank">ActorRef::ask</a>
 </sup>
 
 ## Benchmarks

--- a/crates/kameo/Cargo.toml
+++ b/crates/kameo/Cargo.toml
@@ -16,7 +16,9 @@ dyn-clone = "1.0"
 futures = "0.3"
 num_cpus = "1.0"
 tokio = { version = "1.37", features = ["macros", "rt", "sync", "time"] }
+tokio-stream = "0.1"
 tracing = "0.1"
+itertools = "0.13.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/crates/kameo/benches/fibonacci.rs
+++ b/crates/kameo/benches/fibonacci.rs
@@ -1,6 +1,7 @@
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::actor::BoundedMailbox;
 use kameo::{
     message::{Context, Message, Query},
     Actor,
@@ -8,7 +9,9 @@ use kameo::{
 
 struct FibActor {}
 
-impl Actor for FibActor {}
+impl Actor for FibActor {
+    type Mailbox = BoundedMailbox<Self>;
+}
 
 struct Fib(u64);
 
@@ -50,7 +53,7 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { unsync_actor_ref.send(Fib(0)).await.unwrap() });
+                .iter(|| async { unsync_actor_ref.ask(Fib(0)).send().await.unwrap() });
         },
     );
 
@@ -59,13 +62,13 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { sync_actor_ref.send(Fib(0)).await.unwrap() });
+                .iter(|| async { sync_actor_ref.ask(Fib(0)).send().await.unwrap() });
         },
     );
 
     c.bench_with_input(BenchmarkId::new("queries_instant", size), &size, |b, _| {
         b.to_async(&rt)
-            .iter(|| async { sync_actor_ref.query(Fib(0)).await.unwrap() });
+            .iter(|| async { sync_actor_ref.query(Fib(0)).send().await.unwrap() });
     });
 
     c.bench_with_input(
@@ -73,7 +76,7 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { unsync_actor_ref.send(Fib(20)).await.unwrap() });
+                .iter(|| async { unsync_actor_ref.ask(Fib(20)).send().await.unwrap() });
         },
     );
 
@@ -82,13 +85,13 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { sync_actor_ref.send(Fib(20)).await.unwrap() });
+                .iter(|| async { sync_actor_ref.ask(Fib(20)).send().await.unwrap() });
         },
     );
 
     c.bench_with_input(BenchmarkId::new("queries_fast", size), &size, |b, _| {
         b.to_async(&rt)
-            .iter(|| async { sync_actor_ref.query(Fib(20)).await.unwrap() });
+            .iter(|| async { sync_actor_ref.query(Fib(20)).send().await.unwrap() });
     });
 
     c.bench_with_input(
@@ -96,7 +99,7 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { unsync_actor_ref.send(Fib(30)).await.unwrap() });
+                .iter(|| async { unsync_actor_ref.ask(Fib(30)).send().await.unwrap() });
         },
     );
 
@@ -105,13 +108,13 @@ fn concurrent_reads(c: &mut Criterion) {
         &size,
         |b, _| {
             b.to_async(&rt)
-                .iter(|| async { sync_actor_ref.send(Fib(30)).await.unwrap() });
+                .iter(|| async { sync_actor_ref.ask(Fib(30)).send().await.unwrap() });
         },
     );
 
     c.bench_with_input(BenchmarkId::new("queries_slow", size), &size, |b, _| {
         b.to_async(&rt)
-            .iter(|| async { sync_actor_ref.query(Fib(30)).await.unwrap() });
+            .iter(|| async { sync_actor_ref.query(Fib(30)).send().await.unwrap() });
     });
 }
 

--- a/crates/kameo/benches/overhead.rs
+++ b/crates/kameo/benches/overhead.rs
@@ -1,5 +1,6 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::actor::UnboundedMailbox;
 use kameo::{
     message::{Context, Message},
     Actor,
@@ -16,7 +17,9 @@ fn actor(c: &mut Criterion) {
 
     struct BenchActor;
 
-    impl Actor for BenchActor {}
+    impl Actor for BenchActor {
+        type Mailbox = UnboundedMailbox<Self>;
+    }
 
     impl Message<u32> for BenchActor {
         type Reply = u32;
@@ -29,7 +32,7 @@ fn actor(c: &mut Criterion) {
 
     c.bench_function("actor_sync_messages", |b| {
         b.to_async(&rt).iter(|| async {
-            actor_ref.send(0).await.unwrap();
+            actor_ref.ask(0).send().await.unwrap();
         });
     });
 }

--- a/crates/kameo/examples/macro.rs
+++ b/crates/kameo/examples/macro.rs
@@ -55,28 +55,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let my_actor_ref = kameo::spawn(MyActor::new());
 
     // Increment the count by 3
-    let count = my_actor_ref.send(Inc { amount: 3 }).await?;
+    let count = my_actor_ref.ask(Inc { amount: 3 }).send().await?;
     info!("Count is {count}");
 
     // Increment the count by 50 in the background
-    my_actor_ref.send_async(Inc { amount: 50 })?;
+    my_actor_ref.tell(Inc { amount: 50 }).send()?;
 
     // Query the count
-    let count = my_actor_ref.query(Count).await?;
+    let count = my_actor_ref.query(Count).send().await?;
     info!("Count is {count}");
 
     // Generic message
     my_actor_ref
-        .send(Print {
+        .ask(Print {
             msg: "Generics work!",
         })
+        .send()
         .await?;
 
     // Async messages that return an Err will cause the actor to panic
-    my_actor_ref.send_async(ForceErr)?;
+    my_actor_ref.tell(ForceErr).send()?;
 
     // Actor should be stopped, so we cannot send more messages to it
-    assert!(my_actor_ref.send(Inc { amount: 2 }).await.is_err());
+    assert!(my_actor_ref.ask(Inc { amount: 2 }).send().await.is_err());
 
     Ok(())
 }

--- a/crates/kameo/examples/stream.rs
+++ b/crates/kameo/examples/stream.rs
@@ -2,7 +2,7 @@ use std::{future::pending, time};
 
 use futures::stream;
 use kameo::{
-    actor::ActorRef,
+    actor::{ActorRef, UnboundedMailbox},
     error::BoxError,
     message::{Context, Message, StreamMessage},
     Actor,
@@ -17,6 +17,8 @@ pub struct MyActor {
 }
 
 impl Actor for MyActor {
+    type Mailbox = UnboundedMailbox<Self>;
+
     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
         let stream = Box::pin(
             stream::repeat(1)

--- a/crates/kameo/src/actor.rs
+++ b/crates/kameo/src/actor.rs
@@ -23,17 +23,18 @@
 
 mod actor_ref;
 mod kind;
+mod mailbox;
 mod pool;
 mod spawn;
 
 use std::any;
 
 use futures::Future;
-use tokio::sync::mpsc;
 
 use crate::error::{ActorStopReason, BoxError, PanicError};
 
 pub use actor_ref::*;
+pub use mailbox::*;
 pub use pool::*;
 pub use spawn::*;
 
@@ -74,14 +75,14 @@ pub trait Actor: Sized {
     ///
     /// Bounded mailboxes enable backpressure to prevent the queued messages from growing indefinitely,
     /// whilst unbounded mailboxes have no backpressure and can grow infinitely until the system runs out of memory.
-    type Mailbox: MailboxBehaviour<Self> + SignalMailbox + Clone + Send + Sync;
+    type Mailbox: Mailbox<Self>;
 
     /// Actor name, useful for logging.
     fn name() -> &'static str {
         any::type_name::<Self>()
     }
 
-    /// The capacity of the actors mailbox.
+    /// Creates a new mailbox.
     fn new_mailbox(&self) -> (Self::Mailbox, MailboxReceiver<Self>) {
         Self::Mailbox::default_mailbox()
     }
@@ -171,188 +172,5 @@ pub trait Actor: Sized {
         reason: ActorStopReason,
     ) -> impl Future<Output = Result<(), BoxError>> + Send {
         async { Ok(()) }
-    }
-}
-
-#[doc(hidden)]
-pub trait MailboxBehaviour<A: Actor>: Sized {
-    type WeakMailbox: WeakMailboxBehaviour<StrongMailbox = Self> + Clone + Send;
-
-    fn default_mailbox() -> (Self, MailboxReceiver<A>);
-    fn send(
-        &self,
-        signal: Signal<A>,
-    ) -> impl Future<Output = Result<(), mpsc::error::SendError<Signal<A>>>> + Send + '_;
-    fn closed(&self) -> impl Future<Output = ()> + '_;
-    fn is_closed(&self) -> bool;
-    fn downgrade(&self) -> Self::WeakMailbox;
-    fn strong_count(&self) -> usize;
-    fn weak_count(&self) -> usize;
-}
-
-#[doc(hidden)]
-pub trait WeakMailboxBehaviour {
-    type StrongMailbox;
-
-    fn upgrade(&self) -> Option<Self::StrongMailbox>;
-    fn strong_count(&self) -> usize;
-    fn weak_count(&self) -> usize;
-}
-
-/// An unbounded mailbox, where the sending messages to a full mailbox causes backpressure.
-#[allow(missing_debug_implementations)]
-pub struct BoundedMailbox<A: Actor>(pub(crate) mpsc::Sender<Signal<A>>);
-
-impl<A: Actor> MailboxBehaviour<A> for BoundedMailbox<A> {
-    type WeakMailbox = WeakBoundedMailbox<A>;
-
-    #[inline]
-    fn default_mailbox() -> (Self, MailboxReceiver<A>) {
-        let (tx, rx) = mpsc::channel(1000);
-        (BoundedMailbox(tx), MailboxReceiver::Bounded(rx))
-    }
-
-    #[inline]
-    async fn send(&self, signal: Signal<A>) -> Result<(), mpsc::error::SendError<Signal<A>>> {
-        self.0.send(signal).await
-    }
-
-    #[inline]
-    async fn closed(&self) {
-        self.0.closed().await
-    }
-
-    #[inline]
-    fn is_closed(&self) -> bool {
-        self.0.is_closed()
-    }
-
-    #[inline]
-    fn downgrade(&self) -> Self::WeakMailbox {
-        WeakBoundedMailbox(self.0.downgrade())
-    }
-
-    #[inline]
-    fn strong_count(&self) -> usize {
-        self.0.strong_count()
-    }
-
-    #[inline]
-    fn weak_count(&self) -> usize {
-        self.0.weak_count()
-    }
-}
-
-impl<A: Actor> Clone for BoundedMailbox<A> {
-    fn clone(&self) -> Self {
-        BoundedMailbox(self.0.clone())
-    }
-}
-
-/// A weak bounded mailbox that does not prevent the actor from being stopped.
-#[allow(missing_debug_implementations)]
-pub struct WeakBoundedMailbox<A: Actor>(pub(crate) mpsc::WeakSender<Signal<A>>);
-
-impl<A: Actor> WeakMailboxBehaviour for WeakBoundedMailbox<A> {
-    type StrongMailbox = BoundedMailbox<A>;
-
-    #[inline]
-    fn upgrade(&self) -> Option<Self::StrongMailbox> {
-        self.0.upgrade().map(BoundedMailbox)
-    }
-
-    #[inline]
-    fn strong_count(&self) -> usize {
-        self.0.strong_count()
-    }
-
-    #[inline]
-    fn weak_count(&self) -> usize {
-        self.0.weak_count()
-    }
-}
-
-impl<A: Actor> Clone for WeakBoundedMailbox<A> {
-    fn clone(&self) -> Self {
-        WeakBoundedMailbox(self.0.clone())
-    }
-}
-
-/// An unbounded mailbox, where the number of messages queued can grow infinitely.
-#[allow(missing_debug_implementations)]
-pub struct UnboundedMailbox<A: Actor>(pub(crate) mpsc::UnboundedSender<Signal<A>>);
-
-impl<A: Actor> MailboxBehaviour<A> for UnboundedMailbox<A> {
-    type WeakMailbox = WeakUnboundedMailbox<A>;
-
-    #[inline]
-    fn default_mailbox() -> (Self, MailboxReceiver<A>) {
-        let (tx, rx) = mpsc::unbounded_channel();
-        (UnboundedMailbox(tx), MailboxReceiver::Unbounded(rx))
-    }
-
-    #[inline]
-    async fn send(&self, signal: Signal<A>) -> Result<(), mpsc::error::SendError<Signal<A>>> {
-        self.0.send(signal)
-    }
-
-    #[inline]
-    async fn closed(&self) {
-        self.0.closed().await
-    }
-
-    #[inline]
-    fn is_closed(&self) -> bool {
-        self.0.is_closed()
-    }
-
-    #[inline]
-    fn downgrade(&self) -> Self::WeakMailbox {
-        WeakUnboundedMailbox(self.0.downgrade())
-    }
-
-    #[inline]
-    fn strong_count(&self) -> usize {
-        self.0.strong_count()
-    }
-
-    #[inline]
-    fn weak_count(&self) -> usize {
-        self.0.weak_count()
-    }
-}
-
-impl<A: Actor> Clone for UnboundedMailbox<A> {
-    fn clone(&self) -> Self {
-        UnboundedMailbox(self.0.clone())
-    }
-}
-
-/// A weak unbounded mailbox that does not prevent the actor from being stopped.
-#[allow(missing_debug_implementations)]
-pub struct WeakUnboundedMailbox<A: Actor>(pub(crate) mpsc::WeakUnboundedSender<Signal<A>>);
-
-impl<A: Actor> WeakMailboxBehaviour for WeakUnboundedMailbox<A> {
-    type StrongMailbox = UnboundedMailbox<A>;
-
-    #[inline]
-    fn upgrade(&self) -> Option<Self::StrongMailbox> {
-        self.0.upgrade().map(UnboundedMailbox)
-    }
-
-    #[inline]
-    fn strong_count(&self) -> usize {
-        self.0.strong_count()
-    }
-
-    #[inline]
-    fn weak_count(&self) -> usize {
-        self.0.weak_count()
-    }
-}
-
-impl<A: Actor> Clone for WeakUnboundedMailbox<A> {
-    fn clone(&self) -> Self {
-        WeakUnboundedMailbox(self.0.clone())
     }
 }

--- a/crates/kameo/src/actor/actor_ref.rs
+++ b/crates/kameo/src/actor/actor_ref.rs
@@ -1,33 +1,30 @@
 use std::{
     cell::Cell,
     collections::HashMap,
-    fmt,
-    marker::PhantomData,
-    pin::Pin,
+    fmt, ops,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, Mutex, TryLockError,
+        Arc,
     },
-    task::{self, ready, Poll},
-    time::Duration,
 };
 
 use dyn_clone::DynClone;
-use futures::{stream::AbortHandle, Future, Stream, StreamExt};
+use futures::{future::BoxFuture, stream::AbortHandle, FutureExt, Stream, StreamExt};
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, Mutex},
     task::JoinHandle,
     task_local,
 };
 
 use crate::{
-    error::{ActorStopReason, BoxSendError, SendError, SendResult},
-    message::{
-        BlockingMessage, BoxReply, DynBlockingMessage, DynMessage, DynQuery, Message, Query,
-        StreamMessage,
-    },
+    error::{ActorStopReason, BoxSendError, SendError},
+    message::{BoxReply, DynMessage, DynQuery, Message, Query, StreamMessage},
     reply::Reply,
+    request::{AskRequest, QueryRequest, TellRequest, WithoutRequestTimeout},
+    Actor,
 };
+
+use super::{BoundedMailbox, MailboxBehaviour, UnboundedMailbox, WeakMailboxBehaviour};
 
 static ACTOR_COUNTER: AtomicU64 = AtomicU64::new(0);
 task_local! {
@@ -37,20 +34,19 @@ thread_local! {
     pub(crate) static CURRENT_THREAD_ACTOR_ID: Cell<Option<u64>> = Cell::new(None);
 }
 
-type Mailbox<A> = mpsc::UnboundedSender<Signal<A>>;
-type WeakMailbox<A> = mpsc::WeakUnboundedSender<Signal<A>>;
-pub(crate) type Links = Arc<Mutex<HashMap<u64, Box<dyn SignalMailbox>>>>;
-
 /// A reference to an actor for sending messages/queries and managing the actor.
-pub struct ActorRef<A: ?Sized> {
+pub struct ActorRef<A: Actor> {
     id: u64,
-    mailbox: Mailbox<A>,
+    mailbox: A::Mailbox,
     abort_handle: AbortHandle,
     links: Links,
 }
 
-impl<A> ActorRef<A> {
-    pub(crate) fn new(mailbox: Mailbox<A>, abort_handle: AbortHandle, links: Links) -> Self {
+impl<A> ActorRef<A>
+where
+    A: Actor,
+{
+    pub(crate) fn new(mailbox: A::Mailbox, abort_handle: AbortHandle, links: Links) -> Self {
         ActorRef {
             id: ACTOR_COUNTER.fetch_add(1, Ordering::Relaxed),
             mailbox,
@@ -107,11 +103,11 @@ impl<A> ActorRef<A> {
     /// that the actor will process all preceding messages before stopping. Any messages sent
     /// after this stop signal will be ignored and dropped. This approach allows for a graceful
     /// shutdown of the actor, ensuring all pending work is completed before termination.
-    pub fn stop_gracefully(&self) -> Result<(), SendError>
+    pub async fn stop_gracefully(&self) -> Result<(), SendError>
     where
         A: 'static,
     {
-        self.mailbox.signal_stop()
+        self.mailbox.signal_stop().await
     }
 
     /// Kills the actor immediately.
@@ -148,146 +144,40 @@ impl<A> ActorRef<A> {
 
     /// Sends a message to the actor, waiting for a reply.
     ///
-    /// The message reply can be awaited asyncronously, or in a blocking context either by awaiting it directly,
-    /// or calling [`SendResult::blocking_recv()`].
-    ///
     /// # Example
     ///
     /// ```
-    /// actor_ref.send(msg).await?; // Receive reply asyncronously
-    /// actor_ref.send(msg).blocking_recv()?; // Receive reply blocking
+    /// actor_ref.ask(msg).send().await?; // Receive reply asyncronously
+    /// actor_ref.ask(msg).blocking_send()?; // Receive reply blocking
+    /// actor_ref.ask(msg).mailbox_timeout(Duration::from_secs(1)).send().await?; // Timeout after 1 second
     /// ```
-    pub fn send<M>(
+    #[inline]
+    pub fn ask<M>(
         &self,
         msg: M,
-    ) -> SendResult<<A::Reply as Reply>::Ok, M, <A::Reply as Reply>::Error>
+    ) -> AskRequest<A, A::Mailbox, M, WithoutRequestTimeout, WithoutRequestTimeout>
     where
         A: Message<M>,
         M: Send + 'static,
     {
-        debug_assert!(
-            !self.is_current(),
-            "actors cannot send messages syncronously themselves as this would deadlock - use send_async instead\nthis assertion only occurs on debug builds, release builds will deadlock",
-        );
-
-        let (reply, rx) = oneshot::channel();
-        let res = self.mailbox.send(Signal::Message {
-            message: Box::new(msg),
-            actor_ref: self.clone(),
-            reply: Some(reply),
-            sent_within_actor: self.is_current(),
-        });
-        if let Err(err) = res {
-            return SendResult::err(err.into());
-        }
-        SendResult::ok(rx)
+        AskRequest::new(self, msg)
     }
 
     /// Sends a message to the actor asyncronously without waiting for a reply.
     ///
-    /// If the handler for this message returns an error, the actor will panic.
-    pub fn send_async<M>(&self, msg: M) -> Result<(), SendError<M>>
-    where
-        A: Message<M>,
-        M: Send + 'static,
-    {
-        Ok(self.mailbox.send(Signal::Message {
-            message: Box::new(msg),
-            actor_ref: self.clone(),
-            reply: None,
-            sent_within_actor: self.is_current(),
-        })?)
-    }
-
-    /// Sends a message to the actor after a delay.
-    ///
-    /// This spawns a tokio::task and sleeps for the duration of `delay` before sending the message.
-    ///
-    /// If the handler for this message returns an error, the actor will panic.
-    pub fn send_after<M>(&self, msg: M, delay: Duration) -> JoinHandle<Result<(), SendError<M>>>
-    where
-        A: Message<M>,
-        M: Send + 'static,
-    {
-        let actor_ref = self.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(delay).await;
-            actor_ref.send_async(msg)
-        })
-    }
-
-    /// Sends a blocking message to the actor, waiting for a reply.
-    ///
-    /// The message reply can be awaited asyncronously, or in a blocking context either by awaiting it directly,
-    /// or calling [`SendResult::blocking_recv()`].
-    ///
     /// # Example
     ///
     /// ```
-    /// actor_ref.send_blocking(msg).await?; // Receive reply asyncronously
-    /// actor_ref.send_blocking(msg).blocking_recv()?; // Receive reply blocking
+    /// actor_ref.tell(msg).send().await?; // Send message
+    /// actor_ref.tell(msg).timeout(Duration::from_secs(1)).send().await?; // Timeout after 1 second
     /// ```
-    pub fn send_blocking<M>(
-        &self,
-        msg: M,
-    ) -> SendResult<<A::Reply as Reply>::Ok, M, <A::Reply as Reply>::Error>
+    #[inline]
+    pub fn tell<M>(&self, msg: M) -> TellRequest<A, A::Mailbox, M, WithoutRequestTimeout>
     where
-        A: BlockingMessage<M> + Sync,
+        A: Message<M>,
         M: Send + 'static,
     {
-        debug_assert!(
-            !self.is_current(),
-            "actors cannot send messages syncronously themselves as this would deadlock - use send_async instead\nthis assertion only occurs on debug builds, release builds will deadlock",
-        );
-
-        let (reply, rx) = oneshot::channel();
-        let res = self.mailbox.send(Signal::BlockingMessage {
-            message: Box::new(msg),
-            actor_ref: self.clone(),
-            reply: Some(reply),
-            sent_within_actor: self.is_current(),
-        });
-        if let Err(err) = res {
-            return SendResult::err(err.into());
-        }
-        SendResult::ok(rx)
-    }
-
-    /// Sends a blocking message to the actor asyncronously without waiting for a reply.
-    ///
-    /// If the handler for this message returns an error, the actor will panic.
-    pub fn send_blocking_async<M>(&self, msg: M) -> Result<(), SendError<M>>
-    where
-        A: BlockingMessage<M> + Sync,
-        M: Send + 'static,
-    {
-        Ok(self.mailbox.send(Signal::BlockingMessage {
-            message: Box::new(msg),
-            actor_ref: self.clone(),
-            reply: None,
-            sent_within_actor: self.is_current(),
-        })?)
-    }
-
-    /// Sends a blocking message to the actor after a delay.
-    ///
-    /// This spawns a tokio::task and sleeps for the duration of `delay` before sending the message.
-    ///
-    /// If the handler for this message returns an error, the actor will panic.
-    pub fn send_blocking_after<M>(
-        &self,
-        msg: M,
-        delay: Duration,
-    ) -> JoinHandle<Result<(), SendError<M>>>
-    where
-        A: BlockingMessage<M> + Sync,
-        M: Send + 'static,
-    {
-        let actor_ref = self.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(delay).await;
-            actor_ref.send_blocking_async(msg)
-        })
+        TellRequest::new(self, msg)
     }
 
     /// Queries the actor for some data.
@@ -297,34 +187,23 @@ impl<A> ActorRef<A> {
     /// If the actor was spawned as `!Sync` with [spawn_unsync](crate::actor::spawn_unsync),
     /// then queries will not be supported and any query will return an error of [`SendError::QueriesNotSupported`].
     ///
-    /// The query reply can be awaited asyncronously, or in a blocking context either by awaiting it directly,
-    /// or calling [`SendResult::blocking_recv()`].
-    ///
     /// # Example
     ///
     /// ```
-    /// actor_ref.query(msg).await?; // Receive reply asyncronously
-    /// actor_ref.query(msg).blocking_recv()?; // Receive reply blocking
+    /// actor_ref.query(msg).send().await?; // Receive reply asyncronously
+    /// actor_ref.query(msg).blocking_send()?; // Receive reply blocking
+    /// actor_ref.query(msg).mailbox_timeout(Duration::from_secs(1)).send().await?; // Timeout after 1 second
     /// ```
+    #[inline]
     pub fn query<M>(
         &self,
         msg: M,
-    ) -> SendResult<<A::Reply as Reply>::Ok, M, <A::Reply as Reply>::Error>
+    ) -> QueryRequest<A, A::Mailbox, M, WithoutRequestTimeout, WithoutRequestTimeout>
     where
         A: Query<M>,
         M: Send + 'static,
     {
-        let (reply, rx) = oneshot::channel();
-        let res = self.mailbox.send(Signal::Query {
-            query: Box::new(msg),
-            actor_ref: self.clone(),
-            reply: Some(reply),
-            sent_within_actor: self.is_current(),
-        });
-        if let Err(err) = res {
-            return SendResult::err(err.into());
-        }
-        SendResult::ok(rx)
+        QueryRequest::new(self, msg)
     }
 
     /// Attaches a stream of messages to the actor.
@@ -340,9 +219,10 @@ impl<A> ActorRef<A> {
         mut stream: S,
         start_value: T,
         finish_value: F,
-    ) -> JoinHandle<Result<(), SendError<StreamMessage<M, T, F>>>>
+    ) -> JoinHandle<Result<(), SendError<StreamMessage<M, T, F>, <A::Reply as Reply>::Error>>>
     where
         A: Message<StreamMessage<M, T, F>> + Send + 'static,
+        A::Mailbox: Send + Sync,
         S: Stream<Item = M> + Send + Unpin + 'static,
         M: Send + 'static,
         T: Send + 'static,
@@ -350,13 +230,17 @@ impl<A> ActorRef<A> {
     {
         let actor_ref = self.clone();
         tokio::spawn(async move {
-            actor_ref.send_async(StreamMessage::Started(start_value))?;
+            actor_ref
+                .send_msg(StreamMessage::Started(start_value))
+                .await?;
 
             while let Some(msg) = stream.next().await {
-                actor_ref.send_async(StreamMessage::Next(msg))?;
+                actor_ref.send_msg(StreamMessage::Next(msg)).await?;
             }
 
-            actor_ref.send_async(StreamMessage::Finished(finish_value))?;
+            actor_ref
+                .send_msg(StreamMessage::Finished(finish_value))
+                .await?;
 
             Ok(())
         })
@@ -365,9 +249,9 @@ impl<A> ActorRef<A> {
     /// Links this actor with a child, making this one the parent.
     ///
     /// If the parent dies, then the child will be notified with a link died signal.
-    pub fn link_child<B>(&self, child: &ActorRef<B>)
+    pub async fn link_child<B>(&self, child: &ActorRef<B>)
     where
-        B: 'static,
+        B: Actor + 'static,
     {
         if self.id == child.id() {
             return;
@@ -375,50 +259,54 @@ impl<A> ActorRef<A> {
 
         let child_id = child.id();
         let child: Box<dyn SignalMailbox> = child.signal_mailbox();
-        self.links.lock().unwrap().insert(child_id, child);
+        self.links.lock().await.insert(child_id, child);
     }
 
     /// Unlinks a previously linked child actor.
-    pub fn unlink_child<B>(&self, child: &ActorRef<B>)
+    pub async fn unlink_child<B>(&self, child: &ActorRef<B>)
     where
-        B: 'static,
+        B: Actor + 'static,
     {
         if self.id == child.id() {
             return;
         }
 
-        self.links.lock().unwrap().remove(&child.id());
+        self.links.lock().await.remove(&child.id());
     }
 
     /// Links this actor with a sibbling, notifying eachother if either one dies.
-    pub fn link_together<B>(&self, sibbling: &ActorRef<B>)
+    pub async fn link_together<B>(&self, sibbling: &ActorRef<B>)
     where
         A: 'static,
-        B: 'static,
+        B: Actor + 'static,
     {
         if self.id == sibbling.id() {
             return;
         }
 
         let (mut this_links, mut sibbling_links) =
-            (self.links.lock().unwrap(), sibbling.links.lock().unwrap());
+            tokio::join!(self.links.lock(), sibbling.links.lock());
         this_links.insert(sibbling.id(), sibbling.signal_mailbox());
         sibbling_links.insert(self.id, self.signal_mailbox());
     }
 
     /// Unlinks previously linked processes from eachother.
-    pub fn unlink_together<B>(&self, sibbling: &ActorRef<B>)
+    pub async fn unlink_together<B>(&self, sibbling: &ActorRef<B>)
     where
-        B: 'static,
+        B: Actor + 'static,
     {
         if self.id == sibbling.id() {
             return;
         }
 
         let (mut this_links, mut sibbling_links) =
-            (self.links.lock().unwrap(), sibbling.links.lock().unwrap());
+            tokio::join!(self.links.lock(), sibbling.links.lock());
         this_links.remove(&sibbling.id());
         sibbling_links.remove(&self.id);
+    }
+
+    pub(crate) fn mailbox(&self) -> &A::Mailbox {
+        &self.mailbox
     }
 
     pub(crate) fn signal_mailbox(&self) -> Box<dyn SignalMailbox>
@@ -427,9 +315,25 @@ impl<A> ActorRef<A> {
     {
         Box::new(self.mailbox.clone())
     }
+
+    async fn send_msg<M>(&self, msg: M) -> Result<(), SendError<M, <A::Reply as Reply>::Error>>
+    where
+        A: Message<M>,
+        M: Send + 'static,
+    {
+        self.mailbox
+            .send(Signal::Message {
+                message: Box::new(msg),
+                actor_ref: self.clone(),
+                reply: None,
+                sent_within_actor: false,
+            })
+            .await?;
+        Ok(())
+    }
 }
 
-impl<A: ?Sized> Clone for ActorRef<A> {
+impl<A: Actor> Clone for ActorRef<A> {
     fn clone(&self) -> Self {
         ActorRef {
             id: self.id,
@@ -440,7 +344,7 @@ impl<A: ?Sized> Clone for ActorRef<A> {
     }
 }
 
-impl<A: ?Sized> fmt::Debug for ActorRef<A> {
+impl<A: Actor> fmt::Debug for ActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("ActorRef");
         d.field("id", &self.id);
@@ -448,14 +352,17 @@ impl<A: ?Sized> fmt::Debug for ActorRef<A> {
             Ok(guard) => {
                 d.field("links", &guard.keys());
             }
-            Err(TryLockError::Poisoned(_)) => {
-                d.field("links", &format_args!("<poisoned>"));
-            }
-            Err(TryLockError::WouldBlock) => {
+            Err(_) => {
                 d.field("links", &format_args!("<locked>"));
             }
         }
         d.finish()
+    }
+}
+
+impl<A: Actor> AsRef<Links> for ActorRef<A> {
+    fn as_ref(&self) -> &Links {
+        &self.links
     }
 }
 
@@ -467,14 +374,14 @@ impl<A: ?Sized> fmt::Debug for ActorRef<A> {
 /// In order to send messages to an actor, the `WeakActorRef` needs to be upgraded using
 /// [`WeakActorRef::upgrade`], which returns `Option<ActorRef>`. It returns `None`
 /// if all `ActorRef`s have been dropped, and otherwise it returns an `ActorRef`.
-pub struct WeakActorRef<A: ?Sized> {
+pub struct WeakActorRef<A: Actor> {
     id: u64,
-    mailbox: WeakMailbox<A>,
+    mailbox: <A::Mailbox as MailboxBehaviour<A>>::WeakMailbox,
     abort_handle: AbortHandle,
     links: Links,
 }
 
-impl<A: ?Sized> WeakActorRef<A> {
+impl<A: Actor> WeakActorRef<A> {
     /// Returns the actor identifier.
     pub fn id(&self) -> u64 {
         self.id
@@ -502,7 +409,7 @@ impl<A: ?Sized> WeakActorRef<A> {
     }
 }
 
-impl<A: ?Sized> Clone for WeakActorRef<A> {
+impl<A: Actor> Clone for WeakActorRef<A> {
     fn clone(&self) -> Self {
         WeakActorRef {
             id: self.id,
@@ -513,7 +420,7 @@ impl<A: ?Sized> Clone for WeakActorRef<A> {
     }
 }
 
-impl<A: ?Sized> fmt::Debug for WeakActorRef<A> {
+impl<A: Actor> fmt::Debug for WeakActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("WeakActorRef");
         d.field("id", &self.id);
@@ -521,10 +428,7 @@ impl<A: ?Sized> fmt::Debug for WeakActorRef<A> {
             Ok(guard) => {
                 d.field("links", &guard.keys());
             }
-            Err(TryLockError::Poisoned(_)) => {
-                d.field("links", &format_args!("<poisoned>"));
-            }
-            Err(TryLockError::WouldBlock) => {
+            Err(_) => {
                 d.field("links", &format_args!("<locked>"));
             }
         }
@@ -532,93 +436,131 @@ impl<A: ?Sized> fmt::Debug for WeakActorRef<A> {
     }
 }
 
-/// A receiver for receiving a message response either asyncronously or blocking.
-///
-/// To receive the message asyncronously, simply `.await` the `MessageReceiver`.
-/// Or to receive in a blocking context, use [`MessageReceiver::blocking_recv()`].
-#[derive(Debug)]
-pub struct MessageReceiver<T, M, E> {
-    rx: oneshot::Receiver<Result<BoxReply, BoxSendError>>,
-    phantom: PhantomData<(T, M, E)>,
-}
+/// A hashmap of linked actors to be notified when the actor dies.
+#[derive(Clone, Default)]
+#[allow(missing_debug_implementations)]
+pub struct Links(Arc<Mutex<HashMap<u64, Box<dyn SignalMailbox>>>>);
 
-impl<T, M, E> MessageReceiver<T, M, E>
-where
-    T: 'static,
-    M: 'static,
-    E: 'static,
-{
-    pub(crate) fn new(rx: oneshot::Receiver<Result<BoxReply, BoxSendError>>) -> Self {
-        MessageReceiver {
-            rx,
-            phantom: PhantomData,
-        }
-    }
+impl ops::Deref for Links {
+    type Target = Mutex<HashMap<u64, Box<dyn SignalMailbox>>>;
 
-    /// Receives the message response outside an async context.
-    pub fn blocking_recv(self) -> Result<T, SendError<M, E>> {
-        let res = self.rx.blocking_recv()?;
-        match res {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
-        }
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
-impl<T, M, E> Future for MessageReceiver<T, M, E>
-where
-    T: 'static,
-    M: 'static,
-    E: 'static,
-{
-    type Output = Result<T, SendError<M, E>>;
+/// A mailbox receiver, either bounded or unbounded.
+#[allow(missing_debug_implementations)]
+pub enum MailboxReceiver<A: Actor> {
+    /// A bounded mailbox receiver.
+    Bounded(mpsc::Receiver<Signal<A>>),
+    /// An unbounded mailbox receiver.
+    Unbounded(mpsc::UnboundedReceiver<Signal<A>>),
+}
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        // Safety: `rx` is `Unpin` and we do not move `self`.
-        let rx = unsafe { self.map_unchecked_mut(|s| &mut s.rx) };
-        let res = ready!(rx.poll(cx));
-        match res? {
-            Ok(val) => Poll::Ready(Ok(*val.downcast().unwrap())),
-            Err(err) => Poll::Ready(Err(err.downcast())),
+impl<A: Actor> MailboxReceiver<A> {
+    pub(crate) async fn recv(&mut self) -> Option<Signal<A>> {
+        match self {
+            MailboxReceiver::Bounded(rx) => rx.recv().await,
+            MailboxReceiver::Unbounded(rx) => rx.recv().await,
         }
     }
 }
 
-pub(crate) trait SignalMailbox: DynClone + Send {
-    fn signal_startup_finished(&self) -> Result<(), SendError>;
-    fn signal_link_died(&self, id: u64, reason: ActorStopReason) -> Result<(), SendError>;
-    fn signal_stop(&self) -> Result<(), SendError>;
+#[doc(hidden)]
+pub trait SignalMailbox: DynClone + Send {
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>>;
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>>;
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>>;
 }
 
 dyn_clone::clone_trait_object!(SignalMailbox);
 
-impl<A> SignalMailbox for Mailbox<A> {
-    fn signal_startup_finished(&self) -> Result<(), SendError> {
-        self.send(Signal::StartupFinished)
-            .map_err(|_| SendError::ActorNotRunning(()))
+impl<A> SignalMailbox for BoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
     }
 
-    fn signal_link_died(&self, id: u64, reason: ActorStopReason) -> Result<(), SendError> {
-        self.send(Signal::LinkDied { id, reason })
-            .map_err(|_| SendError::ActorNotRunning(()))
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
     }
 
-    fn signal_stop(&self) -> Result<(), SendError> {
-        self.send(Signal::Stop)
-            .map_err(|_| SendError::ActorNotRunning(()))
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
     }
 }
 
-pub(crate) enum Signal<A: ?Sized> {
+impl<A> SignalMailbox for UnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[doc(hidden)]
+pub enum Signal<A: Actor> {
     StartupFinished,
     Message {
         message: Box<dyn DynMessage<A>>,
-        actor_ref: ActorRef<A>,
-        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
-        sent_within_actor: bool,
-    },
-    BlockingMessage {
-        message: Box<dyn DynBlockingMessage<A>>,
         actor_ref: ActorRef<A>,
         reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
         sent_within_actor: bool,
@@ -636,7 +578,7 @@ pub(crate) enum Signal<A: ?Sized> {
     Stop,
 }
 
-impl<A> Signal<A> {
+impl<A: Actor> Signal<A> {
     pub(crate) fn downcast_message<M>(self) -> Option<M>
     where
         M: 'static,

--- a/crates/kameo/src/actor/mailbox.rs
+++ b/crates/kameo/src/actor/mailbox.rs
@@ -1,0 +1,353 @@
+use dyn_clone::DynClone;
+use futures::{future::BoxFuture, Future, FutureExt};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{
+    error::{ActorStopReason, BoxSendError, SendError},
+    message::{BoxReply, DynMessage, DynQuery},
+    Actor,
+};
+
+use super::ActorRef;
+
+#[doc(hidden)]
+pub trait Mailbox<A: Actor>: SignalMailbox + Clone + Send + Sync + Sized {
+    type WeakMailbox: WeakMailbox<StrongMailbox = Self>;
+
+    fn default_mailbox() -> (Self, MailboxReceiver<A>);
+    fn send(
+        &self,
+        signal: Signal<A>,
+    ) -> impl Future<Output = Result<(), mpsc::error::SendError<Signal<A>>>> + Send + '_;
+    fn closed(&self) -> impl Future<Output = ()> + '_;
+    fn is_closed(&self) -> bool;
+    fn downgrade(&self) -> Self::WeakMailbox;
+    fn strong_count(&self) -> usize;
+    fn weak_count(&self) -> usize;
+}
+
+#[doc(hidden)]
+pub trait WeakMailbox: Clone + Send {
+    type StrongMailbox;
+
+    fn upgrade(&self) -> Option<Self::StrongMailbox>;
+    fn strong_count(&self) -> usize;
+    fn weak_count(&self) -> usize;
+}
+
+/// An unbounded mailbox, where the sending messages to a full mailbox causes backpressure.
+#[allow(missing_debug_implementations)]
+pub struct BoundedMailbox<A: Actor>(pub(crate) mpsc::Sender<Signal<A>>);
+
+impl<A: Actor> BoundedMailbox<A> {
+    /// Creates a new bounded mailbox with a given capacity.
+    #[inline]
+    pub fn new(capacity: usize) -> (Self, MailboxReceiver<A>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        (BoundedMailbox(tx), MailboxReceiver::Bounded(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for BoundedMailbox<A> {
+    type WeakMailbox = WeakBoundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, MailboxReceiver<A>) {
+        BoundedMailbox::new(1000)
+    }
+
+    #[inline]
+    async fn send(&self, signal: Signal<A>) -> Result<(), mpsc::error::SendError<Signal<A>>> {
+        self.0.send(signal).await
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakBoundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for BoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        BoundedMailbox(self.0.clone())
+    }
+}
+
+/// A weak bounded mailbox that does not prevent the actor from being stopped.
+#[allow(missing_debug_implementations)]
+pub struct WeakBoundedMailbox<A: Actor>(pub(crate) mpsc::WeakSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakBoundedMailbox<A> {
+    type StrongMailbox = BoundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(BoundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakBoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakBoundedMailbox(self.0.clone())
+    }
+}
+
+/// An unbounded mailbox, where the number of messages queued can grow infinitely.
+#[allow(missing_debug_implementations)]
+pub struct UnboundedMailbox<A: Actor>(pub(crate) mpsc::UnboundedSender<Signal<A>>);
+
+impl<A: Actor> UnboundedMailbox<A> {
+    /// Creates a new unbounded mailbox.
+    #[inline]
+    pub fn new() -> (Self, MailboxReceiver<A>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (UnboundedMailbox(tx), MailboxReceiver::Unbounded(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for UnboundedMailbox<A> {
+    type WeakMailbox = WeakUnboundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, MailboxReceiver<A>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (UnboundedMailbox(tx), MailboxReceiver::Unbounded(rx))
+    }
+
+    #[inline]
+    async fn send(&self, signal: Signal<A>) -> Result<(), mpsc::error::SendError<Signal<A>>> {
+        self.0.send(signal)
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakUnboundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for UnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        UnboundedMailbox(self.0.clone())
+    }
+}
+
+/// A weak unbounded mailbox that does not prevent the actor from being stopped.
+#[allow(missing_debug_implementations)]
+pub struct WeakUnboundedMailbox<A: Actor>(pub(crate) mpsc::WeakUnboundedSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakUnboundedMailbox<A> {
+    type StrongMailbox = UnboundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(UnboundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakUnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakUnboundedMailbox(self.0.clone())
+    }
+}
+
+/// A mailbox receiver, either bounded or unbounded.
+#[allow(missing_debug_implementations)]
+pub enum MailboxReceiver<A: Actor> {
+    /// A bounded mailbox receiver.
+    Bounded(mpsc::Receiver<Signal<A>>),
+    /// An unbounded mailbox receiver.
+    Unbounded(mpsc::UnboundedReceiver<Signal<A>>),
+}
+
+impl<A: Actor> MailboxReceiver<A> {
+    pub(crate) async fn recv(&mut self) -> Option<Signal<A>> {
+        match self {
+            MailboxReceiver::Bounded(rx) => rx.recv().await,
+            MailboxReceiver::Unbounded(rx) => rx.recv().await,
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[doc(hidden)]
+pub enum Signal<A: Actor> {
+    StartupFinished,
+    Message {
+        message: Box<dyn DynMessage<A>>,
+        actor_ref: ActorRef<A>,
+        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+        sent_within_actor: bool,
+    },
+    Query {
+        query: Box<dyn DynQuery<A>>,
+        actor_ref: ActorRef<A>,
+        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+        sent_within_actor: bool,
+    },
+    LinkDied {
+        id: u64,
+        reason: ActorStopReason,
+    },
+    Stop,
+}
+
+impl<A: Actor> Signal<A> {
+    pub(crate) fn downcast_message<M>(self) -> Option<M>
+    where
+        M: 'static,
+    {
+        match self {
+            Signal::Message { message, .. } => message.as_any().downcast().ok().map(|v| *v),
+            Signal::Query { query: message, .. } => message.as_any().downcast().ok().map(|v| *v),
+            _ => None,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub trait SignalMailbox: DynClone + Send {
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>>;
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>>;
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>>;
+}
+
+dyn_clone::clone_trait_object!(SignalMailbox);
+
+impl<A> SignalMailbox for BoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+impl<A> SignalMailbox for UnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: u64,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}

--- a/crates/kameo/src/actor/spawn.rs
+++ b/crates/kameo/src/actor/spawn.rs
@@ -210,7 +210,10 @@ async fn run_actor_lifecycle<A, S>(
         .map_err(PanicError::new_boxed)
         .and_then(convert::identity);
 
-    let _ = actor_ref.signal_mailbox().signal_startup_finished().await;
+    let _ = actor_ref
+        .weak_signal_mailbox()
+        .signal_startup_finished()
+        .await;
     let actor_ref = {
         // Downgrade actor ref
         let weak_actor_ref = actor_ref.downgrade();

--- a/crates/kameo/src/lib.rs
+++ b/crates/kameo/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! - **Async**: Built on tokio, actors run asyncronously in their own isolated spawned tasks.
 //! - **Supervision**: Link actors, creating dependencies through child/parent/sibbling relationships.
-//! - **MPSC Unbounded Channels**: Uses mpsc channels for messaging between actors.
+//! - **MPSC Bounded/Unbounded Channels**: Uses mpsc channels for messaging between actors with boundedness configurable.
 //! - **Concurrent Queries**: Support concurrent processing of queries when mutable state isn't necessary.
 //! - **Panic Safe**: Catches panics internally, allowing actors to be restarted.
 //!
@@ -69,6 +69,8 @@
 //! ```rust
 //! // Derive Actor
 //! impl kameo::actor::Actor for Counter {
+//!     type Mailbox = kameo::actor::UnboundedMailbox<Self>;
+//!
 //!     fn name(&self) -> Cow<'_, str> {
 //!         Cow::Borrowed("Counter")
 //!     }
@@ -92,7 +94,7 @@
 //! ```
 //! let counter_ref = kameo::spawn(Counter { count: 0 });
 //!
-//! let count = counter_ref.send(Inc(42)).await?;
+//! let count = counter_ref.ask(Inc(42)).send().await?;
 //! println!("Count is {count}");
 //! ```
 
@@ -106,6 +108,7 @@ pub mod actor;
 pub mod error;
 pub mod message;
 pub mod reply;
+pub mod request;
 
 pub use actor::{spawn, Actor};
 pub use kameo_macros::{messages, Actor, Reply};

--- a/crates/kameo/src/reply.rs
+++ b/crates/kameo/src/reply.rs
@@ -74,7 +74,7 @@ pub trait Reply: Send + 'static {
     type Error: Send + 'static;
     /// The type sent back to the receiver.
     ///
-    /// In almost all cases this will be `Self`. The only exception is the `DeligatedReply` type.
+    /// In almost all cases this will be `Self`. The only exception is the `DelegatedReply` type.
     type Value: Reply;
 
     /// Converts a reply to a `Result`.

--- a/crates/kameo/src/request.rs
+++ b/crates/kameo/src/request.rs
@@ -1,0 +1,120 @@
+//! Types for sending requests including messages and queries to actors.
+
+use std::time::Duration;
+
+use futures::Future;
+
+use crate::{
+    actor::{ActorRef, BoundedMailbox, UnboundedMailbox},
+    error::SendError,
+    message::Message,
+    reply::ReplySender,
+    Actor, Reply,
+};
+
+mod ask;
+mod query;
+mod tell;
+
+pub use ask::AskRequest;
+pub use query::QueryRequest;
+pub use tell::TellRequest;
+
+/// A trait for sending messages to an actor.
+///
+/// Typically `ActorRef::tell` and `ActorRef::ask` would be used directly, as they provide more functionality such as setting timeouts.
+/// Methods on this trait are helpful shorthand methods, which can be used for ActorRef's with any mailbox type (bounded or unbounded).
+pub trait Request<A, M, Mb>
+where
+    A: Actor<Mailbox = Mb> + Message<M>,
+{
+    /// Sends a message to an actor without waiting for any reply.
+    fn tell(
+        &self,
+        msg: M,
+    ) -> impl Future<Output = Result<(), SendError<M, <A::Reply as Reply>::Error>>> + Send;
+
+    /// Sends a message to an actor, waiting for a reply.
+    fn ask(
+        &self,
+        msg: M,
+    ) -> impl Future<
+        Output = Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>>,
+    > + Send;
+
+    /// Forwards a message to an actor, waiting for a reply to be sent back to `tx`.
+    fn ask_forwarded(
+        &self,
+        msg: M,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> impl Future<
+        Output = Result<
+            (),
+            SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+        >,
+    > + Send;
+}
+
+impl<A, M> Request<A, M, BoundedMailbox<A>> for ActorRef<A>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: Send + 'static,
+{
+    async fn tell(&self, msg: M) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        ActorRef::tell(self, msg).send().await
+    }
+
+    async fn ask(
+        &self,
+        msg: M,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        ActorRef::ask(self, msg).send().await
+    }
+
+    async fn ask_forwarded(
+        &self,
+        msg: M,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        ActorRef::ask(self, msg).forward(tx).await
+    }
+}
+
+impl<A, M> Request<A, M, UnboundedMailbox<A>> for ActorRef<A>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Message<M>,
+    M: Send + 'static,
+{
+    async fn tell(&self, msg: M) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        ActorRef::tell(self, msg).send()
+    }
+
+    async fn ask(
+        &self,
+        msg: M,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        ActorRef::ask(self, msg).send().await
+    }
+
+    async fn ask_forwarded(
+        &self,
+        msg: M,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        ActorRef::ask(self, msg).forward(tx)
+    }
+}
+
+/// A type for requests without any timeout set.
+#[allow(missing_debug_implementations)]
+pub struct WithoutRequestTimeout;
+
+/// A type for timeouts in actor requests.
+#[allow(missing_debug_implementations)]
+pub struct WithRequestTimeout(Duration);

--- a/crates/kameo/src/request/ask.rs
+++ b/crates/kameo/src/request/ask.rs
@@ -1,0 +1,309 @@
+use std::{marker::PhantomData, time::Duration};
+
+use tokio::{sync::oneshot, time::timeout};
+
+use crate::{
+    actor::{ActorRef, BoundedMailbox, Signal, UnboundedMailbox},
+    error::{BoxSendError, SendError},
+    message::{BoxReply, Message},
+    reply::ReplySender,
+    Actor, Reply,
+};
+
+use super::{WithRequestTimeout, WithoutRequestTimeout};
+
+/// A request to send a message to an actor, waiting for a reply.
+#[allow(missing_debug_implementations)]
+pub struct AskRequest<A, Mb, M, Tm, Tr>
+where
+    A: Actor<Mailbox = Mb>,
+{
+    mailbox: Mb,
+    signal: Signal<A>,
+    rx: oneshot::Receiver<Result<BoxReply, BoxSendError>>,
+    mailbox_timeout: Tm,
+    reply_timeout: Tr,
+    phantom: PhantomData<M>,
+}
+
+impl<A, M> AskRequest<A, A::Mailbox, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor,
+{
+    pub(crate) fn new(actor_ref: &ActorRef<A>, msg: M) -> Self
+    where
+        A: Message<M>,
+        M: Send + 'static,
+    {
+        let (reply, rx) = oneshot::channel();
+
+        AskRequest {
+            mailbox: actor_ref.mailbox().clone(),
+            signal: Signal::Message {
+                message: Box::new(msg),
+                actor_ref: actor_ref.clone(),
+                reply: Some(reply),
+                sent_within_actor: actor_ref.is_current(),
+            },
+            rx,
+            mailbox_timeout: WithoutRequestTimeout,
+            reply_timeout: WithoutRequestTimeout,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, M, Tm, Tr> AskRequest<A, BoundedMailbox<A>, M, Tm, Tr>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>>,
+{
+    /// Sets the timeout for waiting for the actors mailbox to have capacity.
+    pub fn mailbox_timeout(
+        self,
+        duration: Duration,
+    ) -> AskRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, Tr> {
+        AskRequest {
+            mailbox: self.mailbox,
+            signal: self.signal,
+            rx: self.rx,
+            mailbox_timeout: WithRequestTimeout(duration),
+            reply_timeout: self.reply_timeout,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, Mb, M, Tm, Tr> AskRequest<A, Mb, M, Tm, Tr>
+where
+    A: Actor<Mailbox = Mb>,
+{
+    /// Sets the timeout for waiting for a reply from the actor.
+    pub fn reply_timeout(self, duration: Duration) -> AskRequest<A, Mb, M, Tm, WithRequestTimeout> {
+        AskRequest {
+            mailbox: self.mailbox,
+            signal: self.signal,
+            rx: self.rx,
+            mailbox_timeout: self.mailbox_timeout,
+            reply_timeout: WithRequestTimeout(duration),
+            phantom: PhantomData,
+        }
+    }
+}
+
+// Bounded
+
+impl<A, M> AskRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message with the mailbox and reply timeouts set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> AskRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message with the mailbox timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub async fn forward(
+        mut self,
+        tx: oneshot::Sender<Result<BoxReply, BoxSendError>>,
+    ) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx),
+            _ => unreachable!("ask requests only support messages"),
+        }
+
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<A, M> AskRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message with the reply timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal).await?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> AskRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal).await?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message from outside the async runtime.
+    pub fn blocking_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.blocking_send(self.signal)?;
+        match self.rx.blocking_recv()? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub async fn forward(
+        mut self,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Query { reply, .. } => *reply = Some(tx.box_sender()),
+            _ => unreachable!("ask requests only support messages and queries"),
+        }
+
+        self.mailbox
+            .0
+            .send(self.signal)
+            .await
+            .map_err(|err| match err.0 {
+                Signal::Message {
+                    message, mut reply, ..
+                } => SendError::ActorNotRunning((
+                    message.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                    ReplySender::new(reply.take().unwrap()),
+                )),
+                Signal::Query {
+                    query, mut reply, ..
+                } => SendError::ActorNotRunning((
+                    query.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                    ReplySender::new(reply.take().unwrap()),
+                )),
+                _ => unreachable!("ask requests only support messages and queries"),
+            })
+    }
+}
+
+// Unbounded
+
+impl<A, M> AskRequest<A, UnboundedMailbox<A>, M, WithoutRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message with the reply timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> AskRequest<A, UnboundedMailbox<A>, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message from outside the async runtime.
+    pub fn blocking_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match self.rx.blocking_recv()? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub fn forward(
+        mut self,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Query { reply, .. } => *reply = Some(tx.box_sender()),
+            _ => unreachable!("ask requests only support messages and queries"),
+        }
+
+        self.mailbox.0.send(self.signal).map_err(|err| match err.0 {
+            Signal::Message {
+                message, mut reply, ..
+            } => SendError::ActorNotRunning((
+                message.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                ReplySender::new(reply.take().unwrap()),
+            )),
+            Signal::Query {
+                query, mut reply, ..
+            } => SendError::ActorNotRunning((
+                query.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                ReplySender::new(reply.take().unwrap()),
+            )),
+            _ => unreachable!("ask requests only support messages and queries"),
+        })
+    }
+}

--- a/crates/kameo/src/request/query.rs
+++ b/crates/kameo/src/request/query.rs
@@ -169,6 +169,17 @@ where
             Err(err) => Err(err.downcast()),
         }
     }
+
+    /// Tries to send the message if the mailbox is not full, waiting for a reply up to the timeout set.
+    pub async fn try_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.try_send(self.signal)?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
 }
 
 impl<A, M> QueryRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout, WithoutRequestTimeout>
@@ -192,6 +203,28 @@ where
         self,
     ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
         self.mailbox.0.blocking_send(self.signal)?;
+        match self.rx.blocking_recv()? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Tries to send the message if the mailbox is not full, waiting for a reply.
+    pub async fn try_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.try_send(self.signal)?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Tries to send the message if the mailbox is not full from outside the async runtime, waiting for a reply.
+    pub fn try_blocking_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.try_send(self.signal)?;
         match self.rx.blocking_recv()? {
             Ok(val) => Ok(*val.downcast().unwrap()),
             Err(err) => Err(err.downcast()),

--- a/crates/kameo/src/request/query.rs
+++ b/crates/kameo/src/request/query.rs
@@ -1,0 +1,313 @@
+use std::{marker::PhantomData, time::Duration};
+
+use tokio::{sync::oneshot, time::timeout};
+
+use crate::{
+    actor::{ActorRef, BoundedMailbox, Signal, UnboundedMailbox},
+    error::{BoxSendError, SendError},
+    message::{BoxReply, Query},
+    reply::ReplySender,
+    Actor, Reply,
+};
+
+use super::{WithRequestTimeout, WithoutRequestTimeout};
+
+/// A request to send a message to an actor, waiting for a reply.
+#[allow(missing_debug_implementations)]
+pub struct QueryRequest<A, Mb, M, Tm, Tr>
+where
+    A: Actor<Mailbox = Mb>,
+{
+    mailbox: Mb,
+    signal: Signal<A>,
+    rx: oneshot::Receiver<Result<BoxReply, BoxSendError>>,
+    mailbox_timeout: Tm,
+    reply_timeout: Tr,
+    phantom: PhantomData<M>,
+}
+
+impl<A, M> QueryRequest<A, A::Mailbox, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor,
+{
+    pub(crate) fn new(actor_ref: &ActorRef<A>, query: M) -> Self
+    where
+        A: Query<M>,
+        M: Send + 'static,
+    {
+        let (reply, rx) = oneshot::channel();
+
+        QueryRequest {
+            mailbox: actor_ref.mailbox().clone(),
+            signal: Signal::Query {
+                query: Box::new(query),
+                actor_ref: actor_ref.clone(),
+                reply: Some(reply),
+                sent_within_actor: actor_ref.is_current(),
+            },
+            rx,
+            mailbox_timeout: WithoutRequestTimeout,
+            reply_timeout: WithoutRequestTimeout,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, M, Tm, Tr> QueryRequest<A, BoundedMailbox<A>, M, Tm, Tr>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>>,
+{
+    /// Sets the timeout for waiting for the actors mailbox to have capacity.
+    pub fn mailbox_timeout(
+        self,
+        duration: Duration,
+    ) -> QueryRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, Tr> {
+        QueryRequest {
+            mailbox: self.mailbox,
+            signal: self.signal,
+            rx: self.rx,
+            mailbox_timeout: WithRequestTimeout(duration),
+            reply_timeout: self.reply_timeout,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, Mb, M, Tm, Tr> QueryRequest<A, Mb, M, Tm, Tr>
+where
+    A: Actor<Mailbox = Mb>,
+{
+    /// Sets the timeout for waiting for a reply from the actor.
+    pub fn reply_timeout(
+        self,
+        duration: Duration,
+    ) -> QueryRequest<A, Mb, M, Tm, WithRequestTimeout> {
+        QueryRequest {
+            mailbox: self.mailbox,
+            signal: self.signal,
+            rx: self.rx,
+            mailbox_timeout: self.mailbox_timeout,
+            reply_timeout: WithRequestTimeout(duration),
+            phantom: PhantomData,
+        }
+    }
+}
+
+// Bounded
+
+impl<A, M> QueryRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message with the mailbox and reply timeouts set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> QueryRequest<A, BoundedMailbox<A>, M, WithRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message with the mailbox timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub async fn forward(
+        mut self,
+        tx: oneshot::Sender<Result<BoxReply, BoxSendError>>,
+    ) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx),
+            Signal::Query { reply, .. } => *reply = Some(tx),
+            _ => unreachable!("ask requests only support messages and queries"),
+        }
+
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.mailbox_timeout.0)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<A, M> QueryRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message with the reply timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal).await?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> QueryRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal).await?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message from outside the async runtime.
+    pub fn blocking_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.blocking_send(self.signal)?;
+        match self.rx.blocking_recv()? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub async fn forward(
+        mut self,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Query { reply, .. } => *reply = Some(tx.box_sender()),
+            _ => unreachable!("ask requests only support messages and queries"),
+        }
+
+        self.mailbox
+            .0
+            .send(self.signal)
+            .await
+            .map_err(|err| match err.0 {
+                Signal::Message {
+                    message, mut reply, ..
+                } => SendError::ActorNotRunning((
+                    message.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                    ReplySender::new(reply.take().unwrap()),
+                )),
+                Signal::Query {
+                    query, mut reply, ..
+                } => SendError::ActorNotRunning((
+                    query.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                    ReplySender::new(reply.take().unwrap()),
+                )),
+                _ => unreachable!("ask requests only support messages and queries"),
+            })
+    }
+}
+
+// Unbounded
+
+impl<A, M> QueryRequest<A, UnboundedMailbox<A>, M, WithoutRequestTimeout, WithRequestTimeout>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message with the reply timeout set, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match timeout(self.reply_timeout.0, self.rx).await?? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+}
+
+impl<A, M> QueryRequest<A, UnboundedMailbox<A>, M, WithoutRequestTimeout, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Query<M>,
+    M: 'static,
+{
+    /// Sends the message, waiting for a reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match self.rx.await? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message from outside the async runtime.
+    pub fn blocking_send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        match self.rx.blocking_recv()? {
+            Ok(val) => Ok(*val.downcast().unwrap()),
+            Err(err) => Err(err.downcast()),
+        }
+    }
+
+    /// Sends the message with the reply being sent back to `tx`.
+    pub fn forward(
+        mut self,
+        tx: ReplySender<<A::Reply as Reply>::Value>,
+    ) -> Result<
+        (),
+        SendError<(M, ReplySender<<A::Reply as Reply>::Value>), <A::Reply as Reply>::Error>,
+    > {
+        match &mut self.signal {
+            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Query { reply, .. } => *reply = Some(tx.box_sender()),
+            _ => unreachable!("ask requests only support messages and queries"),
+        }
+
+        self.mailbox.0.send(self.signal).map_err(|err| match err.0 {
+            Signal::Message {
+                message, mut reply, ..
+            } => SendError::ActorNotRunning((
+                message.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                ReplySender::new(reply.take().unwrap()),
+            )),
+            Signal::Query {
+                query, mut reply, ..
+            } => SendError::ActorNotRunning((
+                query.as_any().downcast::<M>().ok().map(|v| *v).unwrap(),
+                ReplySender::new(reply.take().unwrap()),
+            )),
+            _ => unreachable!("ask requests only support messages and queries"),
+        })
+    }
+}

--- a/crates/kameo/src/request/tell.rs
+++ b/crates/kameo/src/request/tell.rs
@@ -1,0 +1,197 @@
+use std::{marker::PhantomData, mem, time::Duration};
+
+use futures::TryFutureExt;
+use tokio::{task::JoinHandle, time::timeout};
+
+use crate::{
+    actor::{ActorRef, BoundedMailbox, Signal, UnboundedMailbox},
+    error::SendError,
+    message::Message,
+    Actor, Reply,
+};
+
+use super::{WithRequestTimeout, WithoutRequestTimeout};
+
+/// A request to send a message to an actor without any reply.
+///
+/// This can be thought of as "fire and forget".
+#[allow(missing_debug_implementations)]
+pub struct TellRequest<A, Mb, M, T>
+where
+    A: Actor<Mailbox = Mb>,
+{
+    mailbox: Mb,
+    signal: Signal<A>,
+    timeout: T,
+    phantom: PhantomData<M>,
+}
+
+impl<A, M> TellRequest<A, A::Mailbox, M, WithoutRequestTimeout>
+where
+    A: Actor,
+{
+    pub(crate) fn new(actor_ref: &ActorRef<A>, msg: M) -> Self
+    where
+        A: Message<M>,
+        M: Send + 'static,
+    {
+        TellRequest {
+            mailbox: actor_ref.mailbox().clone(),
+            signal: Signal::Message {
+                message: Box::new(msg),
+                actor_ref: actor_ref.clone(),
+                reply: None,
+                sent_within_actor: actor_ref.is_current(),
+            },
+            timeout: WithoutRequestTimeout,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, M, T> TellRequest<A, BoundedMailbox<A>, M, T>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>>,
+{
+    /// Sets the timeout for waiting for a reply from the actor.
+    pub fn timeout(
+        self,
+        duration: Duration,
+    ) -> TellRequest<A, BoundedMailbox<A>, M, WithRequestTimeout> {
+        TellRequest {
+            mailbox: self.mailbox,
+            signal: self.signal,
+            timeout: WithRequestTimeout(duration),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, M> TellRequest<A, BoundedMailbox<A>, M, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message.
+    pub async fn send(self) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal).await?;
+        Ok(())
+    }
+
+    /// Sends the message from outside the async runtime.
+    pub fn blocking_send(self) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.blocking_send(self.signal)?;
+        Ok(())
+    }
+
+    /// Sends the message after the given delay.
+    ///
+    /// If reserve is true, then a permit will be reserved in
+    /// the actors mailbox before waiting for the delay.
+    pub fn delayed_send(
+        mut self,
+        delay: Duration,
+        reserve: bool,
+    ) -> JoinHandle<Result<(), SendError<M, <A::Reply as Reply>::Error>>>
+    where
+        A: 'static,
+        M: Send,
+    {
+        tokio::spawn(async move {
+            let permit = match reserve {
+                true => Some(self.mailbox.0.reserve().await.map_err(|_| {
+                    SendError::ActorNotRunning(
+                        mem::replace(&mut self.signal, Signal::Stop) // Replace signal with a dummy value
+                            .downcast_message::<M>()
+                            .unwrap(),
+                    )
+                })?),
+                false => None,
+            };
+
+            tokio::time::sleep(delay).await;
+
+            match permit {
+                Some(permit) => permit.send(self.signal),
+                None => self.mailbox.0.send(self.signal).await?,
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<A, M> TellRequest<A, BoundedMailbox<A>, M, WithRequestTimeout>
+where
+    A: Actor<Mailbox = BoundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message with the timeout set.
+    pub async fn send(self) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox
+            .0
+            .send_timeout(self.signal, self.timeout.0)
+            .await?;
+        Ok(())
+    }
+
+    /// Sends the message after the given delay with the timeout set.
+    ///
+    /// If reserve is true, then a permit will be reserved in
+    /// the actors mailbox before waiting for the delay.
+    pub fn delayed_send(
+        mut self,
+        delay: Duration,
+        reserve: bool,
+    ) -> JoinHandle<Result<(), SendError<M, <A::Reply as Reply>::Error>>>
+    where
+        A: 'static,
+        M: Send,
+    {
+        tokio::spawn(async move {
+            let permit = match reserve {
+                true => {
+                    let permit = timeout(
+                        self.timeout.0,
+                        self.mailbox.0.reserve().map_err(|_| {
+                            SendError::ActorNotRunning(
+                                mem::replace(&mut self.signal, Signal::Stop) // Replace signal with a dummy value
+                                    .downcast_message::<M>()
+                                    .unwrap(),
+                            )
+                        }),
+                    )
+                    .await??;
+                    Some(permit)
+                }
+                false => None,
+            };
+
+            tokio::time::sleep(delay).await;
+
+            match permit {
+                Some(permit) => permit.send(self.signal),
+                None => {
+                    self.mailbox
+                        .0
+                        .send_timeout(self.signal, self.timeout.0)
+                        .await?
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<A, M> TellRequest<A, UnboundedMailbox<A>, M, WithoutRequestTimeout>
+where
+    A: Actor<Mailbox = UnboundedMailbox<A>> + Message<M>,
+    M: 'static,
+{
+    /// Sends the message.
+    pub fn send(self) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.send(self.signal)?;
+        Ok(())
+    }
+}

--- a/crates/kameo/src/request/tell.rs
+++ b/crates/kameo/src/request/tell.rs
@@ -84,6 +84,12 @@ where
         Ok(())
     }
 
+    /// Tries to send the message if the mailbox is not full.
+    pub fn try_send(self) -> Result<(), SendError<M, <A::Reply as Reply>::Error>> {
+        self.mailbox.0.try_send(self.signal)?;
+        Ok(())
+    }
+
     /// Sends the message after the given delay.
     ///
     /// If reserve is true, then a permit will be reserved in

--- a/crates/kameo_macros/src/derive_actor.rs
+++ b/crates/kameo_macros/src/derive_actor.rs
@@ -18,6 +18,8 @@ impl ToTokens for DeriveActor {
         tokens.extend(quote! {
             #[automatically_derived]
             impl #impl_generics ::kameo::actor::Actor for #ident #ty_generics #where_clause {
+                type Mailbox = ::kameo::actor::UnboundedMailbox<Self>;
+
                 fn name() -> &'static str {
                     #name
                 }

--- a/crates/kameo_macros/src/lib.rs
+++ b/crates/kameo_macros/src/lib.rs
@@ -41,9 +41,9 @@ use syn::parse_macro_input;
 ///     }
 /// }
 ///
-/// counter_ref.send(Inc { amount: 5 }).await?;
-/// counter_ref.query(Count).await?;
-/// counter_ref.send(Dec { amount: 2 }.clone()).await?;
+/// counter_ref.ask(Inc { amount: 5 }).send().await?;
+/// counter_ref.query(Count).send().await?;
+/// counter_ref.ask(Dec { amount: 2 }.clone()).send().await?;
 /// ```
 ///
 /// <details>


### PR DESCRIPTION
Closes https://github.com/tqwewe/kameo/issues/3 and https://github.com/tqwewe/kameo/issues/28

This PR changes how the fundamentals of kameo works, but adds support for choosing the boundedness of actor mailboxes. The actor mailbox can be set when implementing `Actor` with the `type Mailbox = BoundedMailbox<Self> or UnboundedMailbox<Self>` associated type.

As unbounded channels differ in asyncness than bounded channels, a new builder syntax has been introduced when sending messages to actors. The types are `AskRequest`, `TellRequest`, and `QueryRequest`. These are returned an ActorRef's with the `.ask(...)`, `.tell(...)`, `.query(...)` methods, and support customizing timeouts.

Sending a message with a reply would look like `my_actor_ref.ask(Foo { ... }).send().await?;`, and sending a message without a reply looks like `my_actor_ref.tell(Foo { ... }).send().await?;`