### PR TITLE
feat!: use multiaddr and add `SwarmFuture`

### DIFF
--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -3,12 +3,11 @@ use std::time::Duration;
 use kameo::{
     actor::RemoteActorRef,
     message::{Context, Message},
-    remote::ActorSwarm,
+    remote::{dial_opts::DialOpts, ActorSwarm},
     request::MessageSend,
     Actor,
 };
 use kameo_macros::{remote_message, RemoteActor};
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -70,12 +69,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Bootstrap the actor swarm
     if is_host {
         ActorSwarm::bootstrap()?
-            .listen_on("0.0.0.0:8020".parse()?)
+            .listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?)
             .await?;
     } else {
-        ActorSwarm::bootstrap()?
-            .add_peer_address(PeerId::random(), "0.0.0.0:8020".parse()?)
-            .await;
+        ActorSwarm::bootstrap()?.dial(
+            DialOpts::unknown_peer_id()
+                .address("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?)
+                .build(),
+        );
     }
 
     if is_host {

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -2,17 +2,13 @@ use std::{cell::Cell, collections::HashMap, fmt, marker::PhantomData, ops, sync:
 
 use futures::{stream::AbortHandle, Stream, StreamExt};
 use serde::{de::DeserializeOwned, Serialize};
-use tokio::{
-    sync::{mpsc, Mutex},
-    task::JoinHandle,
-    task_local,
-};
+use tokio::{sync::Mutex, task::JoinHandle, task_local};
 
 use crate::{
     error::{RegistrationError, SendError},
     mailbox::{Mailbox, Signal, SignalMailbox, WeakMailbox},
     message::{Message, StreamMessage},
-    remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand},
+    remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand, SwarmSender},
     reply::Reply,
     request::{
         AskRequest, LocalAskRequest, LocalTellRequest, RemoteAskRequest, RemoteTellRequest,
@@ -380,12 +376,12 @@ impl<A: Actor> AsRef<Links> for ActorRef<A> {
 /// A reference to an actor running remotely.
 pub struct RemoteActorRef<A: Actor> {
     id: ActorID,
-    swarm_tx: mpsc::Sender<SwarmCommand>,
+    swarm_tx: SwarmSender,
     phantom: PhantomData<A::Mailbox>,
 }
 
 impl<A: Actor> RemoteActorRef<A> {
-    pub(crate) fn new(id: ActorID, swarm_tx: mpsc::Sender<SwarmCommand>) -> Self {
+    pub(crate) fn new(id: ActorID, swarm_tx: SwarmSender) -> Self {
         RemoteActorRef {
             id,
             swarm_tx,
@@ -443,8 +439,8 @@ impl<A: Actor> RemoteActorRef<A> {
         TellRequest::new_remote(self, msg)
     }
 
-    pub(crate) async fn send_to_swarm(&self, msg: SwarmCommand) {
-        self.swarm_tx.send(msg).await.unwrap()
+    pub(crate) fn send_to_swarm(&self, msg: SwarmCommand) {
+        self.swarm_tx.send(msg)
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use _internal::{RemoteMessageFns, RemoteMessageRegistrationID, REMOTE_MESSAGES};
+pub use libp2p::swarm::dial_opts;
 pub use libp2p::PeerId;
 pub use libp2p_identity::Keypair;
 use once_cell::sync::Lazy;

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -902,25 +902,23 @@ where
 {
     let actor_id = actor_ref.id();
     let (reply_tx, reply_rx) = oneshot::channel();
-    actor_ref
-        .send_to_swarm(SwarmCommand::Req {
-            peer_id: actor_id
-                .peer_id_intern()
-                .cloned()
-                .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
-            req: SwarmReq::Ask {
-                actor_id,
-                actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
-                message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
-                payload: rmp_serde::to_vec_named(msg)
-                    .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
-                mailbox_timeout,
-                reply_timeout,
-                immediate,
-            },
-            reply: reply_tx,
-        })
-        .await;
+    actor_ref.send_to_swarm(SwarmCommand::Req {
+        peer_id: actor_id
+            .peer_id_intern()
+            .cloned()
+            .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
+        req: SwarmReq::Ask {
+            actor_id,
+            actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
+            message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
+            payload: rmp_serde::to_vec_named(msg)
+                .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
+            mailbox_timeout,
+            reply_timeout,
+            immediate,
+        },
+        reply: reply_tx,
+    });
 
     match reply_rx.await.unwrap() {
         SwarmResp::Ask(res) => match res {

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -486,24 +486,22 @@ where
 {
     let actor_id = actor_ref.id();
     let (reply_tx, reply_rx) = oneshot::channel();
-    actor_ref
-        .send_to_swarm(SwarmCommand::Req {
-            peer_id: actor_id
-                .peer_id_intern()
-                .cloned()
-                .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
-            req: SwarmReq::Tell {
-                actor_id,
-                actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
-                message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
-                payload: rmp_serde::to_vec_named(msg)
-                    .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
-                mailbox_timeout,
-                immediate,
-            },
-            reply: reply_tx,
-        })
-        .await;
+    actor_ref.send_to_swarm(SwarmCommand::Req {
+        peer_id: actor_id
+            .peer_id_intern()
+            .cloned()
+            .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
+        req: SwarmReq::Tell {
+            actor_id,
+            actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
+            message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
+            payload: rmp_serde::to_vec_named(msg)
+                .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
+            mailbox_timeout,
+            immediate,
+        },
+        reply: reply_tx,
+    });
 
     match reply_rx.await.unwrap() {
         SwarmResp::Tell(res) => match res {


### PR DESCRIPTION
The purpose of this PR is to provide more flexibility to developers by exposing the libp2p `Multiaddr` directly instead of converting from a SocketAddr. This has some breaking changes, but overall provides more control.

**Features:**
- Use Multiaddr instead of SocketAddr
- Add `dial` method for dialing peers
- Return `SwarmFuture`, allowing `.await` to be omitted from swarm methods if the response can be ignored. This includes changing the swarm mpsc to unbounded so channel capacity doesn't have to be awaited.