### PR TITLE
Hide remote actor functionality behind "remote" feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo build --features remote --verbose
+      - run: cargo test --features remote --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ categories = ["asynchronous", "concurrency", "rust-patterns"]
 keywords = ["actor", "tokio"]
 
 [features]
-doc = []
 remote = ["dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde", "dep:internment"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ lto = true
 opt-level = 3
 codegen-units = 1
 
+
+[package.metadata.docs.rs]
+all-features = true
+
 [package]
 name = "kameo"
 description = "Fault-tolerant Async Actors Built on Tokio"
@@ -19,22 +23,26 @@ license = "MIT OR Apache-2.0"
 categories = ["asynchronous", "concurrency", "rust-patterns"]
 keywords = ["actor", "tokio"]
 
+[features]
+doc = []
+remote = ["dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde", "dep:internment"]
+
 [dependencies]
 kameo_macros = { version = "0.11.0", path = "./macros" }
 
 dyn-clone = "1.0"
 futures = "0.3"
 itertools = "0.13.0"
-internment = { version = "0.8.5", features = ["serde"] }
-libp2p = { version = "0.54.1", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"] }
-libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"] }
-linkme = "0.3.28"
+internment = { version = "0.8.5", features = ["serde"], optional = true }
+libp2p = { version = "0.54.1", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"], optional = true }
+libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"], optional = true }
+linkme = { version= "0.3.28", optional = true }
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "sync", "time", "tracing"] }
 tokio-stream = "0.1"
 tracing = "0.1"
-rmp-serde = "1.3.0"
+rmp-serde = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -1,18 +1,21 @@
-use std::{cell::Cell, collections::HashMap, fmt, marker::PhantomData, ops, sync::Arc};
+use std::{cell::Cell, collections::HashMap, fmt, ops, sync::Arc};
 
 use futures::{stream::AbortHandle, Stream, StreamExt};
-use serde::{de::DeserializeOwned, Serialize};
 use tokio::{sync::Mutex, task::JoinHandle, task_local};
 
+#[cfg(feature = "remote")]
+use crate::remote;
+#[cfg(feature = "remote")]
+use std::marker::PhantomData;
+
 use crate::{
-    error::{RegistrationError, SendError},
+    error::{self, SendError},
     mailbox::{Mailbox, SignalMailbox, WeakMailbox},
     message::{Message, StreamMessage},
-    remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand, SwarmSender},
     reply::Reply,
     request::{
-        AskRequest, LocalAskRequest, LocalTellRequest, MessageSend, RemoteAskRequest,
-        RemoteTellRequest, TellRequest, WithoutRequestTimeout,
+        self, AskRequest, LocalAskRequest, LocalTellRequest, MessageSend, TellRequest,
+        WithoutRequestTimeout,
     },
     Actor,
 };
@@ -23,7 +26,7 @@ task_local! {
     pub(crate) static CURRENT_ACTOR_ID: ActorID;
 }
 thread_local! {
-    pub(crate) static CURRENT_THREAD_ACTOR_ID: Cell<Option<ActorID>> = Cell::new(None);
+    pub(crate) static CURRENT_THREAD_ACTOR_ID: Cell<Option<ActorID>> = const { Cell::new(None) };
 }
 
 /// A reference to an actor, used for sending messages and managing its lifecycle.
@@ -67,12 +70,14 @@ where
     /// Registers the actor under a given name within the actor swarm.
     ///
     /// This makes the actor discoverable by other nodes in the distributed system.
-    pub async fn register(&self, name: &str) -> Result<(), RegistrationError>
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    pub async fn register(&self, name: &str) -> Result<(), error::RegistrationError>
     where
-        A: RemoteActor + 'static,
+        A: remote::RemoteActor + 'static,
     {
-        ActorSwarm::get()
-            .ok_or(RegistrationError::SwarmNotBootstrapped)?
+        remote::ActorSwarm::get()
+            .ok_or(error::RegistrationError::SwarmNotBootstrapped)?
             .register(self.clone(), name.to_string())
             .await
     }
