### PR TITLE
feat: add support for preparing an actor and running it outside a spawned task

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -204,7 +204,7 @@ pub trait Actor: Sized + Send + 'static {
     /// - `reason`: The reason why the actor is being stopped.
     #[allow(unused_variables)]
     fn on_stop(
-        self,
+        &mut self,
         actor_ref: WeakActorRef<Self>,
         reason: ActorStopReason,
     ) -> impl Future<Output = Result<(), BoxError>> + Send {

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -80,7 +80,7 @@ pub use spawn::*;
 ///     }
 ///
 ///     async fn on_stop(
-///         self,
+///         &mut self,
 ///         actor_ref: WeakActorRef<Self>,
 ///         reason: ActorStopReason,
 ///     ) -> Result<(), BoxError> {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{self, SendError},
     mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Mailbox, Signal},
     message::{BoxReply, Message},
-    reply::{BoxReplySender, ReplySender},
+    reply::ReplySender,
     Actor, Reply,
 };
 
@@ -36,7 +36,7 @@ where
 {
     mailbox: &'a Mb,
     signal: Signal<A>,
-    rx: BoxReplySender,
+    rx: oneshot::Receiver<Result<BoxReply, error::BoxSendError>>,
 }
 
 /// A request to a remote actor.

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{self, SendError},
     mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Mailbox, Signal},
     message::{BoxReply, Message},
-    reply::ReplySender,
+    reply::{BoxReplySender, ReplySender},
     Actor, Reply,
 };
 
@@ -36,7 +36,7 @@ where
 {
     mailbox: &'a Mb,
     signal: Signal<A>,
-    rx: oneshot::Receiver<Result<BoxReply, error::BoxSendError>>,
+    rx: BoxReplySender,
 }
 
 /// A request to a remote actor.


### PR DESCRIPTION
A new `PreparedActor` is returned from the `kameo::actor::prepare(actor)` function, which lets you run the actor locally in the current context, or spawned in a tokio task.