### PR TITLE
docs: add in-depth distributed actors information to kameo book

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Distributed actors in Kameo are designed to interact with each other as if they 
         .await?;
     ```
 
-A full example can be found in [examples/remote.rs](examples/remote.rs).
+See the [kameo book](https://docs.page/tqwewe/kameo/distributed-actors) for in-depth information on distributed actors in kameo.
+Additionally, a full example can be found in [examples/remote.rs](examples/remote.rs).
 
 ## Additional Resources
 

--- a/docs.json
+++ b/docs.json
@@ -52,6 +52,36 @@
           "icon": "shield-alt"
         }
       ]
+    },
+    {
+      "group": "Distributed Actors",
+      "pages": [
+        {
+          "title": "Overview",
+          "href": "/distributed-actors",
+          "icon": "network-wired"
+        },
+        {
+          "title": "Bootstrapping the Actor Swarm",
+          "href": "/distributed-actors/bootstrapping-actor-swarm",
+          "icon": "play-circle"
+        },
+        {
+          "title": "Dialing and Connecting to Other Nodes",
+          "href": "/distributed-actors/dialing-connecting-nodes",
+          "icon": "link"
+        },
+        {
+          "title": "Registering and Looking up Actors",
+          "href": "/distributed-actors/registering-looking-up-actors",
+          "icon": "user-tag"
+        },
+        {
+          "title": "Messaging Remote Actors",
+          "href": "/distributed-actors/messaging-remote-actors",
+          "icon": "envelope-open-text"
+        }
+      ]
     }
   ]
 }

--- a/docs/distributed-actors.mdx
+++ b/docs/distributed-actors.mdx
@@ -1,0 +1,41 @@
+---
+title: Distributed Actors
+---
+
+Kameo’s distributed actor system enables actors to communicate seamlessly across different nodes in a decentralized network. This architecture provides a powerful foundation for building fault-tolerant, scalable, and resilient distributed systems. At its core, Kameo leverages [libp2p](https://libp2p.io) for peer-to-peer communication and a decentralized actor registry.
+
+#### Key Components
+
+- **ActorSwarm**: The central structure responsible for managing peer-to-peer communication between nodes. It initializes the libp2p swarm, manages connections, and coordinates actor registration and message routing.
+- **RemoteActorRef**: A reference to an actor that resides on a remote node. This reference abstracts away the networking details and allows you to interact with remote actors using familiar APIs.
+- **Multiaddress**: libp2p uses multiaddresses to specify how nodes can be reached using different network protocols like TCP, WebSockets, or QUIC. Multiaddresses are essential for routing messages between nodes.
+- **Kademlia DHT**: Kameo uses Kademlia DHT to store and retrieve actor registration details. When an actor is registered, its name is stored as a key in the DHT, and the value contains information about how to reach the actor, making it discoverable by other nodes.
+
+#### How Distributed Actors Work
+
+1. **Bootstrapping the Actor Swarm**: Each node in the network must initialize an `ActorSwarm` to participate in the distributed system. The swarm manages the libp2p connections and allows the node to register actors and send/receive messages.
+
+2. **Actor Registration**: After bootstrapping the swarm, actors can be registered under unique names. Once registered, the actor’s address is propagated through the Kademlia DHT, making it discoverable by other nodes.
+
+3. **Remote Messaging**: Once an actor is registered, other nodes can look it up and send messages to it. The `RemoteActorRef` allows you to send and receive messages across the network without worrying about the underlying networking.
+
+#### Why Use Distributed Actors?
+
+Distributed actors are ideal for building systems that need to scale horizontally across multiple machines or geographic locations. They enable fault-tolerant systems, as nodes can fail or be added without disrupting the overall network. Some common use cases for distributed actors include:
+
+- **Real-Time Systems**: Chat systems, multiplayer games, and real-time data monitoring where actors need to communicate with low latency.
+- **Microservices Architecture**: Building independent services that communicate via message passing, while maintaining resilience to failures.
+- **IoT Systems**: Distributed control systems where devices communicate with each other using lightweight actors.
+
+#### Key Benefits
+
+- **Decentralized Architecture**: No single point of failure. Actors can be registered, discovered, and messaged from any node in the network.
+- **Fault Tolerance**: The system continues to operate even if nodes fail or become unreachable. Actor registration via Kademlia DHT ensures nodes can find each other.
+- **Scalability**: Add more nodes to the swarm to handle more actors and distribute load across the network.
+- **Flexible Networking**: By using libp2p, Kameo supports various network protocols, allowing it to adapt to different environments and infrastructure.
+
+#### What’s Next?
+
+Now that you have an understanding of how distributed actors work, you’re ready to dive deeper into the specifics of setting up the actor swarm, registering actors, and messaging across nodes.
+
+Explore the next section on [Bootstrapping the Actor Swarm](/distributed-actors/bootstrapping-actor-swarm) to get started with setting up your distributed actor system.

--- a/docs/distributed-actors/bootstrapping-actor-swarm.mdx
+++ b/docs/distributed-actors/bootstrapping-actor-swarm.mdx
@@ -1,0 +1,62 @@
+---
+title: Bootstrapping Actor Swarm
+---
+
+Before actors can communicate across nodes in a distributed system, you need to initialize the `ActorSwarm`. The `ActorSwarm` is responsible for managing peer-to-peer connections, actor registration, and message routing across nodes. This section explains how to bootstrap the swarm, set up network listening, and prepare your system for distributed communication.
+
+#### Initializing the Actor Swarm
+
+The first step in setting up distributed actors is bootstrapping the `ActorSwarm`. This initializes the swarm, allowing the node to participate in the network and accept incoming connections.
+
+```rust
+let actor_swarm = ActorSwarm::bootstrap()?;
+```
+
+This will initialize the swarm with default settings, preparing the node to listen for connections from other nodes. Once bootstrapped, you can register actors and send messages.
+
+#### Bootstrapping with Identity
+
+In some cases, you may want to bootstrap the swarm with a specific identity (keypair). This allows nodes to be uniquely identified in the network, which can be useful for secure communication or when interacting with known peers.
+
+```rust
+let keypair = Keypair::generate();
+let actor_swarm = ActorSwarm::bootstrap_with_identity(keypair)?;
+```
+
+The `Keypair` generates a cryptographic identity for the node. This is useful for secure, verifiable communication between peers. The node will now be identified by its `PeerId`, derived from the keypair.
+
+#### Listening on a Multiaddress
+
+After bootstrapping the swarm, you need to instruct the node to listen on a specific network address. Kameo uses libp2p’s **multiaddress** format, which allows nodes to specify how they can be reached over the network. Multiaddresses define the protocol (e.g., TCP or QUIC) and the IP address/port combination.
+
+```rust
+actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+```
+
+In this example, the node is listening on the IP address `0.0.0.0` (which represents all available network interfaces) on UDP port `8020`, using the QUIC protocol. You can customize this address based on your network environment or use different protocols as needed.
+
+#### Example: Bootstrapping and Listening
+
+Here’s a full example that combines bootstrapping the swarm and setting up a listener:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Bootstrap the swarm with a default identity
+    let actor_swarm = ActorSwarm::bootstrap()?;
+
+    // Start listening on a multiaddress
+    actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+
+    // The node is now ready to register actors and communicate with other nodes
+    Ok(())
+}
+```
+
+Once the swarm is bootstrapped and listening, the node can register actors, dial other peers, and send messages. This setup ensures the node is part of the network and ready to accept and route messages.
+
+#### What’s Next?
+
+Now that your node is part of the distributed system, it’s time to explore how to connect to other nodes and establish communication. In the next section, we’ll cover how to dial and connect to peers using multiaddresses.
+
+Explore the next section on [Dialing and Connecting to Other Nodes](/distributed-actors/dialing-connecting-nodes) for more details.

