### PR TITLE
feat: use interned peer ids for improved performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ kameo_macros = { version = "0.10.0", path = "./macros" }
 dyn-clone = "1.0"
 futures = "0.3"
 itertools = "0.13.0"
+internment = { version = "0.8.5", features = ["serde"] }
 libp2p = { version = "0.54.1", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"] }
 libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"] }
 linkme = "0.3.28"

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -905,8 +905,9 @@ where
     actor_ref
         .send_to_swarm(SwarmCommand::Req {
             peer_id: actor_id
-                .peer_id()
-                .unwrap_or_else(|| *ActorSwarm::get().unwrap().local_peer_id()),
+                .peer_id_intern()
+                .cloned()
+                .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
             req: SwarmReq::Ask {
                 actor_id,
                 actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -489,8 +489,9 @@ where
     actor_ref
         .send_to_swarm(SwarmCommand::Req {
             peer_id: actor_id
-                .peer_id()
-                .unwrap_or_else(|| *ActorSwarm::get().unwrap().local_peer_id()),
+                .peer_id_intern()
+                .cloned()
+                .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
             req: SwarmReq::Tell {
                 actor_id,
                 actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),


### PR DESCRIPTION
This PR improves performance of actor spawning by ~16% by reducing the memory size of `ActorID` with the use of interning the inner PeerId. This reduces the size of ActorID from 96 to 16, which gives a nice performance increase when creating and copying `ActorID`s.

**Important note:**
Creating `ActorID`s with different PeerIds is technically a memory leak, since the cache of PeerIds is never cleaned up. However the size of a PeerId is 80 bytes, and so for 1MB of memory to be used, you'd need to have 12,500 unique PeerIds used, which could technically happen if they're created randomly and frequently, however nodes shouldn't be changed that often for this to be an issue.