### PR TITLE
feat!: add request traits

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,7 +1,8 @@
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
-use kameo::actor::BoundedMailbox;
+use kameo::mailbox::bounded::BoundedMailbox;
+use kameo::request::MessageSend;
 use kameo::{
     message::{Context, Message},
     Actor,

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -1,6 +1,7 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
-use kameo::actor::UnboundedMailbox;
+use kameo::mailbox::unbounded::UnboundedMailbox;
+use kameo::request::MessageSend;
 use kameo::{
     message::{Context, Message},
     Actor,

--- a/examples/ask.rs
+++ b/examples/ask.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
 use kameo::{
-    actor::UnboundedMailbox,
+    mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
+    request::{MessageSend, MessageSendSync},
     Actor,
 };
 use tracing::info;
@@ -35,7 +36,7 @@ impl Message<Inc> for MyActor {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter("trace".parse::<EnvFilter>().unwrap())
@@ -45,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let my_actor_ref = kameo::spawn(MyActor::default());
 
-    my_actor_ref.tell(Inc { amount: 3 }).send()?;
+    my_actor_ref.tell(Inc { amount: 3 }).send_sync()?;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Increment the count by 3

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,7 @@
 use kameo::{
-    actor::UnboundedMailbox,
+    mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
+    request::{MessageSend, MessageSendSync},
     Actor,
 };
 use tracing::info;
@@ -48,7 +49,7 @@ impl Message<ForceErr> for MyActor {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter("trace".parse::<EnvFilter>().unwrap())
@@ -63,14 +64,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Count is {count}");
 
     // Increment the count by 50 in the background
-    my_actor_ref.tell(Inc { amount: 50 }).send()?;
+    my_actor_ref.tell(Inc { amount: 50 }).send_sync()?;
 
     // Increment the count by 2
     let count = my_actor_ref.ask(Inc { amount: 2 }).send().await?;
     info!("Count is {count}");
 
     // Async messages that return an Err will cause the actor to panic
-    my_actor_ref.tell(ForceErr).send()?;
+    my_actor_ref.tell(ForceErr).send_sync()?;
 
     // Actor should be stopped, so we cannot send more messages to it
     assert!(my_actor_ref.ask(Inc { amount: 2 }).send().await.is_err());

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
-use kameo::{messages, Actor};
+use kameo::{
+    messages,
+    request::{MessageSend, MessageSendSync},
+    Actor,
+};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -54,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Count is {count}");
 
     // Increment the count by 50 in the background
-    my_actor_ref.tell(Inc { amount: 50 }).send()?;
+    my_actor_ref.tell(Inc { amount: 50 }).send_sync()?;
 
     // Generic message
     my_actor_ref
@@ -65,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Async messages that return an Err will cause the actor to panic
-    my_actor_ref.tell(ForceErr).send()?;
+    my_actor_ref.tell(ForceErr).send_sync()?;
 
     // Actor should be stopped, so we cannot send more messages to it
     assert!(my_actor_ref.ask(Inc { amount: 2 }).send().await.is_err());

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use kameo::{
     actor::{ActorPool, BroadcastMsg, WorkerMsg},
     message::{Context, Message},
+    request::MessageSend,
     Actor,
 };
 use tracing_subscriber::EnvFilter;
@@ -36,7 +37,7 @@ impl Message<ForceStop> for MyActor {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter("warn".parse::<EnvFilter>().unwrap())

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,6 +1,7 @@
 use kameo::{
     actor::{PubSub, Publish, Subscribe},
     message::{Context, Message},
+    request::MessageSend,
     Actor,
 };
 use tracing_subscriber::EnvFilter;
@@ -38,7 +39,7 @@ impl Message<PrintActorID> for ActorB {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter("warn".parse::<EnvFilter>().unwrap())

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -4,6 +4,7 @@ use kameo::{
     actor::RemoteActorRef,
     message::{Context, Message},
     remote::ActorSwarm,
+    request::MessageSend,
     Actor,
 };
 use kameo_macros::{remote_message, RemoteActor};

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -2,8 +2,9 @@ use std::{future::pending, time};
 
 use futures::stream;
 use kameo::{
-    actor::{ActorRef, UnboundedMailbox},
+    actor::ActorRef,
     error::BoxError,
+    mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message, StreamMessage},
     Actor,
 };
@@ -57,7 +58,7 @@ impl Message<StreamMessage<i64, &'static str, &'static str>> for MyActor {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter("trace".parse::<EnvFilter>().unwrap())

--- a/macros/src/derive_actor.rs
+++ b/macros/src/derive_actor.rs
@@ -28,21 +28,21 @@ impl ToTokens for DeriveActor {
 
         let mailbox_expanded = match attrs.mailbox {
             MailboxKind::Bounded(_) => quote! {
-                ::kameo::actor::BoundedMailbox<Self>
+                ::kameo::mailbox::bounded::BoundedMailbox<Self>
             },
             MailboxKind::Unbounded => quote! {
-                ::kameo::actor::UnboundedMailbox<Self>
+                ::kameo::mailbox::unbounded::UnboundedMailbox<Self>
             },
         };
         let new_mailbox_expanded = match attrs.mailbox {
             MailboxKind::Bounded(cap) => {
                 let cap = cap.unwrap_or(1000);
                 quote! {
-                    ::kameo::actor::BoundedMailbox::new(#cap)
+                    ::kameo::mailbox::bounded::BoundedMailbox::new(#cap)
                 }
             }
             MailboxKind::Unbounded => quote! {
-                ::kameo::actor::UnboundedMailbox::new()
+                ::kameo::mailbox::unbounded::UnboundedMailbox::new()
             },
         };
 
@@ -55,7 +55,7 @@ impl ToTokens for DeriveActor {
                     #name
                 }
 
-                fn new_mailbox() -> (Self::Mailbox, ::kameo::actor::MailboxReceiver<Self>) {
+                fn new_mailbox() -> (Self::Mailbox, <Self::Mailbox as ::kameo::mailbox::Mailbox<Self>>::Receiver) {
                     #new_mailbox_expanded
                 }
             }

--- a/macros/src/remote_message.rs
+++ b/macros/src/remote_message.rs
@@ -60,44 +60,62 @@ impl RemoteMessage {
                 #[linkme(crate = ::kameo::remote::_internal::linkme)]
                 static REG: (
                     ::kameo::remote::_internal::RemoteMessageRegistrationID<'static>,
-                    (
-                        ::kameo::remote::_internal::AskRemoteMessageFn,
-                        ::kameo::remote::_internal::TellRemoteMessageFn,
-                    ),
+                    ::kameo::remote::_internal::RemoteMessageFns,
                 ) = (
                     ::kameo::remote::_internal::RemoteMessageRegistrationID {
                         actor_remote_id: <#actor_ty as ::kameo::remote::RemoteActor>::REMOTE_ID,
                         message_remote_id: <#actor_ty #ty_generics as ::kameo::remote::RemoteMessage<#message_generics>>::REMOTE_ID,
                     },
-                    (
-                        (|actor_id: ::kameo::actor::ActorID,
-                          msg: ::std::vec::Vec<u8>,
-                          mailbox_timeout: ::std::option::Option<::std::time::Duration>,
-                          reply_timeout: ::std::option::Option<::std::time::Duration>,
-                          immediate: bool| {
-                            ::std::boxed::Box::pin(::kameo::remote::_internal::ask_remote_message::<
-                                #actor_ty,
-                                #message_generics,
-                            >(
-                                actor_id,
-                                msg,
-                                mailbox_timeout,
-                                reply_timeout,
-                                immediate,
-                            ))
-                        }) as ::kameo::remote::_internal::AskRemoteMessageFn,
-                        (|actor_id: ::kameo::actor::ActorID,
-                          msg: ::std::vec::Vec<u8>,
-                          mailbox_timeout: ::std::option::Option<::std::time::Duration>,
-                          immediate: bool| {
-                            ::std::boxed::Box::pin(::kameo::remote::_internal::tell_remote_message::<
-                                #actor_ty,
-                                #message_generics,
-                            >(
-                                actor_id, msg, mailbox_timeout, immediate
-                            ))
-                        }) as ::kameo::remote::_internal::TellRemoteMessageFn,
-                    ),
+                    ::kameo::remote::_internal::RemoteMessageFns {
+                        ask: (|actor_id: ::kameo::actor::ActorID,
+                              msg: ::std::vec::Vec<u8>,
+                              mailbox_timeout: ::std::option::Option<::std::time::Duration>,
+                              reply_timeout: ::std::option::Option<::std::time::Duration>| {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::ask::<
+                                    #actor_ty,
+                                    #message_generics,
+                                >(
+                                    actor_id,
+                                    msg,
+                                    mailbox_timeout,
+                                    reply_timeout,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteAskFn,
+                        try_ask: (|actor_id: ::kameo::actor::ActorID,
+                              msg: ::std::vec::Vec<u8>,
+                              reply_timeout: ::std::option::Option<::std::time::Duration>| {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::try_ask::<
+                                    #actor_ty,
+                                    #message_generics,
+                                >(
+                                    actor_id,
+                                    msg,
+                                    reply_timeout,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteTryAskFn,
+                        tell: (|actor_id: ::kameo::actor::ActorID,
+                              msg: ::std::vec::Vec<u8>,
+                              mailbox_timeout: ::std::option::Option<::std::time::Duration>| {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::tell::<
+                                    #actor_ty,
+                                    #message_generics,
+                                >(
+                                    actor_id,
+                                    msg,
+                                    mailbox_timeout,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteTellFn,
+                        try_tell: (|actor_id: ::kameo::actor::ActorID,
+                              msg: ::std::vec::Vec<u8>| {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::try_tell::<
+                                    #actor_ty,
+                                    #message_generics,
+                                >(
+                                    actor_id,
+                                    msg,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteTryTellFn,
+                    },
                 );
             };
         }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -24,7 +24,6 @@
 mod actor_ref;
 mod id;
 mod kind;
-mod mailbox;
 mod pool;
 mod pubsub;
 mod spawn;
@@ -33,11 +32,13 @@ use std::any;
 
 use futures::Future;
 
-use crate::error::{ActorStopReason, BoxError, PanicError};
+use crate::{
+    error::{ActorStopReason, BoxError, PanicError},
+    mailbox::Mailbox,
+};
 
 pub use actor_ref::*;
 pub use id::*;
-pub use mailbox::*;
 pub use pool::*;
 pub use pubsub::*;
 pub use spawn::*;
@@ -87,7 +88,7 @@ pub trait Actor: Sized + Send + 'static {
     }
 
     /// Creates a new mailbox.
-    fn new_mailbox() -> (Self::Mailbox, MailboxReceiver<Self>) {
+    fn new_mailbox() -> (Self::Mailbox, <Self::Mailbox as Mailbox<Self>>::Receiver) {
         Self::Mailbox::default_mailbox()
     }
 

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -6,10 +6,11 @@ use tokio::sync::oneshot;
 use crate::{
     actor::{Actor, ActorRef, WeakActorRef},
     error::{ActorStopReason, BoxSendError, PanicError},
+    mailbox::Signal,
     message::{BoxReply, DynMessage},
 };
 
-use super::{ActorID, Signal};
+use super::ActorID;
 
 pub(crate) trait ActorState<A: Actor>: Sized {
     fn new_from_actor(actor: A, actor_ref: WeakActorRef<A>) -> Self;

--- a/src/actor/mailbox/bounded.rs
+++ b/src/actor/mailbox/bounded.rs
@@ -1,0 +1,209 @@
+use std::fmt;
+
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::mpsc;
+
+use crate::{
+    actor::ActorID,
+    error::{ActorStopReason, SendError},
+    Actor,
+};
+
+use super::{Mailbox, MailboxReceiver, Signal, SignalMailbox, WeakMailbox};
+
+/// An unbounded mailbox, where the sending messages to a full mailbox causes backpressure.
+pub struct BoundedMailbox<A: Actor>(mpsc::Sender<Signal<A>>);
+
+impl<A: Actor> BoundedMailbox<A> {
+    /// Creates a new bounded mailbox with a given capacity.
+    #[inline]
+    pub fn new(capacity: usize) -> (Self, BoundedMailboxReceiver<A>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        (BoundedMailbox(tx), BoundedMailboxReceiver(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for BoundedMailbox<A> {
+    type Receiver = BoundedMailboxReceiver<A>;
+    type WeakMailbox = WeakBoundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, Self::Receiver) {
+        BoundedMailbox::new(1000)
+    }
+
+    #[inline]
+    async fn send(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>>> {
+        Ok(self.0.send(signal).await?)
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakBoundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for BoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        BoundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for BoundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+/// A bounded mailbox receiver.
+pub struct BoundedMailboxReceiver<A: Actor>(mpsc::Receiver<Signal<A>>);
+
+impl<A: Actor> fmt::Debug for BoundedMailboxReceiver<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundedMailboxReceiver")
+            .field("rx", &self.0)
+            .finish()
+    }
+}
+
+impl<A: Actor> MailboxReceiver<A> for BoundedMailboxReceiver<A> {
+    async fn recv(&mut self) -> Option<Signal<A>> {
+        self.0.recv().await
+    }
+}
+
+/// A weak bounded mailbox that does not prevent the actor from being stopped.
+pub struct WeakBoundedMailbox<A: Actor>(mpsc::WeakSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakBoundedMailbox<A> {
+    type StrongMailbox = BoundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(BoundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakBoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakBoundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for WeakBoundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeakBoundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+impl<A> SignalMailbox for BoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+impl<A> SignalMailbox for WeakBoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_startup_finished().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_link_died(id, reason).await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_stop().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+}

--- a/src/actor/mailbox/unbounded.rs
+++ b/src/actor/mailbox/unbounded.rs
@@ -1,0 +1,198 @@
+use std::fmt;
+
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::mpsc;
+
+use crate::{
+    actor::ActorID,
+    error::{ActorStopReason, SendError},
+    Actor,
+};
+
+use super::{Mailbox, MailboxReceiver, Signal, SignalMailbox, WeakMailbox};
+
+/// An unbounded mailbox, where the number of messages queued can grow infinitely.
+pub struct UnboundedMailbox<A: Actor>(mpsc::UnboundedSender<Signal<A>>);
+
+impl<A: Actor> UnboundedMailbox<A> {
+    /// Creates a new unbounded mailbox.
+    #[inline]
+    pub fn new() -> (Self, UnboundedMailboxReceiver<A>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (UnboundedMailbox(tx), UnboundedMailboxReceiver(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for UnboundedMailbox<A> {
+    type Receiver = UnboundedMailboxReceiver<A>;
+    type WeakMailbox = WeakUnboundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, Self::Receiver) {
+        UnboundedMailbox::new()
+    }
+
+    #[inline]
+    async fn send(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>>> {
+        Ok(self.0.send(signal)?)
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakUnboundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for UnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        UnboundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for UnboundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnboundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+/// An unbounded mailbox receiver.
+pub struct UnboundedMailboxReceiver<A: Actor>(mpsc::UnboundedReceiver<Signal<A>>);
+
+impl<A: Actor> MailboxReceiver<A> for UnboundedMailboxReceiver<A> {
+    async fn recv(&mut self) -> Option<Signal<A>> {
+        self.0.recv().await
+    }
+}
+
+/// A weak unbounded mailbox that does not prevent the actor from being stopped.
+pub struct WeakUnboundedMailbox<A: Actor>(mpsc::WeakUnboundedSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakUnboundedMailbox<A> {
+    type StrongMailbox = UnboundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(UnboundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakUnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakUnboundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for WeakUnboundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeakUnboundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+impl<A> SignalMailbox for UnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+impl<A> SignalMailbox for WeakUnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_startup_finished().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_link_died(id, reason).await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_stop().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+}

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -10,12 +10,13 @@ use tracing::{error, trace};
 use crate::{
     actor::{
         kind::{ActorBehaviour, ActorState},
-        Actor, ActorRef, Links, Signal, CURRENT_ACTOR_ID,
+        Actor, ActorRef, Links, CURRENT_ACTOR_ID,
     },
     error::{ActorStopReason, PanicError},
+    mailbox::{Mailbox, MailboxReceiver, Signal},
 };
 
-use super::{ActorID, MailboxReceiver};
+use super::ActorID;
 
 /// Spawns an actor in a tokio task.
 ///
@@ -185,7 +186,7 @@ where
 async fn run_actor_lifecycle<A, S>(
     actor_ref: ActorRef<A>,
     mut actor: A,
-    mailbox_rx: MailboxReceiver<A>,
+    mailbox_rx: <A::Mailbox as Mailbox<A>>::Receiver,
     abort_registration: AbortRegistration,
     links: Links,
 ) where
@@ -252,7 +253,7 @@ async fn run_actor_lifecycle<A, S>(
 
 async fn abortable_actor_loop<A, S>(
     state: &mut S,
-    mut mailbox_rx: MailboxReceiver<A>,
+    mut mailbox_rx: <A::Mailbox as Mailbox<A>>::Receiver,
 ) -> ActorStopReason
 where
     A: Actor,
@@ -268,7 +269,7 @@ where
 
 async fn recv_mailbox_loop<A, S>(
     state: &mut S,
-    mailbox_rx: &mut MailboxReceiver<A>,
+    mailbox_rx: &mut <A::Mailbox as Mailbox<A>>::Receiver,
 ) -> ActorStopReason
 where
     A: Actor,

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,7 @@ use tokio::{
     time::error::Elapsed,
 };
 
-use crate::{
-    actor::{ActorID, Signal},
-    message::BoxDebug,
-    Actor,
-};
+use crate::{actor::ActorID, mailbox::Signal, message::BoxDebug, Actor};
 
 /// A dyn boxed error.
 pub type BoxError = Box<dyn error::Error + Send + Sync + 'static>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod actor;
 pub mod error;
+pub mod mailbox;
 pub mod message;
 pub mod remote;
 pub mod reply;

--- a/src/mailbox/bounded.rs
+++ b/src/mailbox/bounded.rs
@@ -1,0 +1,211 @@
+//! Bounded mailbox types based on tokio mpsc bounded channels.
+
+use std::fmt;
+
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::mpsc;
+
+use crate::{
+    actor::ActorID,
+    error::{ActorStopReason, SendError},
+    Actor,
+};
+
+use super::{Mailbox, MailboxReceiver, Signal, SignalMailbox, WeakMailbox};
+
+/// An unbounded mailbox, where the sending messages to a full mailbox causes backpressure.
+pub struct BoundedMailbox<A: Actor>(pub(crate) mpsc::Sender<Signal<A>>);
+
+impl<A: Actor> BoundedMailbox<A> {
+    /// Creates a new bounded mailbox with a given capacity.
+    #[inline]
+    pub fn new(capacity: usize) -> (Self, BoundedMailboxReceiver<A>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        (BoundedMailbox(tx), BoundedMailboxReceiver(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for BoundedMailbox<A> {
+    type Receiver = BoundedMailboxReceiver<A>;
+    type WeakMailbox = WeakBoundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, Self::Receiver) {
+        BoundedMailbox::new(1000)
+    }
+
+    #[inline]
+    async fn send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.send(signal).await?)
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakBoundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for BoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        BoundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for BoundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+/// A bounded mailbox receiver.
+pub struct BoundedMailboxReceiver<A: Actor>(mpsc::Receiver<Signal<A>>);
+
+impl<A: Actor> MailboxReceiver<A> for BoundedMailboxReceiver<A> {
+    async fn recv(&mut self) -> Option<Signal<A>> {
+        self.0.recv().await
+    }
+}
+
+impl<A: Actor> fmt::Debug for BoundedMailboxReceiver<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundedMailboxReceiver")
+            .field("rx", &self.0)
+            .finish()
+    }
+}
+
+/// A weak bounded mailbox that does not prevent the actor from being stopped.
+pub struct WeakBoundedMailbox<A: Actor>(mpsc::WeakSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakBoundedMailbox<A> {
+    type StrongMailbox = BoundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(BoundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakBoundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakBoundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for WeakBoundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeakBoundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+impl<A> SignalMailbox for BoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .await
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+impl<A> SignalMailbox for WeakBoundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_startup_finished().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_link_died(id, reason).await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_stop().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+}

--- a/src/mailbox/unbounded.rs
+++ b/src/mailbox/unbounded.rs
@@ -1,0 +1,208 @@
+//! Unbounded mailbox types based on tokio mpsc unbounded channels.
+
+use std::fmt;
+
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::mpsc;
+
+use crate::{
+    actor::ActorID,
+    error::{ActorStopReason, SendError},
+    Actor,
+};
+
+use super::{Mailbox, MailboxReceiver, Signal, SignalMailbox, WeakMailbox};
+
+/// An unbounded mailbox, where the number of messages queued can grow infinitely.
+pub struct UnboundedMailbox<A: Actor>(pub(crate) mpsc::UnboundedSender<Signal<A>>);
+
+impl<A: Actor> UnboundedMailbox<A> {
+    /// Creates a new unbounded mailbox.
+    #[inline]
+    pub fn new() -> (Self, UnboundedMailboxReceiver<A>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (UnboundedMailbox(tx), UnboundedMailboxReceiver(rx))
+    }
+}
+
+impl<A: Actor> Mailbox<A> for UnboundedMailbox<A> {
+    type Receiver = UnboundedMailboxReceiver<A>;
+    type WeakMailbox = WeakUnboundedMailbox<A>;
+
+    #[inline]
+    fn default_mailbox() -> (Self, Self::Receiver) {
+        UnboundedMailbox::new()
+    }
+
+    #[inline]
+    async fn send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.send(signal)?)
+    }
+
+    #[inline]
+    async fn closed(&self) {
+        self.0.closed().await
+    }
+
+    #[inline]
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    #[inline]
+    fn downgrade(&self) -> Self::WeakMailbox {
+        WeakUnboundedMailbox(self.0.downgrade())
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for UnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        UnboundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for UnboundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnboundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+/// An unbounded mailbox receiver.
+pub struct UnboundedMailboxReceiver<A: Actor>(mpsc::UnboundedReceiver<Signal<A>>);
+
+impl<A: Actor> MailboxReceiver<A> for UnboundedMailboxReceiver<A> {
+    async fn recv(&mut self) -> Option<Signal<A>> {
+        self.0.recv().await
+    }
+}
+
+impl<A: Actor> fmt::Debug for UnboundedMailboxReceiver<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnboundedMailboxReceiver")
+            .field("rx", &self.0)
+            .finish()
+    }
+}
+
+/// A weak unbounded mailbox that does not prevent the actor from being stopped.
+pub struct WeakUnboundedMailbox<A: Actor>(mpsc::WeakUnboundedSender<Signal<A>>);
+
+impl<A: Actor> WeakMailbox for WeakUnboundedMailbox<A> {
+    type StrongMailbox = UnboundedMailbox<A>;
+
+    #[inline]
+    fn upgrade(&self) -> Option<Self::StrongMailbox> {
+        self.0.upgrade().map(UnboundedMailbox)
+    }
+
+    #[inline]
+    fn strong_count(&self) -> usize {
+        self.0.strong_count()
+    }
+
+    #[inline]
+    fn weak_count(&self) -> usize {
+        self.0.weak_count()
+    }
+}
+
+impl<A: Actor> Clone for WeakUnboundedMailbox<A> {
+    fn clone(&self) -> Self {
+        WeakUnboundedMailbox(self.0.clone())
+    }
+}
+
+impl<A: Actor> fmt::Debug for WeakUnboundedMailbox<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeakUnboundedMailbox")
+            .field("tx", &self.0)
+            .finish()
+    }
+}
+
+impl<A> SignalMailbox for UnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::StartupFinished)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::LinkDied { id, reason })
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            self.0
+                .send(Signal::Stop)
+                .map_err(|_| SendError::ActorNotRunning(()))
+        }
+        .boxed()
+    }
+}
+
+impl<A> SignalMailbox for WeakUnboundedMailbox<A>
+where
+    A: Actor,
+{
+    fn signal_startup_finished(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_startup_finished().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_link_died(
+        &self,
+        id: ActorID,
+        reason: ActorStopReason,
+    ) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_link_died(id, reason).await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+
+    fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>> {
+        async move {
+            match self.upgrade() {
+                Some(mb) => mb.signal_stop().await,
+                None => Err(SendError::ActorNotRunning(())),
+            }
+        }
+        .boxed()
+    }
+}

--- a/src/remote/_internal.rs
+++ b/src/remote/_internal.rs
@@ -6,32 +6,48 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::actor::{ActorID, ActorRef};
-use crate::error::RemoteSendError;
+use crate::error::{RemoteSendError, SendError};
 use crate::message::Message;
+use crate::request::{
+    AskRequest, LocalAskRequest, LocalTellRequest, MaybeRequestTimeout, MessageSend, TellRequest,
+    TryMessageSend,
+};
 use crate::{Actor, Reply};
 
 use super::REMOTE_REGISTRY;
 
 #[linkme::distributed_slice]
-pub static REMOTE_MESSAGES: [(
-    RemoteMessageRegistrationID<'static>,
-    (AskRemoteMessageFn, TellRemoteMessageFn),
-)];
+pub static REMOTE_MESSAGES: [(RemoteMessageRegistrationID<'static>, RemoteMessageFns)];
 
-pub type AskRemoteMessageFn = fn(
+#[derive(Clone, Copy, Debug)]
+pub struct RemoteMessageFns {
+    pub ask: RemoteAskFn,
+    pub try_ask: RemoteTryAskFn,
+    pub tell: RemoteTellFn,
+    pub try_tell: RemoteTryTellFn,
+}
+
+pub type RemoteAskFn = fn(
     actor_id: ActorID,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
     reply_timeout: Option<Duration>,
-    immediate: bool,
 ) -> BoxFuture<'static, Result<Vec<u8>, RemoteSendError<Vec<u8>>>>;
 
-pub type TellRemoteMessageFn = fn(
+pub type RemoteTryAskFn = fn(
+    actor_id: ActorID,
+    msg: Vec<u8>,
+    reply_timeout: Option<Duration>,
+) -> BoxFuture<'static, Result<Vec<u8>, RemoteSendError<Vec<u8>>>>;
+
+pub type RemoteTellFn = fn(
     actor_id: ActorID,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
-    immediate: bool,
 ) -> BoxFuture<'static, Result<(), RemoteSendError<Vec<u8>>>>;
+
+pub type RemoteTryTellFn =
+    fn(actor_id: ActorID, msg: Vec<u8>) -> BoxFuture<'static, Result<(), RemoteSendError<Vec<u8>>>>;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct RemoteMessageRegistrationID<'a> {
@@ -39,27 +55,46 @@ pub struct RemoteMessageRegistrationID<'a> {
     pub message_remote_id: &'a str,
 }
 
-pub async fn ask_remote_message<A, M>(
+pub async fn ask<A, M>(
     actor_id: ActorID,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
     reply_timeout: Option<Duration>,
-    immediate: bool,
 ) -> Result<Vec<u8>, RemoteSendError<Vec<u8>>>
 where
     A: Actor + Message<M>,
-    M: DeserializeOwned,
-    ActorRef<A>: crate::request::Request<A, M, A::Mailbox>,
+    M: DeserializeOwned + Send + 'static,
     <A::Reply as Reply>::Ok: Serialize,
     <A::Reply as Reply>::Error: Serialize,
+    AskRequest<
+        LocalAskRequest<A, A::Mailbox>,
+        A::Mailbox,
+        M,
+        MaybeRequestTimeout,
+        MaybeRequestTimeout,
+    >: MessageSend<Ok = <A::Reply as Reply>::Ok, Error = SendError<M, <A::Reply as Reply>::Error>>,
 {
-    let res =
-        ask_remote_message_inner::<A, M>(actor_id, msg, mailbox_timeout, reply_timeout, immediate)
-            .await;
+    let actor_ref = {
+        let remote_actors = REMOTE_REGISTRY.lock().await;
+        remote_actors
+            .get(&actor_id)
+            .ok_or(RemoteSendError::ActorNotRunning)?
+            .downcast_ref::<ActorRef<A>>()
+            .ok_or(RemoteSendError::BadActorType)?
+            .clone()
+    };
+    let msg: M = rmp_serde::decode::from_slice(&msg)
+        .map_err(|err| RemoteSendError::DeserializeMessage(err.to_string()))?;
+
+    let res = actor_ref
+        .ask(msg)
+        .into_maybe_timeouts(mailbox_timeout.into(), reply_timeout.into())
+        .send()
+        .await;
     match res {
         Ok(reply) => Ok(rmp_serde::to_vec_named(&reply)
             .map_err(|err| RemoteSendError::SerializeReply(err.to_string()))?),
-        Err(err) => Err(err
+        Err(err) => Err(RemoteSendError::from(err)
             .map_err(|err| match rmp_serde::to_vec_named(&err) {
                 Ok(payload) => RemoteSendError::HandlerError(payload),
                 Err(err) => RemoteSendError::SerializeHandlerError(err.to_string()),
@@ -68,17 +103,26 @@ where
     }
 }
 
-async fn ask_remote_message_inner<A, M>(
+pub async fn try_ask<A, M>(
     actor_id: ActorID,
     msg: Vec<u8>,
-    mailbox_timeout: Option<Duration>,
     reply_timeout: Option<Duration>,
-    immediate: bool,
-) -> Result<<A::Reply as Reply>::Ok, RemoteSendError<<A::Reply as Reply>::Error>>
+) -> Result<Vec<u8>, RemoteSendError<Vec<u8>>>
 where
     A: Actor + Message<M>,
-    M: DeserializeOwned,
-    ActorRef<A>: crate::request::Request<A, M, A::Mailbox>,
+    M: DeserializeOwned + Send + 'static,
+    <A::Reply as Reply>::Ok: Serialize,
+    <A::Reply as Reply>::Error: Serialize,
+    AskRequest<
+        LocalAskRequest<A, A::Mailbox>,
+        A::Mailbox,
+        M,
+        MaybeRequestTimeout,
+        MaybeRequestTimeout,
+    >: TryMessageSend<
+        Ok = <A::Reply as Reply>::Ok,
+        Error = SendError<M, <A::Reply as Reply>::Error>,
+    >,
 {
     let actor_ref = {
         let remote_actors = REMOTE_REGISTRY.lock().await;
@@ -92,47 +136,34 @@ where
     let msg: M = rmp_serde::decode::from_slice(&msg)
         .map_err(|err| RemoteSendError::DeserializeMessage(err.to_string()))?;
 
-    let reply =
-        crate::request::Request::ask(&actor_ref, msg, mailbox_timeout, reply_timeout, immediate)
-            .await?;
-
-    Ok(reply)
+    let res = actor_ref
+        .ask(msg)
+        .into_maybe_timeouts(None.into(), reply_timeout.into())
+        .try_send()
+        .await;
+    match res {
+        Ok(reply) => Ok(rmp_serde::to_vec_named(&reply)
+            .map_err(|err| RemoteSendError::SerializeReply(err.to_string()))?),
+        Err(err) => Err(RemoteSendError::from(err)
+            .map_err(|err| match rmp_serde::to_vec_named(&err) {
+                Ok(payload) => RemoteSendError::HandlerError(payload),
+                Err(err) => RemoteSendError::SerializeHandlerError(err.to_string()),
+            })
+            .flatten()),
+    }
 }
 
-pub async fn tell_remote_message<A, M>(
+pub async fn tell<A, M>(
     actor_id: ActorID,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
-    immediate: bool,
 ) -> Result<(), RemoteSendError<Vec<u8>>>
 where
     A: Actor + Message<M>,
-    M: DeserializeOwned,
-    ActorRef<A>: crate::request::Request<A, M, A::Mailbox>,
+    M: DeserializeOwned + Send + 'static,
     <A::Reply as Reply>::Error: Serialize,
-{
-    let res = tell_remote_message_inner::<A, M>(actor_id, msg, mailbox_timeout, immediate).await;
-    match res {
-        Ok(()) => Ok(()),
-        Err(err) => Err(err
-            .map_err(|err| match rmp_serde::to_vec_named(&err) {
-                Ok(payload) => RemoteSendError::HandlerError(payload),
-                Err(err) => RemoteSendError::SerializeHandlerError(err.to_string()),
-            })
-            .flatten()),
-    }
-}
-
-async fn tell_remote_message_inner<A, M>(
-    actor_id: ActorID,
-    msg: Vec<u8>,
-    mailbox_timeout: Option<Duration>,
-    immediate: bool,
-) -> Result<(), RemoteSendError<<A::Reply as Reply>::Error>>
-where
-    A: Actor + Message<M>,
-    M: DeserializeOwned,
-    ActorRef<A>: crate::request::Request<A, M, A::Mailbox>,
+    TellRequest<LocalTellRequest<A, A::Mailbox>, A::Mailbox, M, MaybeRequestTimeout>:
+        MessageSend<Ok = (), Error = SendError<M, <A::Reply as Reply>::Error>>,
 {
     let actor_ref = {
         let remote_actors = REMOTE_REGISTRY.lock().await;
@@ -146,7 +177,54 @@ where
     let msg: M = rmp_serde::decode::from_slice(&msg)
         .map_err(|err| RemoteSendError::DeserializeMessage(err.to_string()))?;
 
-    crate::request::Request::tell(&actor_ref, msg, mailbox_timeout, immediate).await?;
+    let res = actor_ref
+        .tell(msg)
+        .into_maybe_timeouts(mailbox_timeout.into())
+        .send()
+        .await;
+    match res {
+        Ok(()) => Ok(()),
+        Err(err) => Err(RemoteSendError::from(err)
+            .map_err(|err| match rmp_serde::to_vec_named(&err) {
+                Ok(payload) => RemoteSendError::HandlerError(payload),
+                Err(err) => RemoteSendError::SerializeHandlerError(err.to_string()),
+            })
+            .flatten()),
+    }
+}
 
-    Ok(())
+pub async fn try_tell<A, M>(actor_id: ActorID, msg: Vec<u8>) -> Result<(), RemoteSendError<Vec<u8>>>
+where
+    A: Actor + Message<M>,
+    M: DeserializeOwned + Send + 'static,
+    <A::Reply as Reply>::Error: Serialize,
+    TellRequest<LocalTellRequest<A, A::Mailbox>, A::Mailbox, M, MaybeRequestTimeout>:
+        TryMessageSend<Ok = (), Error = SendError<M, <A::Reply as Reply>::Error>>,
+{
+    let actor_ref = {
+        let remote_actors = REMOTE_REGISTRY.lock().await;
+        remote_actors
+            .get(&actor_id)
+            .ok_or(RemoteSendError::ActorNotRunning)?
+            .downcast_ref::<ActorRef<A>>()
+            .ok_or(RemoteSendError::BadActorType)?
+            .clone()
+    };
+    let msg: M = rmp_serde::decode::from_slice(&msg)
+        .map_err(|err| RemoteSendError::DeserializeMessage(err.to_string()))?;
+
+    let res = actor_ref
+        .tell(msg)
+        .into_maybe_timeouts(None.into())
+        .try_send()
+        .await;
+    match res {
+        Ok(()) => Ok(()),
+        Err(err) => Err(RemoteSendError::from(err)
+            .map_err(|err| match rmp_serde::to_vec_named(&err) {
+                Ok(payload) => RemoteSendError::HandlerError(payload),
+                Err(err) => RemoteSendError::SerializeHandlerError(err.to_string()),
+            })
+            .flatten()),
+    }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -98,7 +98,7 @@ pub trait Reply: Send + 'static {
 #[must_use = "the deligated reply should be returned by the handler"]
 #[derive(Clone, Copy, Debug)]
 pub struct DelegatedReply<R> {
-    phantom: PhantomData<R>,
+    phantom: PhantomData<fn() -> R>,
 }
 
 impl<R> DelegatedReply<R> {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -480,22 +480,6 @@ impl_try_message_send!(
     WithRequestTimeout,
     |req| (None, Some(req.reply_timeout.0))
 );
-// TODO: This one shouldnt be here!
-impl_try_message_send!(
-    remote,
-    BoundedMailbox,
-    WithRequestTimeout,
-    WithoutRequestTimeout,
-    |req| (Some(req.mailbox_timeout.0), None)
-);
-// TODO: This one shouldn't be here
-impl_try_message_send!(
-    remote,
-    BoundedMailbox,
-    WithRequestTimeout,
-    WithRequestTimeout,
-    |req| (Some(req.mailbox_timeout.0), Some(req.reply_timeout.0))
-);
 
 impl_try_message_send!(
     remote,


### PR DESCRIPTION
Moves request send methods into separate traits including:
- MessageSend (`send`)
- MessageSendSync (`send_sync`)
- TryMessageSend (`try_send`)
- TryMessageSendSync (`try_send_sync`)
- BlockingMessageSend (`blocking_send`)
- TryBlockingMessageSend (`try_blocking_send`)
- ForwardMessageSend (`forward`)

These traits are implemented given the following features:

| Method              | Ask (bounded) | Ask (unbounded) | Tell (bounded) | Tell (unbounded) |
|---------------------|---------------|-----------------|----------------|------------------|
| `send`              | ✅ 📬 ⏳ 🌐 | ✅ ⏳ 🌐 |      ✅ 📬 🌐     |        ✅ 🌐      |
| `send_sync`         |       ❌       |        ❌        |        ❌       |         ✅       |
| `try_send`          |     ✅ ⏳ 🌐     |      ✅ ⏳ 🌐      |       ✅ 🌐      |        ✅ 🌐  |
| `try_send_sync`     |       ❌       |        ❌        |        ✅       |         ✅       |
| `blocking_send`     |       ✅       |        ✅        |        ✅       |         ✅       |
| `try_blocking_send` |       ✅       |        ✅        |        ✅       |         ✅       |
| `forward`           |      ✅ 📬      |        ✅        |        ❌       |         ❌       |

This rework has heavily influced some internals including remote messaging. One downside to the PR is that sending messages requires you to import the trait into your module. However the fact that sending uses traits now allows some powerful Rust patterns with Kameo.