--- a/docs/distributed-actors/dialing-connecting-nodes.mdx
+++ b/docs/distributed-actors/dialing-connecting-nodes.mdx
@@ -1,0 +1,96 @@
+---
+title: Dialing and Connecting to Other Nodes
+---
+
+Once your node is bootstrapped and listening on an address, the next step in setting up a distributed actor system is dialing and connecting to other nodes. Kameo’s `ActorSwarm` allows nodes to discover and connect with peers using libp2p’s peer-to-peer communication capabilities. This section covers how to dial peers using multiaddresses, how to manage peer connections, and how libp2p’s mDNS feature can simplify peer discovery.
+
+#### Dialing a Peer
+
+To establish a connection with another node, you need to dial its multiaddress. A multiaddress specifies the protocol, IP address, and port required to reach the node.
+
+```rust
+actor_swarm.dial("/ip4/192.0.2.0/udp/8020/quic-v1".parse()?).await?;
+```
+
+In this example, the node is dialing another node located at IP address `192.0.2.0` on UDP port `8020`, using the QUIC protocol. Once the connection is established, the node can interact with remote actors on the peer.
+
+#### Auto-discovery with mDNS
+
+In most cases, libp2p’s [**mDNS (Multicast DNS)**](https://docs.libp2p.io/concepts/discovery-routing/mdns/) feature allows nodes to automatically discover each other on the same local network, without needing to manually dial peers. This greatly simplifies setting up a distributed system, as peers will be able to find and connect to each other without explicit configuration.
+
+If your network environment supports mDNS, it can be enabled by default in Kameo’s `ActorSwarm`. With mDNS, nodes announce themselves to the network and discover other peers in the same multicast domain.
+
+```rust
+// Example of using mDNS auto-discovery
+let actor_swarm = ActorSwarm::bootstrap()?;
+actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+// Peers on the same local network can now discover each other automatically
+```
+
+This makes peer discovery effortless in environments where mDNS is available, such as local networks or development environments.
+
+#### Dialing with Options
+
+For more advanced use cases, Kameo provides the `DialOpts` structure, which allows you to customize how you dial peers. This is useful when you need to include additional details or preferences when establishing connections, such as specifying peer IDs.
+
+```rust
+let dial_opts = DialOpts::unknown_peer_id()
+    .address("/ip4/192.0.2.0/udp/8020/quic-v1".parse()?)
+    .build();
+
+actor_swarm.dial(dial_opts).await?;
+```
+
+In this example, `DialOpts` is used to dial a peer at a known address without specifying the peer’s ID. This option can be customized depending on the situation, such as when connecting to peers with specific identities or conditions.
+
+#### Adding Peer Addresses Manually
+
+In some cases, you may want to manually add a known peer’s address to the swarm without dialing immediately. This can be useful for preloading peers or when you want to manage connections programmatically.
+
+```rust
+let peer_id: PeerId = ...; // Obtained from the peer's identity
+let addr: Multiaddr = "/ip4/192.0.2.0/tcp/1234".parse()?;
+
+actor_swarm.add_peer_address(peer_id, addr);
+```
+
+This example shows how to associate a peer’s identity with a known address. Once the peer address is added, the swarm will use it to attempt future connections or for message routing.
+
+#### Disconnecting from Peers
+
+If you need to disconnect from a peer, you can do so using the peer’s `PeerId`. This is helpful when you want to manage peer connections and ensure that a node is no longer part of the active network.
+
+```rust
+actor_swarm.disconnect_peer_id(peer_id);
+```
+
+This cleanly terminates the connection with the specified peer, removing it from the swarm’s list of active peers.
+
+#### Example: Dialing and Connecting to Peers
+
+Here’s a full example of how to dial a peer and establish a connection:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Bootstrap the swarm
+    let actor_swarm = ActorSwarm::bootstrap()?;
+
+    // Start listening on a multiaddress
+    actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+
+    // Dial a peer on a specific address
+    actor_swarm.dial("/ip4/192.0.2.0/udp/8020/quic-v1".parse()?).await?;
+
+    // The node is now connected to the peer and can send/receive messages
+    Ok(())
+}
+```
+
+This example shows how to bootstrap the swarm, set up a listener, and connect to another node using a multiaddress.
+
+#### What’s Next?
+
+Now that you can connect to other nodes, the next step is registering actors and looking them up across the network. This allows nodes to discover and interact with actors on remote peers.
+
+Explore the next section on [Registering and Looking up Actors](/distributed-actors/registering-looking-up-actors) to learn more about actor registration and discovery.

--- a/docs/distributed-actors/messaging-remote-actors.mdx
+++ b/docs/distributed-actors/messaging-remote-actors.mdx
@@ -1,0 +1,125 @@
+---
+title: Messaging Remote Actors
+---
+
+Once actors are registered and discoverable across nodes, the next step is to start communicating with them. Kameo allows you to send messages to remote actors just like you would with local actors. The underlying networking is handled transparently, and messages are routed across the network using the `RemoteActorRef`. This section explains how to message remote actors and handle replies.
+
+#### Sending Messages
+
+After looking up a remote actor using `RemoteActorRef`, you can send messages to it using the familiar `ask` and `tell` patterns.
+
+- **ask**: Used when you expect a reply from the remote actor.
+- **tell**: Used when you do not expect a reply, a "fire-and-forget" style message.
+
+```rust
+// Lookup the remote actor
+let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
+
+// Send a message and await the reply
+if let Some(actor) = remote_actor_ref {
+    let result = actor.ask(&Inc { amount: 10 }).send().await?;
+    println!("Incremented count: {result}");
+}
+```
+
+In this example, the node looks up the actor named `"my_actor"` and sends an `Inc` message to increment the actor's internal state. The message is serialized and sent over the network to the remote actor, and the reply is awaited asynchronously.
+
+#### Fire-and-Forget Messaging
+
+If you don’t need a response from the actor, you can use the `tell` method to send a message without waiting for a reply.
+
+```rust
+// Send a fire-and-forget message
+actor.tell(&LogMessage { text: String::from("Logging event") }).send().await?;
+```
+
+The `tell` method is useful for one-way communication where no acknowledgment is required, such as logging or notification systems.
+
+#### Requirements for Remote Messaging
+
+There are two requirements to enable messaging between nodes:
+
+1. **The Actor must implement `RemoteActor`**: Any actor that can be messaged remotely must implement the `RemoteActor` trait, which uniquely identifies the actor type. This allows the system to route messages to the correct actor on remote nodes.
+
+```rust
+#[derive(RemoteActor)]
+pub struct MyActor;
+```
+
+2. **Message Serialization with `#[remote_message]`**: In Kameo, messages sent between nodes must be serializable. To enable this, message types need to implement `Serialize` and `Deserialize` traits, and the message implementation must be annotated with the `#[remote_message]` macro, which assigns a unique identifier to the actor and message type handler.
+
+```rust
+#[remote_message("3b9128f1-0593-44a0-b83a-f4188baa05bf")]
+impl Message<Inc> for MyActor {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+        self.count += msg.amount as i64;
+        self.count
+    }
+}
+```
+
+This `#[remote_message]` macro ensures that the message is properly serialized and routed to the correct actor across the network. The UUID string assigned to each message must be unique within the crate to avoid conflicts.
+
+#### Handling Replies
+
+When sending a message using the `ask` pattern, you’ll typically want to handle a response from the remote actor. The reply type is specified in the actor’s message handler and can be awaited asynchronously.
+
+```rust
+let result = actor.ask(&Inc { amount: 10 }).send().await?;
+println!("Received reply: {}", result);
+```
+
+In this example, the reply from the remote actor is awaited, and the result is printed once received.
+
+#### Why the `#[remote_message]` Macro is Needed
+
+Unlike actor systems that use a traditional enum for message types, Kameo allows actors to handle a variety of message types without defining a centralized enum for all possible messages. This flexibility introduces a challenge when deserializing incoming messages—because we don't know the exact message type at the time of deserialization.
+
+To solve this, Kameo leverages the [**linkme**](https://crates.io/crates/linkme) crate, which dynamically builds a `HashMap` of registered message types at link time:
+
+```rust
+HashMap<RemoteMessageRegistrationID, RemoteMessagesFns>
+```
+
+- **`RemoteMessageRegistrationID`**: A unique identifier combining the actor’s ID and the message’s ID (both provided via the `RemoteActor` and `#[remote_message]` macros).
+- **`RemoteMessagesFns`**: A struct containing function pointers for handling messages (`ask` or `tell`) for the given actor and message type.
+
+When a message is received, Kameo uses this hashmap to look up the appropriate function for deserializing and handling the message, based on the combination of the actor and message IDs.
+
+By using the `#[remote_message]` macro, Kameo registers each message type during link time, ensuring that when a message is received, the system knows how to deserialize it and which function to invoke on the target actor.
+
+#### Example: Messaging a Remote Actor
+
+Here’s a full example of how to message a remote actor and handle its reply:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Bootstrap the swarm and listen on an address
+    let actor_swarm = ActorSwarm::bootstrap()?;
+    actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+
+    // Lookup a registered remote actor
+    let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
+
+    if let Some(actor) = remote_actor_ref {
+        // Send a message and await the reply
+        let result = actor.ask(&Inc { amount: 10 }).send().await?;
+        println!("Incremented count: {result}");
+    } else {
+        println!("Actor not found");
+    }
+
+    Ok(())
+}
+```
+
+In this example, a node is bootstrapped, connected to a network, and looks up a remote actor named `"my_actor"`. After finding the actor, the node sends an increment message (`Inc`) and waits for a response, which is printed upon receipt.
+
+#### What’s Next?
+
+Now that you’ve seen how to send messages to remote actors and handle replies, you can start building distributed systems where actors on different nodes communicate seamlessly. Experiment with sending different types of messages and handling remote interactions.
+
+If you haven’t yet set up your actor system, go back to the [Bootstrapping the Actor Swarm](/distributed-actors/bootstrapping-actor-swarm) section for instructions on setting up your distributed actor environment.

--- a/docs/distributed-actors/registering-looking-up-actors.mdx
+++ b/docs/distributed-actors/registering-looking-up-actors.mdx
@@ -1,0 +1,108 @@
+---
+title: Registering and Looking up Actors
+---
+
+In a distributed system, actors need to be discoverable by other nodes so that they can receive messages from remote peers. Kameo provides actor registration and lookup mechanisms using a decentralized registry powered by **Kademlia DHT** (Distributed Hash Table). This section covers how to register actors and look them up across the network using `ActorSwarm`.
+
+#### Registering Actors
+
+After bootstrapping the `ActorSwarm` and setting up the node to listen for connections, actors can be registered under unique names. This makes them discoverable by other nodes, allowing remote actors to send messages to them.
+
+To register an actor, use the `ActorRef::register` method, which registers the actor under a specified name.
+
+```rust
+// Spawn and register an actor
+let actor_ref = kameo::spawn(MyActor::default());
+actor_ref.register("my_actor").await?;
+```
+
+In this example, an actor of type `MyActor` is spawned and registered with the name `"my_actor"`. The name is propagated across the network using the Kademlia DHT, which stores the mapping between the actor’s name and its reference on the node. Other nodes can now look up and interact with this actor using its registered name.
+
+#### Actor Lookup
+
+Once an actor is registered, other nodes can look it up by name. The `RemoteActorRef::lookup` method allows you to retrieve a reference to an actor that is registered on a remote node. If the lookup is successful, the returned `RemoteActorRef` can be used to send messages to the remote actor, just like with local actors.
+
+```rust
+// Lookup a registered remote actor
+let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
+
+if let Some(actor) = remote_actor_ref {
+    // Use the actor reference to send a message
+    let result = actor.ask(&Inc { amount: 10 }).send().await?;
+    println!("Incremented count: {result}");
+} else {
+    println!("Actor not found");
+}
+```
+
+In this example, the node attempts to look up an actor registered with the name `"my_actor"`. If the actor is found on a remote node, a `RemoteActorRef` is returned, allowing the local node to send messages to the remote actor. A `RemoteActorRef` may in fact be a reference to an actor running on the current node.
+
+#### Kademlia DHT: Decentralized Actor Lookup
+
+Kameo’s actor registration and lookup system is powered by **Kademlia DHT**, a distributed hash table used to store and retrieve actor registration details across nodes. When an actor is registered, its name is stored as a key in the DHT, and the value is a reference to the actor on the node where it was registered.
+
+This decentralized registry ensures that actors can be discovered efficiently across a network of nodes, without relying on a centralized registry or server. Each node stores a portion of the DHT and can look up actors registered on other nodes.
+
+- **Registration**: When an actor is registered, its name is propagated to other nodes using the DHT.
+- **Lookup**: When a node looks up an actor by name, the DHT retrieves the location of the actor from the network and returns a reference to the actor.
+
+#### Example: Registering and Looking up Actors
+
+Here’s a full example showing how to register an actor on one node and look it up from another:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Node 1: Register an actor
+    let actor_swarm = ActorSwarm::bootstrap()?;
+    actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+    let actor_ref = kameo::spawn(MyActor::default());
+    actor_ref.register("my_actor").await?;
+    
+    // Node 2: Lookup the actor and send a message
+    let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
+    if let Some(actor) = remote_actor_ref {
+        let result = actor.ask(&Inc { amount: 10 }).send().await?;
+        println!("Incremented count: {result}");
+    } else {
+        println!("Actor not found");
+    }
+    
+    Ok(())
+}
+```
+
+In this example, Node 1 registers an actor with the name `"my_actor"`, and Node 2 looks up the actor using its registered name. Once the actor is found, Node 2 sends a message to it.
+
+#### Retry Mechanism for Actor Lookup
+
+In distributed systems, there can be cases where an actor is not yet registered or its registration hasn’t fully propagated through the Kademlia DHT. This can happen if the actor has just been registered or if the network is still syncing. In such cases, it’s useful to implement a retry mechanism when looking up actors, giving the system time to propagate the registration.
+
+A simple retry loop can help ensure that your node eventually finds the actor, especially in systems where actors are expected to register shortly after startup:
+
+```rust
+use std::time::Duration;
+use tokio::time::sleep;
+
+async fn retry_lookup() -> Result<Option<RemoteActorRef<MyActor>>, RegistrationError> {
+    for _ in 0..5 {
+        if let Some(actor) = RemoteActorRef::<MyActor>::lookup("my_actor").await? {
+            return Ok(Some(actor));
+        }
+        // Retry after a delay if actor is not found
+        sleep(Duration::from_secs(2)).await;
+    }
+    println!("Actor not found after retries");
+    Ok(None)
+}
+```
+
+In this example, the lookup is retried up to 5 times, with a 2-second delay between each attempt. If the actor is registered in the meantime, the lookup will succeed and return a reference to the actor. This approach ensures more resilient lookups in scenarios where actor registration or DHT propagation may be delayed.
+
+A cleaner solution might involve using a crate such as [backon](https://crates.io/crates/backon) for retrying actor lookups.
+
+#### What’s Next?
+
+With actors now registered and discoverable across nodes, the next step is to explore how to send messages to remote actors. The messaging system allows you to send and receive messages between actors on different nodes using `RemoteActorRef`.
+
+Explore the next section on [Messaging Remote Actors](/distributed-actors/messaging-remote-actors) to learn more.


### PR DESCRIPTION
As peer feedback, in-depth information on distributed actors in kameo was lacking. This PR adds sections to the kameo book covering how to use distributed actors, and how it works internally.

Sections added:
- Distributed Actors Overview
- Bootstrapping Actor Swarm
- Dialing and Connecting to Other Nodes
- Registering and Looking up Actors
- Messaging Remote Actors

Closes https://github.com/tqwewe/kameo/issues/50