### PR TITLE
feat: add public `BoxReplySender` type alias

### DIFF
--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -1,13 +1,13 @@
 use std::{collections::VecDeque, mem, panic::AssertUnwindSafe};
 
 use futures::{Future, FutureExt};
-use tokio::sync::oneshot;
 
 use crate::{
     actor::{Actor, ActorRef, WeakActorRef},
-    error::{ActorStopReason, BoxSendError, PanicError},
+    error::{ActorStopReason, PanicError},
     mailbox::Signal,
-    message::{BoxReply, DynMessage},
+    message::DynMessage,
+    reply::BoxReplySender,
 };
 
 use super::ActorID;
@@ -21,7 +21,7 @@ pub(crate) trait ActorState<A: Actor>: Sized {
         &mut self,
         message: Box<dyn DynMessage<A>>,
         actor_ref: ActorRef<A>,
-        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+        reply: Option<BoxReplySender>,
         sent_within_actor: bool,
     ) -> impl Future<Output = Option<ActorStopReason>> + Send;
 
@@ -91,7 +91,7 @@ where
         &mut self,
         message: Box<dyn DynMessage<A>>,
         actor_ref: ActorRef<A>,
-        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+        reply: Option<BoxReplySender>,
         sent_within_actor: bool,
     ) -> Option<ActorStopReason> {
         if !sent_within_actor && !self.finished_startup {

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -7,12 +7,12 @@ pub mod unbounded;
 
 use dyn_clone::DynClone;
 use futures::{future::BoxFuture, Future};
-use tokio::sync::oneshot;
 
 use crate::{
     actor::{ActorID, ActorRef},
-    error::{ActorStopReason, BoxSendError, SendError},
-    message::{BoxReply, DynMessage},
+    error::{ActorStopReason, SendError},
+    message::DynMessage,
+    reply::BoxReplySender,
     Actor,
 };
 
@@ -68,7 +68,7 @@ pub enum Signal<A: Actor> {
     Message {
         message: Box<dyn DynMessage<A>>,
         actor_ref: ActorRef<A>,
-        reply: Option<oneshot::Sender<Result<BoxReply, BoxSendError>>>,
+        reply: Option<BoxReplySender>,
         sent_within_actor: bool,
     },
     LinkDied {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -831,7 +831,7 @@ impl_forward_message!(
     WithoutRequestTimeout,
     |req, tx| {
         match &mut req.location.signal {
-            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Message { reply, .. } => *reply = Some(tx.boxed()),
             _ => unreachable!("ask requests only support messages"),
         }
 
@@ -859,7 +859,7 @@ impl_forward_message!(
     WithoutRequestTimeout,
     |req, tx| {
         match &mut req.location.signal {
-            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Message { reply, .. } => *reply = Some(tx.boxed()),
             _ => unreachable!("ask requests only support messages"),
         }
 
@@ -880,7 +880,7 @@ impl_forward_message!(
     WithoutRequestTimeout,
     |req, tx| {
         match &mut req.location.signal {
-            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Message { reply, .. } => *reply = Some(tx.boxed()),
             _ => unreachable!("ask requests only support messages"),
         }
 
@@ -935,7 +935,7 @@ impl_forward_message_sync!(
     WithoutRequestTimeout,
     |req, tx| {
         match &mut req.location.signal {
-            Signal::Message { reply, .. } => *reply = Some(tx.box_sender()),
+            Signal::Message { reply, .. } => *reply = Some(tx.boxed()),
             _ => unreachable!("ask requests only support messages"),
         }
 


### PR DESCRIPTION
Exposes a new `BoxReplySender` type alias with new method `.boxed()`, and additionally removes the `#[doc_hidden]` attributes on the `DynMessage` trait.