### PR TITLE
docs: improve code docs and examples with all tests passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = [
   "time",
 ] }
 tokio-stream = { version = "0.1.15", features = ["time"] }
+tokio-test = "0.4.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo add kameo
 
 ## Example: Defining an Actor
 
-```rust
+```rust,ignore
 use kameo::Actor;
 use kameo::message::{Context, Message};
 use kameo::request::MessageSend;
@@ -76,7 +76,7 @@ impl Message<Inc> for Counter {
 
 Spawn and message the actor.
 
-```rust
+```rust,ignore
 // Spawn the actor and get a reference to it
 let actor_ref = kameo::spawn(Counter { count: 0 });
 
@@ -95,7 +95,7 @@ Distributed actors in Kameo are designed to interact with each other as if they 
 
 1. **Actor Registration:** Actors can be registered under a unique name using `ActorRef::register`. Once registered, other actors or systems can look up this actor from a remote node. Under the hood, Kameo uses a **Kademlia Distributed Hash Table (DHT)**, provided by libp2p, to handle actor registration and lookup across nodes in a distributed manner.
 
-   ```rust
+   ```rust,ignore
    // On the host node, register the actor
    let actor_ref = kameo::spawn(MyActor::default());
    actor_ref.register("my_actor").await?;
@@ -103,14 +103,14 @@ Distributed actors in Kameo are designed to interact with each other as if they 
 
 2. **Actor Lookup:** On remote nodes, actors can look up registered actors using `RemoteActorRef::lookup`. This returns a reference to the remote actor that can be messaged.
 
-   ```rust
+   ```rust,ignore
    // On a guest node, lookup the remote actor
    let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
    ```
 
 3. **Message Passing:** Once the remote actor reference is obtained, you can send messages to it just like with local actors. The message is serialized, sent over the network, deserialized on the remote node, and handled by the actor.
 
-   ```rust
+   ```rust,ignore
    if let Some(remote_actor_ref) = remote_actor_ref {
        let count = remote_actor_ref.ask(&Inc { amount: 10 }).send().await?;
        println!("Incremented! Count is {count}");
@@ -119,7 +119,7 @@ Distributed actors in Kameo are designed to interact with each other as if they 
 
 4. **Message Registration:** In order to send messages between nodes, the message type must implement `Serialize` and `Deserialize`. Additionally, it needs to be annotated with the `#[remote_message("uuid")]` macro, where the `uuid` is a unique identifier for the message type. This UUID helps identify which message implementation to use when sending and receiving messages over the network. It's important to ensure that the UUID does not conflict with other registered messages in your crate.
 
-   ```rust
+   ```rust,ignore
    #[remote_message("3b9128f1-0593-44a0-b83a-f4188baa05bf")]
    impl Message<Inc> for MyActor {
        type Reply = i64;
@@ -138,7 +138,7 @@ Distributed actors in Kameo are designed to interact with each other as if they 
 
     Kameo actors use these multiaddresses when communicating across nodes. The `ActorSwarm` component handles networking, allowing actors to register, look up, and send messages to remote actors, abstracting away the underlying complexity.
 
-    ```rust
+    ```rust,ignore
     // Bootstrap the actor swarm and listen on a UDP port 8020
     ActorSwarm::bootstrap()?
         .listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?)

--- a/src/actor/pubsub.rs
+++ b/src/actor/pubsub.rs
@@ -1,3 +1,50 @@
+//! Provides a publish-subscribe (pubsub) mechanism for actors.
+//!
+//! The `pubsub` module allows actors to broadcast messages to multiple subscribers. It offers
+//! a lightweight pubsub actor that can manage multiple subscriptions and publish messages to
+//! all subscribed actors simultaneously. This is useful in scenarios where multiple actors need
+//! to react to the same event or data.
+//!
+//! `PubSub` can be used either as a standalone object or as a spawned actor. When spawned as an actor,
+//! the `Publish(msg)` and `Subscribe(actor_ref)` messages are used to interact with it.
+//!
+//! # Features
+//! - **Publish-Subscribe Pattern**: Actors can subscribe to the `PubSub` actor to receive broadcast messages.
+//! - **Message Broadcasting**: Messages published to the `PubSub` actor are sent to all subscribed actors.
+//! - **Subscriber Management**: Actors can subscribe and unsubscribe dynamically, allowing flexible message routing.
+//!
+//! # Example
+//!
+//! ```
+//! use kameo::Actor;
+//! use kameo::actor::{PubSub, Publish, Subscribe};
+//! # use kameo::message::{Context, Message};
+//! use kameo::request::MessageSend;
+//!
+//! #[derive(Actor)]
+//! struct MyActor;
+//! #
+//! # impl Message<&'static str> for MyActor {
+//! #     type Reply = ();
+//! #     async fn handle(&mut self, msg: &'static str, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+//! # }
+//!
+//! # tokio_test::block_on(async {
+//! let mut pubsub = PubSub::new();
+//! let actor_ref = kameo::spawn(MyActor);
+//!
+//! // Use PubSub as a standalone object
+//! pubsub.subscribe(actor_ref.clone());
+//! pubsub.publish("Hello, World!").await;
+//!
+//! // Or spawn PubSub as an actor and use messages
+//! let pubsub_actor_ref = kameo::spawn(PubSub::new());
+//! pubsub_actor_ref.tell(Subscribe(actor_ref)).send().await?;
+//! pubsub_actor_ref.tell(Publish("Hello, spawned world!")).send().await?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # });
+//! ```
+
 use std::collections::HashMap;
 
 use futures::future::{join_all, BoxFuture};
@@ -12,7 +59,12 @@ use crate::{
 
 use super::{ActorID, ActorRef};
 
-/// A mpsc-like pubsub actor.
+/// A publish-subscribe (pubsub) actor that allows message broadcasting to multiple subscribers.
+///
+/// `PubSub` can be used as a standalone object or spawned as an actor. When spawned, messages can
+/// be sent using the `Publish(msg)` and `Subscribe(actor_ref)` messages to publish data and manage subscribers.
+/// This provides flexibility in how you interact with the pubsub system, depending on whether you want
+/// to manage it directly or interact with it via messages.
 #[allow(missing_debug_implementations)]
 pub struct PubSub<M> {
     subscribers: HashMap<ActorID, Box<dyn MessageSubscriber<M> + Send + Sync>>,
@@ -20,13 +72,35 @@ pub struct PubSub<M> {
 
 impl<M> PubSub<M> {
     /// Creates a new pubsub instance.
+    ///
+    /// This initializes the pubsub actor with an empty list of subscribers.
     pub fn new() -> Self {
         PubSub {
             subscribers: HashMap::new(),
         }
     }
 
-    /// Publishes a message to all subscribers.
+    /// Publishes a message to all subscribed actors.
+    ///
+    /// The message is cloned and sent to each subscriber. Any actor subscribed to the `PubSub` actor
+    /// will receive a copy of the message.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kameo::actor::PubSub;
+    ///
+    /// #[derive(Clone)]
+    /// struct Msg(String);
+    ///
+    /// # tokio_test::block_on(async {
+    /// let mut pubsub = PubSub::new();
+    /// pubsub.publish(Msg("Hello!".to_string())).await;
+    /// # })
+    /// ```
+    ///
+    /// # Requirements
+    /// The message type `M` must implement `Clone` and `Send`, since it needs to be duplicated for each subscriber.
     pub async fn publish(&mut self, msg: M)
     where
         M: Clone + Send + 'static,
@@ -49,7 +123,36 @@ impl<M> PubSub<M> {
         }
     }
 
-    /// Subscribes an actor receive all messages published.
+    /// Subscribes an actor to receive all messages published by the pubsub actor.
+    ///
+    /// Once subscribed, the actor will receive all messages sent to the pubsub actor via the `publish` method.
+    /// The actor reference is stored in the list of subscribers, and messages are sent to the actor asynchronously.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kameo::Actor;
+    /// use kameo::actor::PubSub;
+    /// # use kameo::message::{Context, Message};
+    ///
+    /// # #[derive(Actor)]
+    /// # struct MyActor;
+    /// #
+    /// # impl Message<Msg> for MyActor {
+    /// #     type Reply = ();
+    /// #     async fn handle(&mut self, msg: Msg, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// # }
+    /// #
+    /// #[derive(Clone)]
+    /// struct Msg(String);
+    ///
+    /// # tokio_test::block_on(async {
+    /// let mut pubsub = PubSub::new();
+    ///
+    /// let actor_ref = kameo::spawn(MyActor);
+    /// pubsub.subscribe(actor_ref);
+    /// # })
+    /// ```
     #[inline]
     pub fn subscribe<A>(&mut self, actor_ref: ActorRef<A>)
     where
@@ -72,7 +175,10 @@ impl<M> Default for PubSub<M> {
     }
 }
 
-/// Publishes a message to a pubsub actor.
+/// A message used to publish data to a `PubSub` actor.
+///
+/// This struct wraps a message of type `M` and is used when sending a message to a pubsub actor.
+/// When this message is received, it is broadcast to all subscribers.
 #[derive(Clone, Debug)]
 pub struct Publish<M>(pub M);
 
@@ -91,7 +197,10 @@ where
     }
 }
 
-/// Subscribes an actor to a pubsub actor.
+/// A message used to subscribe an actor to a `PubSub` actor.
+///
+/// This struct wraps an `ActorRef` and is used to subscribe an actor to a pubsub actor. Once subscribed,
+/// the actor will receive all published messages from the pubsub actor.
 #[derive(Clone, Debug)]
 pub struct Subscribe<A: Actor>(pub ActorRef<A>);
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -110,12 +110,19 @@ where
     /// - The [ReplySender], if not `None`, should be used by the delegated responder to send the actual reply.
     ///
     /// ```
-    /// use kameo::message::{Context, DelegatedReply, Message};
+    /// use kameo::message::{Context, Message};
+    /// use kameo::reply::DelegatedReply;
     ///
-    /// impl Message<MyMsg> for MyActor {
+    /// # #[derive(kameo::Actor)]
+    /// # struct MyActor;
+    /// #
+    ///
+    /// struct Msg;
+    ///
+    /// impl Message<Msg> for MyActor {
     ///     type Reply = DelegatedReply<String>;
     ///
-    ///     async fn handle(&mut self, msg: MyMsg, mut ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    ///     async fn handle(&mut self, msg: Msg, mut ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
     ///         let (delegated_reply, reply_sender) = ctx.reply_sender();
     ///
     ///         if let Some(tx) = reply_sender {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -6,6 +6,7 @@
 //! names and send messages between actors on different nodes as though they were local.
 //!
 //! ## Key Features
+//!
 //! - **Swarm Management**: The `ActorSwarm` struct handles a distributed swarm of nodes,
 //!   managing peer discovery and communication.
 //! - **Actor Registration**: Actors can be registered under a unique name and looked up across
@@ -14,27 +15,34 @@
 //!   of Kademlia DHT and libp2p's networking capabilities.
 //!
 //! ## Getting Started
+//!
 //! To use remote actors, you must first initialize an `ActorSwarm`, which will set up the necessary
 //! networking components to allow remote actors to communicate across nodes.
 //!
-//! ```rust
+//! ```
 //! use kameo::remote::ActorSwarm;
 //!
+//! # tokio_test::block_on(async {
 //! // Initialize the actor swarm
-//! let actor_swarm = ActorSwarm::bootstrap();
-//! actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?);
+//! ActorSwarm::bootstrap()?
+//!     .listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # });
 //! ```
 //!
 //! ## Example Use Case
+//!
 //! - A distributed chat system where actors represent individual users, and messages are sent between them across multiple nodes.
 //!
 //! ## Types in the Module
+//!
 //! - [`ActorSwarm`]: The core struct for managing the distributed swarm of nodes and coordinating actor registration and messaging.
 //! - [`SwarmFuture`]: A future that holds the response from the actor swarm.
 //! - [`RemoteActor`]: A trait for identifying remote actors via a unique ID.
 //! - [`RemoteMessage`]: A trait for identifying remote messages via a unique ID.
 //!
 //! ### Re-exports
+//!
 //! - `Keypair`, `PeerId`, `dial_opts`: Re-exported from the libp2p library to assist with handling peer identities and dialing options.
 
 use std::{
@@ -83,7 +91,9 @@ static REMOTE_MESSAGES_MAP: Lazy<HashMap<RemoteMessageRegistrationID<'static>, R
 ///
 /// ## Example with Derive
 ///
-/// ```rust
+/// ```
+/// use kameo::RemoteActor;
+///
 /// #[derive(RemoteActor)]
 /// pub struct MyActor;
 /// ```
@@ -91,6 +101,8 @@ static REMOTE_MESSAGES_MAP: Lazy<HashMap<RemoteMessageRegistrationID<'static>, R
 /// ## Example Manual Implementation
 ///
 /// ```
+/// use kameo::remote::RemoteActor;
+///
 /// pub struct MyActor;
 ///
 /// impl RemoteActor for MyActor {

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -39,18 +39,26 @@ static ACTOR_SWARM: OnceCell<ActorSwarm> = OnceCell::new();
 /// enabling peer discovery, actor registration, and remote message routing.
 ///
 /// ## Key Features
+///
 /// - **Swarm Management**: Initializes and manages the libp2p swarm, allowing nodes to discover
 ///   and communicate in a peer-to-peer network.
 /// - **Actor Registration**: Actors can be registered under a unique name, making them discoverable
 ///   and accessible across the network.
 /// - **Message Routing**: Handles reliable message delivery to remote actors using Kademlia DHT.
 ///
-/// ### Example
-/// ```rust
+/// # Example
+///
+/// ```
+/// use kameo::remote::ActorSwarm;
+///
+/// # tokio_test::block_on(async {
 /// // Initialize the actor swarm
-/// let actor_swarm = ActorSwarm::bootstrap();
+/// let actor_swarm = ActorSwarm::bootstrap()?;
+///
 /// // Set up the swarm to listen on a specific address
 /// actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # });
 /// ```
 ///
 /// The `ActorSwarm` is the essential component for enabling distributed actor communication
@@ -144,10 +152,16 @@ impl ActorSwarm {
     /// For more information on multiaddresses, see [libp2p addressing](https://docs.libp2p.io/concepts/fundamentals/addressing/).
     ///
     /// ## Example
-    /// ```rust
+    ///
+    /// ```
+    /// use kameo::remote::ActorSwarm;
+    ///
+    /// # tokio_test::block_on(async {
     /// ActorSwarm::bootstrap()?
     ///     .listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?)
     ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # });
     /// ```
     ///
     /// ## Returns


### PR DESCRIPTION
Updates code docs to add more examples and improved wording. Additionally, updates all examples to pass when running `cargo test --doc`.

Closes https://github.com/tqwewe/kameo/issues/49