### PR TITLE
fix!: `attach_stream` panicking when actor is stopped

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -226,7 +226,7 @@ where
         mut stream: S,
         start_value: T,
         finish_value: F,
-    ) -> JoinHandle<Result<(), SendError<StreamMessage<M, T, F>, <A::Reply as Reply>::Error>>>
+    ) -> JoinHandle<Result<S, SendError<StreamMessage<M, T, F>, <A::Reply as Reply>::Error>>>
     where
         A: Message<StreamMessage<M, T, F>>,
         S: Stream<Item = M> + Send + Unpin + 'static,
@@ -261,7 +261,7 @@ where
                         }
                     }
                     _ = actor_ref.wait_for_stop() => {
-                        return Ok(());
+                        return Ok(stream);
                     }
                 }
             }
@@ -271,7 +271,7 @@ where
                 .send()
                 .await?;
 
-            Ok(())
+            Ok(stream)
         })
     }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -31,7 +31,7 @@ pub trait Mailbox<A: Actor>: SignalMailbox + Clone + Send + Sync {
         signal: Signal<A>,
     ) -> impl Future<Output = Result<(), SendError<Signal<A>, E>>> + Send + '_;
     /// Waits for the mailbox to be closed.
-    fn closed(&self) -> impl Future<Output = ()> + '_;
+    fn closed(&self) -> impl Future<Output = ()> + Send + '_;
     /// Checks if the mailbox is closed.
     fn is_closed(&self) -> bool;
     /// Downgrades the mailbox to a weak mailbox.


### PR DESCRIPTION
Fixes https://github.com/tqwewe/kameo/issues/45

As described in the issue, there was a panic that occured when using `attach_stream` on an actor that stops. This PR fixes this by using the `SendMessage` trait.

Additionally, the spawned tokio task stops when the stream returns `None`, and returns the stream.