### PR TITLE
feat: add spawn_link and link/unlink functions

### DIFF
--- a/src/actor/pool.rs
+++ b/src/actor/pool.rs
@@ -173,7 +173,7 @@ where
 
     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
         for worker in &self.workers {
-            worker.link_child(&actor_ref).await;
+            worker.link(&actor_ref).await;
         }
 
         Ok(())
@@ -201,7 +201,7 @@ where
             Factory::Sync(f) => f(),
             Factory::Async(f) => f().await,
         };
-        self.workers[i].link_child(&actor_ref).await;
+        self.workers[i].link(&actor_ref).await;
 
         Ok(None)
     }


### PR DESCRIPTION
This PR deprecates the existing `link_child`, `unlink_child`, `link_together`, and `unlink_together` methods on ActoRef in favor of the new `link` and `unlink` methods.

A new `spawn_link` function is also provided to ensure an actor is linked with another before being spawned.

The internal APIs used for spawning is also improved.