@@ -80,12 +85,14 @@ where
     /// Looks up an actor registered locally by its name.
     ///
     /// Returns `Some` if the actor exists, or `None` if no actor with the given name is registered.
-    pub async fn lookup(name: &str) -> Result<Option<Self>, RegistrationError>
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    pub async fn lookup(name: &str) -> Result<Option<Self>, error::RegistrationError>
     where
-        A: RemoteActor + 'static,
+        A: remote::RemoteActor + 'static,
     {
-        ActorSwarm::get()
-            .ok_or(RegistrationError::SwarmNotBootstrapped)?
+        remote::ActorSwarm::get()
+            .ok_or(error::RegistrationError::SwarmNotBootstrapped)?
             .lookup_local(name.to_string())
             .await
     }
@@ -133,7 +140,7 @@ where
     /// This method ensures that the actor finishes processing any messages that were already in the queue
     /// before it shuts down. Any new messages sent after the stop signal will be ignored.
     #[inline]
-    pub async fn stop_gracefully(&self) -> Result<(), SendError> {
+    pub async fn stop_gracefully(&self) -> Result<(), error::SendError> {
         self.mailbox.signal_stop().await
     }
 
@@ -456,7 +463,7 @@ where
             A::Mailbox,
             StreamMessage<M, T, F>,
             WithoutRequestTimeout,
-        >: MessageSend<
+        >: request::MessageSend<
             Ok = (),
             Error = SendError<StreamMessage<M, T, F>, <A::Reply as Reply>::Error>,
         >,
@@ -541,14 +548,18 @@ impl<A: Actor> AsRef<Links> for ActorRef<A> {
 ///
 /// `RemoteActorRef` allows sending messages to actors on different nodes in a distributed system.
 /// It supports the same messaging patterns as `ActorRef` for local actors, including `ask` and `tell` messaging.
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub struct RemoteActorRef<A: Actor> {
     id: ActorID,
-    swarm_tx: SwarmSender,
+    swarm_tx: remote::SwarmSender,
     phantom: PhantomData<A::Mailbox>,
 }
 
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> RemoteActorRef<A> {
-    pub(crate) fn new(id: ActorID, swarm_tx: SwarmSender) -> Self {
+    pub(crate) fn new(id: ActorID, swarm_tx: remote::SwarmSender) -> Self {
         RemoteActorRef {
             id,
             swarm_tx,
@@ -564,12 +575,12 @@ impl<A: Actor> RemoteActorRef<A> {
     /// Looks up an actor registered by name across the distributed network.
     ///
     /// Returns `Some` if the actor is found, or `None` if no actor with the given name is registered.
-    pub async fn lookup(name: &str) -> Result<Option<Self>, RegistrationError>
+    pub async fn lookup(name: &str) -> Result<Option<Self>, error::RegistrationError>
     where
-        A: RemoteActor + 'static,
+        A: remote::RemoteActor + 'static,
     {
-        ActorSwarm::get()
-            .ok_or(RegistrationError::SwarmNotBootstrapped)?
+        remote::ActorSwarm::get()
+            .ok_or(error::RegistrationError::SwarmNotBootstrapped)?
             .lookup(name.to_string())
             .await
     }
@@ -610,16 +621,16 @@ impl<A: Actor> RemoteActorRef<A> {
         &'a self,
         msg: &'a M,
     ) -> AskRequest<
-        RemoteAskRequest<'a, A, M>,
+        request::RemoteAskRequest<'a, A, M>,
         A::Mailbox,
         M,
         WithoutRequestTimeout,
         WithoutRequestTimeout,
     >
     where
-        A: RemoteActor + Message<M> + RemoteMessage<M>,
-        M: Serialize,
-        <A::Reply as Reply>::Ok: DeserializeOwned,
+        A: remote::RemoteActor + Message<M> + remote::RemoteMessage<M>,
+        M: serde::Serialize,
+        <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
     {
         AskRequest::new_remote(self, msg)
     }
@@ -659,7 +670,7 @@ impl<A: Actor> RemoteActorRef<A> {
     pub fn tell<'a, M>(
         &'a self,
         msg: &'a M,
-    ) -> TellRequest<RemoteTellRequest<'a, A, M>, A::Mailbox, M, WithoutRequestTimeout>
+    ) -> TellRequest<request::RemoteTellRequest<'a, A, M>, A::Mailbox, M, WithoutRequestTimeout>
     where
         A: Message<M>,
         M: Send + 'static,
@@ -667,21 +678,25 @@ impl<A: Actor> RemoteActorRef<A> {
         TellRequest::new_remote(self, msg)
     }
 
-    pub(crate) fn send_to_swarm(&self, msg: SwarmCommand) {
+    pub(crate) fn send_to_swarm(&self, msg: remote::SwarmCommand) {
         self.swarm_tx.send(msg)
     }
 }
 
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> Clone for RemoteActorRef<A> {
     fn clone(&self) -> Self {
         RemoteActorRef {
-            id: self.id.clone(),
+            id: self.id,
             swarm_tx: self.swarm_tx.clone(),
             phantom: PhantomData,
         }
     }
 }
 
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> fmt::Debug for RemoteActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("RemoteActorRef");
@@ -714,13 +729,11 @@ impl<A: Actor> WeakActorRef<A> {
     /// Tries to convert a `WeakActorRef` into a [`ActorRef`]. This will return `Some`
     /// if there are other `ActorRef` instances alive, otherwise `None` is returned.
     pub fn upgrade(&self) -> Option<ActorRef<A>> {
-        self.mailbox.upgrade().and_then(|mailbox| {
-            Some(ActorRef {
-                id: self.id,
-                mailbox,
-                abort_handle: self.abort_handle.clone(),
-                links: self.links.clone(),
-            })
+        self.mailbox.upgrade().map(|mailbox| ActorRef {
+            id: self.id,
+            mailbox,
+            abort_handle: self.abort_handle.clone(),
+            links: self.links.clone(),
         })
     }
 

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -71,7 +71,6 @@ where
     ///
     /// This makes the actor discoverable by other nodes in the distributed system.
     #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     pub async fn register(&self, name: &str) -> Result<(), error::RegistrationError>
     where
         A: remote::RemoteActor + 'static,
@@ -86,7 +85,6 @@ where
     ///
     /// Returns `Some` if the actor exists, or `None` if no actor with the given name is registered.
     #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     pub async fn lookup(name: &str) -> Result<Option<Self>, error::RegistrationError>
     where
         A: remote::RemoteActor + 'static,
@@ -549,7 +547,6 @@ impl<A: Actor> AsRef<Links> for ActorRef<A> {
 /// `RemoteActorRef` allows sending messages to actors on different nodes in a distributed system.
 /// It supports the same messaging patterns as `ActorRef` for local actors, including `ask` and `tell` messaging.
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub struct RemoteActorRef<A: Actor> {
     id: ActorID,
     swarm_tx: remote::SwarmSender,
@@ -557,7 +554,6 @@ pub struct RemoteActorRef<A: Actor> {
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> RemoteActorRef<A> {
     pub(crate) fn new(id: ActorID, swarm_tx: remote::SwarmSender) -> Self {
         RemoteActorRef {
@@ -684,7 +680,6 @@ impl<A: Actor> RemoteActorRef<A> {
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> Clone for RemoteActorRef<A> {
     fn clone(&self) -> Self {
         RemoteActorRef {
@@ -696,7 +691,6 @@ impl<A: Actor> Clone for RemoteActorRef<A> {
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<A: Actor> fmt::Debug for RemoteActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("RemoteActorRef");

--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -1,11 +1,12 @@
 use std::sync::atomic::Ordering;
 use std::{fmt, sync::atomic::AtomicU64};
 
+#[cfg(feature = "remote")]
 use internment::Intern;
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ActorIDFromBytesError;
+#[cfg(feature = "remote")]
 use crate::remote::ActorSwarm;
 
 static ACTOR_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -18,7 +19,8 @@ static ACTOR_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub struct ActorID {
     sequence_id: u64,
     /// None indicates a local actor; the local peer ID should be used in this case.
-    peer_id: Option<Intern<PeerId>>,
+    #[cfg(feature = "remote")]
+    peer_id: Option<Intern<libp2p::PeerId>>,
 }
 
 impl ActorID {
@@ -37,6 +39,7 @@ impl ActorID {
     pub fn new(sequence_id: u64) -> Self {
         ActorID {
             sequence_id,
+            #[cfg(feature = "remote")]
             peer_id: ActorSwarm::get().map(|swarm| swarm.local_peer_id_intern().clone()),
         }
     }
@@ -51,7 +54,9 @@ impl ActorID {
     /// # Returns
     ///
     /// A new `ActorID` instance.
-    pub fn new_with_peer_id(sequence_id: u64, peer_id: PeerId) -> Self {
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    pub fn new_with_peer_id(sequence_id: u64, peer_id: libp2p::PeerId) -> Self {
         ActorID {
             sequence_id,
             peer_id: Some(Intern::new(peer_id)),
@@ -86,7 +91,9 @@ impl ActorID {
     /// # Returns
     ///
     /// An `Option<PeerId>`. `None` indicates a local actor.
-    pub fn peer_id(&self) -> Option<PeerId> {
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    pub fn peer_id(&self) -> Option<libp2p::PeerId> {
         self.peer_id.map(|peer_id| *peer_id)
     }
 
@@ -100,13 +107,17 @@ impl ActorID {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(8 + 42);
         bytes.extend(&self.sequence_id.to_le_bytes());
+
+        #[cfg(feature = "remote")]
         let peer_id_bytes = self
             .peer_id
             .map(|peer_id| peer_id.to_bytes())
             .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
+        #[cfg(feature = "remote")]
         if let Some(peer_id_bytes) = peer_id_bytes {
             bytes.extend(peer_id_bytes);
         }
+
         bytes
     }
 
@@ -128,14 +139,16 @@ impl ActorID {
         );
 
         // Extract the peer id
+        #[cfg(feature = "remote")]
         let peer_id = if bytes.len() > 8 {
-            Some(Intern::new(PeerId::from_bytes(&bytes[8..])?))
+            Some(Intern::new(libp2p::PeerId::from_bytes(&bytes[8..])?))
         } else {
             None
         };
 
         Ok(ActorID {
             sequence_id,
+            #[cfg(feature = "remote")]
             peer_id,
         })
     }
@@ -147,7 +160,8 @@ impl ActorID {
     /// # Returns
     ///
     /// An `Option<&Intern<PeerId>>`. `None` indicates a local actor.
-    pub(crate) fn peer_id_intern(&self) -> Option<&Intern<PeerId>> {
+    #[cfg(feature = "remote")]
+    pub(crate) fn peer_id_intern(&self) -> Option<&Intern<libp2p::PeerId>> {
         self.peer_id.as_ref()
     }
 
@@ -159,9 +173,10 @@ impl ActorID {
     /// # Returns
     ///
     /// An `ActorID` with a guaranteed `peer_id`.
+    #[cfg(feature = "remote")]
     pub(crate) fn with_hydrate_peer_id(mut self) -> ActorID {
         if self.peer_id.is_none() {
-            self.peer_id = Some(ActorSwarm::get().unwrap().local_peer_id_intern().clone());
+            self.peer_id = Some(*ActorSwarm::get().unwrap().local_peer_id_intern());
         }
         self
     }
@@ -170,16 +185,25 @@ impl ActorID {
 impl fmt::Display for ActorID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ActorID({}, ", self.sequence_id)?;
+
+        #[cfg(feature = "remote")]
         match self.peer_id {
             Some(peer_id) => write!(f, "{peer_id})"),
             None => write!(f, "local)"),
         }
+
+        #[cfg(not(feature = "remote"))]
+        Ok(())
     }
 }
 
 impl fmt::Debug for ActorID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ActorID({:?}, {:?})", self.sequence_id, self.peer_id)
+        #[cfg(feature = "remote")]
+        return write!(f, "ActorID({:?}, {:?})", self.sequence_id, self.peer_id);
+
+        #[cfg(not(feature = "remote"))]
+        return write!(f, "ActorID({:?})", self.sequence_id);
     }
 }
 
@@ -203,6 +227,7 @@ impl<'de> Deserialize<'de> for ActorID {
             ActorIDFromBytesError::MissingSequenceID => {
                 serde::de::Error::invalid_length(bytes_len, &"sequence ID")
             }
+            #[cfg(feature = "remote")]
             err @ ActorIDFromBytesError::ParsePeerID(_) => serde::de::Error::custom(err),
         })
     }

--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -55,7 +55,6 @@ impl ActorID {
     ///
     /// A new `ActorID` instance.
     #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     pub fn new_with_peer_id(sequence_id: u64, peer_id: libp2p::PeerId) -> Self {
         ActorID {
             sequence_id,
@@ -92,7 +91,6 @@ impl ActorID {
     ///
     /// An `Option<PeerId>`. `None` indicates a local actor.
     #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     pub fn peer_id(&self) -> Option<libp2p::PeerId> {
         self.peer_id.map(|peer_id| *peer_id)
     }
@@ -184,16 +182,14 @@ impl ActorID {
 
 impl fmt::Display for ActorID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ActorID({}, ", self.sequence_id)?;
+        #[cfg(not(feature = "remote"))]
+        return write!(f, "ActorID({})", self.sequence_id);
 
         #[cfg(feature = "remote")]
         match self.peer_id {
-            Some(peer_id) => write!(f, "{peer_id})"),
-            None => write!(f, "local)"),
+            Some(peer_id) => write!(f, "ActorID({}, {peer_id})", self.sequence_id),
+            None => write!(f, "ActorID({}, local)", self.sequence_id),
         }
-
-        #[cfg(not(feature = "remote"))]
-        Ok(())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,6 @@ use std::{
     sync::{Arc, Mutex, MutexGuard, PoisonError},
 };
 
-use libp2p::TransportError;
-use libp2p_identity::ParseError;
 use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{mpsc, oneshot},
@@ -235,11 +233,15 @@ pub enum BootstrapError {
     /// Behaviour error.
     BehaviourError(Box<dyn error::Error + Send + Sync + 'static>),
     /// An error during listening on a Transport.
-    Transport(TransportError<io::Error>),
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    Transport(libp2p::TransportError<io::Error>),
 }
 
-impl From<TransportError<io::Error>> for BootstrapError {
-    fn from(err: TransportError<io::Error>) -> Self {
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+impl From<libp2p::TransportError<io::Error>> for BootstrapError {
+    fn from(err: libp2p::TransportError<io::Error>) -> Self {
         BootstrapError::Transport(err)
     }
 }
@@ -248,6 +250,7 @@ impl fmt::Display for BootstrapError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BootstrapError::BehaviourError(err) => err.fmt(f),
+            #[cfg(feature = "remote")]
             BootstrapError::Transport(err) => err.fmt(f),
         }
     }
@@ -627,11 +630,15 @@ pub enum ActorIDFromBytesError {
     /// The byte slice doesn't contain enough data for the `sequence_id`.
     MissingSequenceID,
     /// An error occurred while parsing the `PeerId`.
-    ParsePeerID(ParseError),
+    #[cfg(feature = "remote")]
+    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+    ParsePeerID(libp2p_identity::ParseError),
 }
 
-impl From<ParseError> for ActorIDFromBytesError {
-    fn from(err: ParseError) -> Self {
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
+impl From<libp2p_identity::ParseError> for ActorIDFromBytesError {
+    fn from(err: libp2p_identity::ParseError) -> Self {
         ActorIDFromBytesError::ParsePeerID(err)
     }
 }
@@ -640,6 +647,7 @@ impl fmt::Display for ActorIDFromBytesError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ActorIDFromBytesError::MissingSequenceID => write!(f, "missing instance ID"),
+            #[cfg(feature = "remote")]
             ActorIDFromBytesError::ParsePeerID(err) => err.fmt(f),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -228,18 +228,16 @@ impl<M, E> From<Elapsed> for SendError<M, E> {
 impl<M, E> error::Error for SendError<M, E> where E: fmt::Debug + fmt::Display {}
 
 /// An error that can occur when bootstrapping the actor swarm.
+#[cfg(feature = "remote")]
 #[derive(Debug)]
 pub enum BootstrapError {
     /// Behaviour error.
     BehaviourError(Box<dyn error::Error + Send + Sync + 'static>),
     /// An error during listening on a Transport.
-    #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     Transport(libp2p::TransportError<io::Error>),
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl From<libp2p::TransportError<io::Error>> for BootstrapError {
     fn from(err: libp2p::TransportError<io::Error>) -> Self {
         BootstrapError::Transport(err)
@@ -631,12 +629,10 @@ pub enum ActorIDFromBytesError {
     MissingSequenceID,
     /// An error occurred while parsing the `PeerId`.
     #[cfg(feature = "remote")]
-    #[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
     ParsePeerID(libp2p_identity::ParseError),
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl From<libp2p_identity::ParseError> for ActorIDFromBytesError {
     fn from(err: libp2p_identity::ParseError) -> Self {
         ActorIDFromBytesError::ParsePeerID(err)

--- a/src/error.rs
+++ b/src/error.rs
@@ -244,6 +244,7 @@ impl From<libp2p::TransportError<io::Error>> for BootstrapError {
     }
 }
 
+#[cfg(feature = "remote")]
 impl fmt::Display for BootstrapError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -254,6 +255,7 @@ impl fmt::Display for BootstrapError {
     }
 }
 
+#[cfg(feature = "remote")]
 impl error::Error for BootstrapError {}
 
 /// An error that can occur when registering & looking up actors by name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,13 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_debug_implementations)]
 #![deny(unused_must_use)]
-#![cfg_attr(feature = "doc", feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod actor;
 pub mod error;
 pub mod mailbox;
 pub mod message;
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub mod remote;
 pub mod reply;
 pub mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,14 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_debug_implementations)]
 #![deny(unused_must_use)]
+#![cfg_attr(feature = "doc", feature(doc_cfg))]
 
 pub mod actor;
 pub mod error;
 pub mod mailbox;
 pub mod message;
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub mod remote;
 pub mod reply;
 pub mod request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -47,8 +47,14 @@ use futures::Future;
 mod ask;
 mod tell;
 
-pub use ask::{AskRequest, LocalAskRequest, RemoteAskRequest};
-pub use tell::{LocalTellRequest, RemoteTellRequest, TellRequest};
+#[cfg(feature = "remote")]
+pub use ask::RemoteAskRequest;
+
+#[cfg(feature = "remote")]
+pub use tell::RemoteTellRequest;
+
+pub use ask::{AskRequest, LocalAskRequest};
+pub use tell::{LocalTellRequest, TellRequest};
 
 use crate::{error::SendError, reply::ReplySender, Reply};
 

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -87,7 +87,6 @@ where
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<'a, A, M>
     AskRequest<
         RemoteAskRequest<'a, A, M>,

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -39,7 +39,6 @@ where
 /// A request to a remote actor.
 #[allow(missing_debug_implementations)]
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub struct RemoteTellRequest<'a, A, M>
 where
     A: Actor,
@@ -76,7 +75,6 @@ where
 }
 
 #[cfg(feature = "remote")]
-#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<'a, A, M> TellRequest<RemoteTellRequest<'a, A, M>, A::Mailbox, M, WithoutRequestTimeout>
 where
     A: Actor,

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -1,15 +1,13 @@
 use core::panic;
-use std::{borrow::Cow, marker::PhantomData, time::Duration};
+use std::{marker::PhantomData, time::Duration};
 
-use serde::{de::DeserializeOwned, Serialize};
-use tokio::sync::oneshot;
+#[cfg(feature = "remote")]
+use crate::remote;
 
 use crate::{
-    actor::{ActorRef, RemoteActorRef},
-    error::{RemoteSendError, SendError},
+    actor, error,
     mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Signal},
     message::Message,
-    remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand, SwarmReq, SwarmResp},
     Actor, Reply,
 };
 
@@ -40,11 +38,13 @@ where
 
 /// A request to a remote actor.
 #[allow(missing_debug_implementations)]
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 pub struct RemoteTellRequest<'a, A, M>
 where
     A: Actor,
 {
-    actor_ref: &'a RemoteActorRef<A>,
+    actor_ref: &'a actor::RemoteActorRef<A>,
     msg: &'a M,
 }
 
@@ -54,7 +54,7 @@ where
     A: Actor,
 {
     #[inline]
-    pub(crate) fn new(actor_ref: &'a ActorRef<A>, msg: M) -> Self
+    pub(crate) fn new(actor_ref: &'a actor::ActorRef<A>, msg: M) -> Self
     where
         A: Message<M>,
         M: Send + 'static,
@@ -75,12 +75,14 @@ where
     }
 }
 
+#[cfg(feature = "remote")]
+#[cfg_attr(feature = "doc", doc(cfg(feature = "remote")))]
 impl<'a, A, M> TellRequest<RemoteTellRequest<'a, A, M>, A::Mailbox, M, WithoutRequestTimeout>
 where
     A: Actor,
 {
     #[inline]
-    pub(crate) fn new_remote(actor_ref: &'a RemoteActorRef<A>, msg: &'a M) -> Self {
+    pub(crate) fn new_remote(actor_ref: &'a actor::RemoteActorRef<A>, msg: &'a M) -> Self {
         TellRequest {
             location: RemoteTellRequest { actor_ref, msg },
             timeout: WithoutRequestTimeout,
@@ -107,6 +109,7 @@ where
     }
 }
 
+#[cfg(feature = "remote")]
 impl<L, Mb, M, T> TellRequest<L, Mb, M, T> {
     #[inline]
     pub(crate) fn into_maybe_timeouts(
@@ -138,7 +141,7 @@ macro_rules! impl_message_send {
             M: Send + 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             async fn send(self) -> Result<Self::Ok, Self::Error> {
@@ -157,12 +160,12 @@ macro_rules! impl_message_send {
                 M,
                 $timeout,
             >: MessageSend,
-            A: Actor<Mailbox = $mailbox<A>> + Message<M> + RemoteActor + RemoteMessage<M>,
-            M: Serialize + Send + Sync,
-            <A::Reply as Reply>::Error: DeserializeOwned,
+            A: Actor<Mailbox = $mailbox<A>> + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
+            M: serde::Serialize + Send + Sync,
+            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
         {
             type Ok = ();
-            type Error = RemoteSendError<<A::Reply as Reply>::Error>;
+            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
 
             #[inline]
             async fn send(self) -> Result<Self::Ok, Self::Error> {
@@ -185,7 +188,9 @@ impl_message_send!(local, BoundedMailbox, WithRequestTimeout, |req| {
         .await?;
     Ok(())
 });
+#[cfg(feature = "remote")]
 impl_message_send!(remote, BoundedMailbox, WithoutRequestTimeout, |req| None);
+#[cfg(feature = "remote")]
 impl_message_send!(remote, BoundedMailbox, WithRequestTimeout, |req| Some(
     req.timeout.0
 ));
@@ -194,6 +199,7 @@ impl_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
     req.location.mailbox.0.send(req.location.signal)?;
     Ok(())
 });
+#[cfg(feature = "remote")]
 impl_message_send!(remote, UnboundedMailbox, WithoutRequestTimeout, |req| None);
 
 impl_message_send!(local, BoundedMailbox, MaybeRequestTimeout, |req| {
@@ -246,7 +252,7 @@ macro_rules! impl_message_send_sync {
             M: 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             fn send_sync(self) -> Result<Self::Ok, Self::Error> {
@@ -279,7 +285,7 @@ macro_rules! impl_try_message_send {
             M: Send + 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             async fn try_send(self) -> Result<Self::Ok, Self::Error> {
@@ -298,12 +304,12 @@ macro_rules! impl_try_message_send {
                 M,
                 $timeout,
             >: TryMessageSend,
-            A: Actor<Mailbox = $mailbox<A>> + Message<M> + RemoteActor + RemoteMessage<M>,
-            M: Serialize + Send + Sync,
-            <A::Reply as Reply>::Error: DeserializeOwned,
+            A: Actor<Mailbox = $mailbox<A>> + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
+            M: serde::Serialize + Send + Sync,
+            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
         {
             type Ok = ();
-            type Error = RemoteSendError<<A::Reply as Reply>::Error>;
+            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
 
             #[inline]
             async fn try_send(self) -> Result<Self::Ok, Self::Error> {
@@ -318,11 +324,13 @@ impl_try_message_send!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
     req.location.mailbox.0.try_send(req.location.signal)?;
     Ok(())
 });
+#[cfg(feature = "remote")]
 impl_try_message_send!(remote, BoundedMailbox, WithoutRequestTimeout, |req| None);
 impl_try_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
     req.location.mailbox.0.send(req.location.signal)?;
     Ok(())
 });
+#[cfg(feature = "remote")]
 impl_try_message_send!(remote, UnboundedMailbox, WithoutRequestTimeout, |req| None);
 
 impl_try_message_send!(local, BoundedMailbox, MaybeRequestTimeout, |req| {
@@ -376,7 +384,7 @@ macro_rules! impl_try_message_send_sync {
             M: 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             fn try_send_sync(self) -> Result<Self::Ok, Self::Error> {
@@ -414,7 +422,7 @@ macro_rules! impl_blocking_message_send {
             M: 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             fn blocking_send(self) -> Result<Self::Ok, Self::Error> {
@@ -452,7 +460,7 @@ macro_rules! impl_try_blocking_message_send {
             M: 'static,
         {
             type Ok = ();
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
             fn try_blocking_send(self) -> Result<Self::Ok, Self::Error> {
@@ -473,30 +481,34 @@ impl_try_blocking_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, 
     Ok(())
 });
 
+#[cfg(feature = "remote")]
 async fn remote_tell<A, M>(
-    actor_ref: &RemoteActorRef<A>,
+    actor_ref: &actor::RemoteActorRef<A>,
     msg: &M,
     mailbox_timeout: Option<Duration>,
     immediate: bool,
-) -> Result<(), RemoteSendError<<A::Reply as Reply>::Error>>
+) -> Result<(), error::RemoteSendError<<A::Reply as Reply>::Error>>
 where
-    A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
-    M: Serialize,
-    <A::Reply as Reply>::Error: DeserializeOwned,
+    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
+    M: serde::Serialize,
+    <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
 {
+    use remote::*;
+    use std::borrow::Cow;
+
     let actor_id = actor_ref.id();
-    let (reply_tx, reply_rx) = oneshot::channel();
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     actor_ref.send_to_swarm(SwarmCommand::Req {
         peer_id: actor_id
             .peer_id_intern()
             .cloned()
-            .unwrap_or_else(|| ActorSwarm::get().unwrap().local_peer_id_intern().clone()),
+            .unwrap_or_else(|| *ActorSwarm::get().unwrap().local_peer_id_intern()),
         req: SwarmReq::Tell {
             actor_id,
             actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
             message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
             payload: rmp_serde::to_vec_named(msg)
-                .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
+                .map_err(|err| error::RemoteSendError::SerializeMessage(err.to_string()))?,
             mailbox_timeout,
             immediate,
         },
@@ -508,8 +520,8 @@ where
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .map_err(|err| match rmp_serde::decode::from_slice(&err) {
-                    Ok(err) => RemoteSendError::HandlerError(err),
-                    Err(err) => RemoteSendError::DeserializeHandlerError(err.to_string()),
+                    Ok(err) => error::RemoteSendError::HandlerError(err),
+                    Err(err) => error::RemoteSendError::DeserializeHandlerError(err.to_string()),
                 })
                 .flatten()),
         },


### PR DESCRIPTION
Closes #58 

Not sure if I made all unnecessary dependencies optional, maybe you'll have some suggestions on which other dependencies can be disabled.