### PR TITLE
Add links to the README badges and add docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kameo 🎬
 
 [![Crates.io Version](https://img.shields.io/crates/v/kameo)](https://crates.io/crates/kameo)
+[![docs.rs](https://img.shields.io/docsrs/kameo)](https://docs.rs/kameo)
 [![Crates.io Total Downloads](https://img.shields.io/crates/d/kameo)](https://crates.io/crates/kameo)
 [![Crates.io License](https://img.shields.io/crates/l/kameo)](https://crates.io/crates/kameo)
 [![GitHub Repo stars](https://img.shields.io/github/stars/tqwewe/kameo)](https://github.com/tqwewe/kameo)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Kameo 🎬
 
-![Crates.io Version](https://img.shields.io/crates/v/kameo)
-![Crates.io Total Downloads](https://img.shields.io/crates/d/kameo)
-![Crates.io License](https://img.shields.io/crates/l/kameo)
-![GitHub Repo stars](https://img.shields.io/github/stars/tqwewe/kameo)
+[![Crates.io Version](https://img.shields.io/crates/v/kameo)](https://crates.io/crates/kameo)
+[![Crates.io Total Downloads](https://img.shields.io/crates/d/kameo)](https://crates.io/crates/kameo)
+[![Crates.io License](https://img.shields.io/crates/l/kameo)](https://crates.io/crates/kameo)
+[![GitHub Repo stars](https://img.shields.io/github/stars/tqwewe/kameo)](https://github.com/tqwewe/kameo)
 
-![Kameo banner image](https://github.com/tqwewe/kameo/blob/main/banner.png?raw=true)
+[![Kameo banner image](https://github.com/tqwewe/kameo/blob/main/banner.png?raw=true)](https://github.com/tqwewe/kameo)
 
 ## What is Kameo
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/kameo)](https://docs.rs/kameo)
 [![Crates.io Total Downloads](https://img.shields.io/crates/d/kameo)](https://crates.io/crates/kameo)
 [![Crates.io License](https://img.shields.io/crates/l/kameo)](https://crates.io/crates/kameo)
-[![GitHub Repo stars](https://img.shields.io/github/stars/tqwewe/kameo)](https://github.com/tqwewe/kameo)
+[![GitHub Repo stars](https://img.shields.io/github/stars/tqwewe/kameo)](https://github.com/tqwewe/kameo/stargazers)
 
 [![Kameo banner image](https://github.com/tqwewe/kameo/blob/main/banner.png?raw=true)](https://github.com/tqwewe/kameo)
 


### PR DESCRIPTION
First off, thanks for making Kameo! It's been great to use in my project.

I've tried to click these badges several times now to get to the crate page/docs/etc expecting it to be similar to how other repos link them, and been bamboozled by it just opening the badge image.

This updates the badges to link off to relevant locations, and adds a docs.rs badge for the api docs.