### PR TITLE
feat!: relax request impls to be generic to any mailbox

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -770,7 +770,7 @@ impl<A: Actor> RemoteActorRef<A> {
     >
     where
         A: remote::RemoteActor + Message<M> + remote::RemoteMessage<M>,
-        M: serde::Serialize,
+        M: serde::Serialize + Send + 'static,
         <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
     {
         AskRequest::new_remote(self, msg)

--- a/src/actor/pool.rs
+++ b/src/actor/pool.rs
@@ -212,6 +212,7 @@ where
 pub enum WorkerReply<A, M>
 where
     A: Actor + Message<M>,
+    M: Send + 'static,
 {
     /// The message was forwarded to a worker.
     Forwarded,

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -30,6 +30,10 @@ pub trait Mailbox<A: Actor>: SignalMailbox + Clone + Send + Sync {
         &self,
         signal: Signal<A>,
     ) -> impl Future<Output = Result<(), SendError<Signal<A>, E>>> + Send + '_;
+    /// Tries to send a signal to the mailbox, failing if the mailbox is full.
+    fn try_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>>;
+    /// Sends a signal to the mailbox, blocking the current thread.
+    fn blocking_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>>;
     /// Waits for the mailbox to be closed.
     fn closed(&self) -> impl Future<Output = ()> + Send + '_;
     /// Checks if the mailbox is closed.

--- a/src/mailbox/bounded.rs
+++ b/src/mailbox/bounded.rs
@@ -40,6 +40,16 @@ impl<A: Actor> Mailbox<A> for BoundedMailbox<A> {
     }
 
     #[inline]
+    fn try_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.try_send(signal)?)
+    }
+
+    #[inline]
+    fn blocking_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.blocking_send(signal)?)
+    }
+
+    #[inline]
     async fn closed(&self) {
         self.0.closed().await
     }

--- a/src/mailbox/unbounded.rs
+++ b/src/mailbox/unbounded.rs
@@ -40,6 +40,16 @@ impl<A: Actor> Mailbox<A> for UnboundedMailbox<A> {
     }
 
     #[inline]
+    fn try_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.send(signal)?)
+    }
+
+    #[inline]
+    fn blocking_send<E: 'static>(&self, signal: Signal<A>) -> Result<(), SendError<Signal<A>, E>> {
+        Ok(self.0.send(signal)?)
+    }
+
+    #[inline]
     async fn closed(&self) {
         self.0.closed().await
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -35,7 +35,7 @@ pub(crate) type BoxReply = Box<dyn any::Any + Send>;
 /// Messages are processed sequentially one at a time, with exclusive mutable access to the actors state.
 ///
 /// The reply type must implement [Reply].
-pub trait Message<T>: Actor {
+pub trait Message<T: Send + 'static>: Actor {
     /// The reply sent back to the message caller.
     type Reply: Reply;
 

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -7,7 +7,7 @@ use crate::remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand, SwarmR
 use crate::{
     actor,
     error::{self, SendError},
-    mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Signal},
+    mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Mailbox, Signal},
     message::{BoxReply, Message},
     reply::ReplySender,
     Actor, Reply,
@@ -158,12 +158,32 @@ impl<L, Mb, M, Tm, Tr> AskRequest<L, Mb, M, Tm, Tr> {
     }
 }
 
-/////////////////////////
-// === MessageSend === //
-/////////////////////////
-macro_rules! impl_message_send {
-    (local, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> MessageSend
+macro_rules! impl_message_trait {
+    (local, $($async:ident)? => $trait:ident :: $method:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
+            for AskRequest<
+                LocalAskRequest<'a, A, A::Mailbox>,
+                A::Mailbox,
+                M,
+                $mailbox_timeout,
+                $reply_timeout,
+            >
+        where
+            A: Actor + Message<M>,
+            M: Send + 'static,
+        {
+            type Ok = <A::Reply as Reply>::Ok;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
+
+            #[inline]
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
+                let $req = self;
+                $($body)*
+            }
+        }
+    };
+    (local, $($async:ident)? => $trait:ident :: $method:ident, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
             for AskRequest<
                 LocalAskRequest<'a, A, $mailbox<A>>,
                 $mailbox<A>,
@@ -176,34 +196,28 @@ macro_rules! impl_message_send {
             M: Send + 'static,
         {
             type Ok = <A::Reply as Reply>::Ok;
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
-            async fn send(self) -> Result<Self::Ok, Self::Error> {
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
                 let $req = self;
                 $($body)*
             }
         }
     };
-    (remote, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| ($mailbox_timeout_body:expr, $reply_timeout_body:expr)) => {
-        impl<'a, A, M> MessageSend
-            for AskRequest<
-                RemoteAskRequest<'a, A, M>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >
+    (remote, $($async:ident)? => $trait:ident :: $method:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| ($mailbox_timeout_body:expr, $reply_timeout_body:expr)) => {
+        impl<'a, A, M> $trait
+            for AskRequest<RemoteAskRequest<'a, A, M>, A::Mailbox, M, $mailbox_timeout, $reply_timeout>
         where
             AskRequest<
-                LocalAskRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
+                LocalAskRequest<'a, A, A::Mailbox>,
+                A::Mailbox,
                 M,
                 $mailbox_timeout,
                 $reply_timeout,
-            >: MessageSend,
-            A: Actor<Mailbox = $mailbox<A>> + Message<M> + RemoteActor + RemoteMessage<M>,
-            M: serde::Serialize + Send + Sync,
+            >: $trait,
+            A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+            M: serde::Serialize + Send + Sync + 'static,
             <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
             <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
         {
@@ -211,7 +225,39 @@ macro_rules! impl_message_send {
             type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
 
             #[inline]
-            async fn send(self) -> Result<Self::Ok, Self::Error> {
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
+                let $req = self;
+                remote_ask(
+                    $req.location.actor_ref,
+                    &$req.location.msg,
+                    $mailbox_timeout_body,
+                    $reply_timeout_body,
+                    false
+                ).await
+            }
+        }
+    };
+    (remote, $($async:ident)? => $trait:ident :: $method:ident, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| ($mailbox_timeout_body:expr, $reply_timeout_body:expr)) => {
+        impl<'a, A, M> $trait
+            for AskRequest<RemoteAskRequest<'a, A, M>, $mailbox<A>, M, $mailbox_timeout, $reply_timeout>
+        where
+            AskRequest<
+                LocalAskRequest<'a, A, $mailbox<A>>,
+                $mailbox<A>,
+                M,
+                $mailbox_timeout,
+                $reply_timeout,
+            >: $trait,
+            A: Actor<Mailbox = $mailbox<A>> + Message<M> + RemoteActor + RemoteMessage<M>,
+            M: serde::Serialize + Send + Sync + 'static,
+            <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
+            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
+        {
+            type Ok = <A::Reply as Reply>::Ok;
+            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
+
+            #[inline]
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
                 let $req = self;
                 remote_ask(
                     $req.location.actor_ref,
@@ -225,21 +271,26 @@ macro_rules! impl_message_send {
     };
 }
 
-impl_message_send!(
+/////////////////////////
+// === MessageSend === //
+/////////////////////////
+impl_message_trait!(
     local,
-    BoundedMailbox,
+    async => MessageSend::send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| {
-        req.location.mailbox.0.send(req.location.signal).await?;
+        req.location.mailbox.send(req.location.signal).await
+            .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))?;
         match req.location.rx.await? {
             Ok(val) => Ok(*val.downcast().unwrap()),
             Err(err) => Err(err.downcast()),
         }
     }
 );
-impl_message_send!(
+impl_message_trait!(
     local,
+    async => MessageSend::send,
     BoundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
@@ -251,8 +302,9 @@ impl_message_send!(
         }
     }
 );
-impl_message_send!(
+impl_message_trait!(
     local,
+    async => MessageSend::send,
     BoundedMailbox,
     WithRequestTimeout,
     WithoutRequestTimeout,
@@ -268,8 +320,9 @@ impl_message_send!(
         }
     }
 );
-impl_message_send!(
+impl_message_trait!(
     local,
+    async => MessageSend::send,
     BoundedMailbox,
     WithRequestTimeout,
     WithRequestTimeout,
@@ -286,21 +339,9 @@ impl_message_send!(
     }
 );
 
-impl_message_send!(
+impl_message_trait!(
     local,
-    UnboundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| {
-        req.location.mailbox.0.send(req.location.signal)?;
-        match req.location.rx.await? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
-        }
-    }
-);
-impl_message_send!(
-    local,
+    async => MessageSend::send,
     UnboundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
@@ -314,32 +355,35 @@ impl_message_send!(
 );
 
 #[cfg(feature = "remote")]
-impl_message_send!(
+impl_message_trait!(
     remote,
-    BoundedMailbox,
+    async => MessageSend::send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| (None, None)
 );
 #[cfg(feature = "remote")]
-impl_message_send!(
+impl_message_trait!(
     remote,
+    async => MessageSend::send,
     BoundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
     |req| (None, Some(req.reply_timeout.0))
 );
 #[cfg(feature = "remote")]
-impl_message_send!(
+impl_message_trait!(
     remote,
+    async => MessageSend::send,
     BoundedMailbox,
     WithRequestTimeout,
     WithoutRequestTimeout,
     |req| (Some(req.mailbox_timeout.0), None)
 );
 #[cfg(feature = "remote")]
-impl_message_send!(
+impl_message_trait!(
     remote,
+    async => MessageSend::send,
     BoundedMailbox,
     WithRequestTimeout,
     WithRequestTimeout,
@@ -347,24 +391,18 @@ impl_message_send!(
 );
 
 #[cfg(feature = "remote")]
-impl_message_send!(
+impl_message_trait!(
     remote,
-    UnboundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| (None, None)
-);
-#[cfg(feature = "remote")]
-impl_message_send!(
-    remote,
+    async => MessageSend::send,
     UnboundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
     |req| (None, Some(req.reply_timeout.0))
 );
 
-impl_message_send!(
+impl_message_trait!(
     local,
+    async => MessageSend::send,
     BoundedMailbox,
     MaybeRequestTimeout,
     MaybeRequestTimeout,
@@ -417,8 +455,9 @@ impl_message_send!(
     }
 );
 
-impl_message_send!(
+impl_message_trait!(
     local,
+    async => MessageSend::send,
     UnboundedMailbox,
     MaybeRequestTimeout,
     MaybeRequestTimeout,
@@ -454,88 +493,26 @@ impl_message_send!(
     }
 );
 
-/////////////////////////
-// === MessageSend === //
-/////////////////////////
-macro_rules! impl_try_message_send {
-    (local, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryMessageSend
-            for AskRequest<
-                LocalAskRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: Send + 'static,
-        {
-            type Ok = <A::Reply as Reply>::Ok;
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            async fn try_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-    (remote, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| ($mailbox_timeout_body:expr, $reply_timeout_body:expr)) => {
-        impl<'a, A, M> TryMessageSend
-            for AskRequest<
-                RemoteAskRequest<'a, A, M>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >
-        where
-            AskRequest<
-                LocalAskRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >: TryMessageSend,
-            A: Actor<Mailbox = $mailbox<A>> + Message<M> + RemoteActor + RemoteMessage<M>,
-            M: serde::Serialize + Send + Sync,
-            <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
-            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
-        {
-            type Ok = <A::Reply as Reply>::Ok;
-            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
-
-            #[inline]
-            async fn try_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                remote_ask(
-                    $req.location.actor_ref,
-                    &$req.location.msg,
-                    $mailbox_timeout_body,
-                    $reply_timeout_body,
-                    true
-                ).await
-            }
-        }
-    };
-}
-
-impl_try_message_send!(
+////////////////////////////
+// === TryMessageSend === //
+////////////////////////////
+impl_message_trait!(
     local,
-    BoundedMailbox,
+    async => TryMessageSend::try_send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| {
-        req.location.mailbox.0.try_send(req.location.signal)?;
+        req.location.mailbox.try_send(req.location.signal)
+            .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))?;
         match req.location.rx.await? {
             Ok(val) => Ok(*val.downcast().unwrap()),
             Err(err) => Err(err.downcast()),
         }
     }
 );
-impl_try_message_send!(
+impl_message_trait!(
     local,
+    async => TryMessageSend::try_send,
     BoundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
@@ -548,21 +525,9 @@ impl_try_message_send!(
     }
 );
 
-impl_try_message_send!(
+impl_message_trait!(
     local,
-    UnboundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| {
-        req.location.mailbox.0.send(req.location.signal)?;
-        match req.location.rx.await? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
-        }
-    }
-);
-impl_try_message_send!(
-    local,
+    async => TryMessageSend::try_send,
     UnboundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
@@ -576,16 +541,17 @@ impl_try_message_send!(
 );
 
 #[cfg(feature = "remote")]
-impl_try_message_send!(
+impl_message_trait!(
     remote,
-    BoundedMailbox,
+    async => TryMessageSend::try_send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| (None, None)
 );
 #[cfg(feature = "remote")]
-impl_try_message_send!(
+impl_message_trait!(
     remote,
+    async => TryMessageSend::try_send,
     BoundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
@@ -593,24 +559,18 @@ impl_try_message_send!(
 );
 
 #[cfg(feature = "remote")]
-impl_try_message_send!(
+impl_message_trait!(
     remote,
-    UnboundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| (None, None)
-);
-#[cfg(feature = "remote")]
-impl_try_message_send!(
-    remote,
+    async => TryMessageSend::try_send,
     UnboundedMailbox,
     WithoutRequestTimeout,
     WithRequestTimeout,
     |req| (None, Some(req.reply_timeout.0))
 );
 
-impl_try_message_send!(
+impl_message_trait!(
     local,
+    async => TryMessageSend::try_send,
     BoundedMailbox,
     MaybeRequestTimeout,
     MaybeRequestTimeout,
@@ -646,8 +606,9 @@ impl_try_message_send!(
     }
 );
 
-impl_try_message_send!(
+impl_message_trait!(
     local,
+    async => TryMessageSend::try_send,
     UnboundedMailbox,
     MaybeRequestTimeout,
     MaybeRequestTimeout,
@@ -686,39 +647,14 @@ impl_try_message_send!(
 /////////////////////////////////
 // === BlockingMessageSend === //
 /////////////////////////////////
-macro_rules! impl_blocking_message_send {
-    (local, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> BlockingMessageSend
-            for AskRequest<
-                LocalAskRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = <A::Reply as Reply>::Ok;
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn blocking_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_blocking_message_send!(
+impl_message_trait!(
     local,
-    BoundedMailbox,
+    => BlockingMessageSend::blocking_send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| {
-        req.location.mailbox.0.blocking_send(req.location.signal)?;
+        req.location.mailbox.blocking_send(req.location.signal)
+            .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))?;
         match req.location.rx.blocking_recv()? {
             Ok(val) => Ok(*val.downcast().unwrap()),
             Err(err) => Err(err.downcast()),
@@ -726,70 +662,17 @@ impl_blocking_message_send!(
     }
 );
 
-impl_blocking_message_send!(
+////////////////////////////////////
+// === TryBlockingMessageSend === //
+////////////////////////////////////
+impl_message_trait!(
     local,
-    UnboundedMailbox,
+    => TryBlockingMessageSend::try_blocking_send,
     WithoutRequestTimeout,
     WithoutRequestTimeout,
     |req| {
-        req.location.mailbox.0.send(req.location.signal)?;
-        match req.location.rx.blocking_recv()? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
-        }
-    }
-);
-
-/////////////////////////////////
-// === BlockingMessageSend === //
-/////////////////////////////////
-macro_rules! impl_try_blocking_message_send {
-    (local, $mailbox:ident, $mailbox_timeout:ident, $reply_timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryBlockingMessageSend
-            for AskRequest<
-                LocalAskRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $mailbox_timeout,
-                $reply_timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = <A::Reply as Reply>::Ok;
-            type Error = SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn try_blocking_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_try_blocking_message_send!(
-    local,
-    BoundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| {
-        req.location.mailbox.0.try_send(req.location.signal)?;
-        match req.location.rx.blocking_recv()? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
-        }
-    }
-);
-
-impl_try_blocking_message_send!(
-    local,
-    UnboundedMailbox,
-    WithoutRequestTimeout,
-    WithoutRequestTimeout,
-    |req| {
-        req.location.mailbox.0.send(req.location.signal)?;
+        req.location.mailbox.try_send(req.location.signal)
+            .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))?;
         match req.location.rx.blocking_recv()? {
             Ok(val) => Ok(*val.downcast().unwrap()),
             Err(err) => Err(err.downcast()),
@@ -965,7 +848,7 @@ async fn remote_ask<'a, A, M>(
 ) -> Result<<A::Reply as Reply>::Ok, error::RemoteSendError<<A::Reply as Reply>::Error>>
 where
     A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
-    M: serde::Serialize,
+    M: serde::Serialize + Send + 'static,
     <A::Reply as Reply>::Ok: for<'de> serde::Deserialize<'de>,
     <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
 {

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -6,7 +6,7 @@ use crate::remote;
 
 use crate::{
     actor, error,
-    mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Signal},
+    mailbox::{bounded::BoundedMailbox, unbounded::UnboundedMailbox, Mailbox, Signal},
     message::Message,
     Actor, Reply,
 };
@@ -122,12 +122,31 @@ impl<L, Mb, M, T> TellRequest<L, Mb, M, T> {
     }
 }
 
-/////////////////////////
-// === MessageSend === //
-/////////////////////////
-macro_rules! impl_message_send {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> MessageSend
+macro_rules! impl_message_trait {
+    (local, $($async:ident)? => $trait:ident :: $method:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
+            for TellRequest<
+                LocalTellRequest<'a, A, A::Mailbox>,
+                A::Mailbox,
+                M,
+                $timeout,
+            >
+        where
+            A: Actor + Message<M>,
+            M: Send + 'static,
+        {
+            type Ok = ();
+            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
+
+            #[inline]
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
+                let $req = self;
+                $($body)*
+            }
+        }
+    };
+    (local, $($async:ident)? => $trait:ident :: $method:ident, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
             for TellRequest<
                 LocalTellRequest<'a, A, $mailbox<A>>,
                 $mailbox<A>,
@@ -142,14 +161,38 @@ macro_rules! impl_message_send {
             type Error = error::SendError<M, <A::Reply as Reply>::Error>;
 
             #[inline]
-            async fn send(self) -> Result<Self::Ok, Self::Error> {
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
                 let $req = self;
                 $($body)*
             }
         }
     };
-    (remote, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> MessageSend
+    (remote, $($async:ident)? => $trait:ident :: $method:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
+            for TellRequest<RemoteTellRequest<'a, A, M>, A::Mailbox, M, $timeout>
+        where
+            TellRequest<
+                LocalTellRequest<'a, A, A::Mailbox>,
+                A::Mailbox,
+                M,
+                $timeout,
+            >: $trait,
+            A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
+            M: serde::Serialize + Send + Sync + 'static,
+            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
+        {
+            type Ok = ();
+            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
+
+            #[inline]
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
+                let $req = self;
+                remote_tell($req.location.actor_ref, &$req.location.msg, $($body)*, false).await
+            }
+        }
+    };
+    (remote, $($async:ident)? => $trait:ident :: $method:ident, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
+        impl<'a, A, M> $trait
             for TellRequest<RemoteTellRequest<'a, A, M>, $mailbox<A>, M, $timeout>
         where
             TellRequest<
@@ -157,16 +200,16 @@ macro_rules! impl_message_send {
                 $mailbox<A>,
                 M,
                 $timeout,
-            >: MessageSend,
+            >: $trait,
             A: Actor<Mailbox = $mailbox<A>> + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-            M: serde::Serialize + Send + Sync,
+            M: serde::Serialize + Send + Sync + 'static,
             <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
         {
             type Ok = ();
             type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
 
             #[inline]
-            async fn send(self) -> Result<Self::Ok, Self::Error> {
+            $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
                 let $req = self;
                 remote_tell($req.location.actor_ref, &$req.location.msg, $($body)*, false).await
             }
@@ -174,164 +217,113 @@ macro_rules! impl_message_send {
     };
 }
 
-impl_message_send!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal).await?;
-    Ok(())
-});
-impl_message_send!(local, BoundedMailbox, WithRequestTimeout, |req| {
+/////////////////////////
+// === MessageSend === //
+/////////////////////////
+impl_message_trait!(local, async => MessageSend::send, WithoutRequestTimeout, |req| {
     req.location
         .mailbox
-        .0
-        .send_timeout(req.location.signal, req.timeout.0)
-        .await?;
-    Ok(())
+        .send(req.location.signal)
+        .await
+        .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))
 });
-#[cfg(feature = "remote")]
-impl_message_send!(remote, BoundedMailbox, WithoutRequestTimeout, |req| None);
-#[cfg(feature = "remote")]
-impl_message_send!(remote, BoundedMailbox, WithRequestTimeout, |req| Some(
-    req.timeout.0
-));
-
-impl_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
-});
-#[cfg(feature = "remote")]
-impl_message_send!(remote, UnboundedMailbox, WithoutRequestTimeout, |req| None);
-
-impl_message_send!(local, BoundedMailbox, MaybeRequestTimeout, |req| {
-    match req.timeout {
-        MaybeRequestTimeout::NoTimeout => {
-            req.location.mailbox.0.send(req.location.signal).await?;
-        }
-        MaybeRequestTimeout::Timeout(timeout) => {
-            req.location
-                .mailbox
-                .0
-                .send_timeout(req.location.signal, timeout)
-                .await?;
-        }
+impl_message_trait!(
+    local,
+    async => MessageSend::send,
+    BoundedMailbox,
+    WithRequestTimeout,
+    |req| {
+        req.location
+            .mailbox
+            .0
+            .send_timeout(req.location.signal, req.timeout.0)
+            .await?;
+        Ok(())
     }
-    Ok(())
-});
+);
+#[cfg(feature = "remote")]
+impl_message_trait!(remote, async => MessageSend::send, WithoutRequestTimeout, |req| None);
+#[cfg(feature = "remote")]
+impl_message_trait!(
+    remote,
+    async => MessageSend::send,
+    BoundedMailbox,
+    WithRequestTimeout,
+    |req| Some(req.timeout.0)
+);
 
-impl_message_send!(local, UnboundedMailbox, MaybeRequestTimeout, |req| {
-    match req.timeout {
-        MaybeRequestTimeout::NoTimeout => {
-            TellRequest {
-                location: req.location,
-                timeout: WithoutRequestTimeout,
-                phantom: PhantomData,
+impl_message_trait!(
+    local,
+    async => MessageSend::send,
+    BoundedMailbox,
+    MaybeRequestTimeout,
+    |req| {
+        match req.timeout {
+            MaybeRequestTimeout::NoTimeout => {
+                req.location.mailbox.0.send(req.location.signal).await?;
             }
-            .send()
-            .await
+            MaybeRequestTimeout::Timeout(timeout) => {
+                req.location
+                    .mailbox
+                    .0
+                    .send_timeout(req.location.signal, timeout)
+                    .await?;
+            }
         }
-        MaybeRequestTimeout::Timeout(_) => {
-            panic!("mailbox timeout is not available with unbounded mailboxes")
+        Ok(())
+    }
+);
+
+impl_message_trait!(
+    local,
+    async => MessageSend::send,
+    UnboundedMailbox,
+    MaybeRequestTimeout,
+    |req| {
+        match req.timeout {
+            MaybeRequestTimeout::NoTimeout => {
+                TellRequest {
+                    location: req.location,
+                    timeout: WithoutRequestTimeout,
+                    phantom: PhantomData,
+                }
+                .send()
+                .await
+            }
+            MaybeRequestTimeout::Timeout(_) => {
+                panic!("mailbox timeout is not available with unbounded mailboxes")
+            }
         }
     }
-});
+);
 
 /////////////////////////////
 // === MessageSendSync === //
 /////////////////////////////
-macro_rules! impl_message_send_sync {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> MessageSendSync
-            for TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = ();
-            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn send_sync(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_message_send_sync!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
-});
+impl_message_trait!(
+    local,
+    => MessageSendSync::send_sync,
+    UnboundedMailbox,
+    WithoutRequestTimeout,
+    |req| {
+        req.location.mailbox.0.send(req.location.signal)?;
+        Ok(())
+    }
+);
 
 ////////////////////////////
 // === TryMessageSend === //
 ////////////////////////////
-macro_rules! impl_try_message_send {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryMessageSend
-            for TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: Send + 'static,
-        {
-            type Ok = ();
-            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            async fn try_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-    (remote, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryMessageSend
-            for TellRequest<RemoteTellRequest<'a, A, M>, $mailbox<A>, M, $timeout>
-        where
-            TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >: TryMessageSend,
-            A: Actor<Mailbox = $mailbox<A>> + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-            M: serde::Serialize + Send + Sync,
-            <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
-        {
-            type Ok = ();
-            type Error = error::RemoteSendError<<A::Reply as Reply>::Error>;
-
-            #[inline]
-            async fn try_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                remote_tell($req.location.actor_ref, &$req.location.msg, $($body)*, true).await
-            }
-        }
-    };
-}
-
-impl_try_message_send!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.try_send(req.location.signal)?;
-    Ok(())
+impl_message_trait!(local, async => TryMessageSend::try_send, WithoutRequestTimeout, |req| {
+    req.location
+        .mailbox
+        .try_send(req.location.signal)
+        .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))
 });
 #[cfg(feature = "remote")]
-impl_try_message_send!(remote, BoundedMailbox, WithoutRequestTimeout, |req| None);
-impl_try_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
-});
-#[cfg(feature = "remote")]
-impl_try_message_send!(remote, UnboundedMailbox, WithoutRequestTimeout, |req| None);
+impl_message_trait!(remote, async => TryMessageSend::try_send, WithoutRequestTimeout, |req| None);
 
-impl_try_message_send!(local, BoundedMailbox, MaybeRequestTimeout, |req| {
+impl_message_trait!(local, async => TryMessageSend::try_send, BoundedMailbox, MaybeRequestTimeout, |req| {
     match req.timeout {
         MaybeRequestTimeout::NoTimeout => {
             TellRequest {
@@ -348,7 +340,7 @@ impl_try_message_send!(local, BoundedMailbox, MaybeRequestTimeout, |req| {
     }
 });
 
-impl_try_message_send!(local, UnboundedMailbox, MaybeRequestTimeout, |req| {
+impl_message_trait!(local, async => TryMessageSend::try_send, UnboundedMailbox, MaybeRequestTimeout, |req| {
     match req.timeout {
         MaybeRequestTimeout::NoTimeout => {
             TellRequest {
@@ -368,37 +360,12 @@ impl_try_message_send!(local, UnboundedMailbox, MaybeRequestTimeout, |req| {
 ////////////////////////////////
 // === TryMessageSendSync === //
 ////////////////////////////////
-macro_rules! impl_try_message_send_sync {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryMessageSendSync
-            for TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = ();
-            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn try_send_sync(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_try_message_send_sync!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
+impl_message_trait!(local, => TryMessageSendSync::try_send_sync, BoundedMailbox, WithoutRequestTimeout, |req| {
     req.location.mailbox.0.try_send(req.location.signal)?;
     Ok(())
 });
 
-impl_try_message_send_sync!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
+impl_message_trait!(local, => TryMessageSendSync::try_send_sync, UnboundedMailbox, WithoutRequestTimeout, |req| {
     req.location.mailbox.0.send(req.location.signal)?;
     Ok(())
 });
@@ -406,77 +373,17 @@ impl_try_message_send_sync!(local, UnboundedMailbox, WithoutRequestTimeout, |req
 ////////////////////////////////
 // === BlockingMessageSend === //
 ////////////////////////////////
-macro_rules! impl_blocking_message_send {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> BlockingMessageSend
-            for TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = ();
-            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn blocking_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_blocking_message_send!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.blocking_send(req.location.signal)?;
-    Ok(())
-});
-
-impl_blocking_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
+impl_message_trait!(local, => BlockingMessageSend::blocking_send, WithoutRequestTimeout, |req| {
+    req.location.mailbox.blocking_send(req.location.signal)
+        .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))
 });
 
 ////////////////////////////////////
 // === TryBlockingMessageSend === //
 ////////////////////////////////////
-macro_rules! impl_try_blocking_message_send {
-    (local, $mailbox:ident, $timeout:ident, |$req:ident| $($body:tt)*) => {
-        impl<'a, A, M> TryBlockingMessageSend
-            for TellRequest<
-                LocalTellRequest<'a, A, $mailbox<A>>,
-                $mailbox<A>,
-                M,
-                $timeout,
-            >
-        where
-            A: Actor<Mailbox = $mailbox<A>> + Message<M>,
-            M: 'static,
-        {
-            type Ok = ();
-            type Error = error::SendError<M, <A::Reply as Reply>::Error>;
-
-            #[inline]
-            fn try_blocking_send(self) -> Result<Self::Ok, Self::Error> {
-                let $req = self;
-                $($body)*
-            }
-        }
-    };
-}
-
-impl_try_blocking_message_send!(local, BoundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.try_send(req.location.signal)?;
-    Ok(())
-});
-
-impl_try_blocking_message_send!(local, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
+impl_message_trait!(local, => TryBlockingMessageSend::try_blocking_send, WithoutRequestTimeout, |req| {
+    req.location.mailbox.try_send(req.location.signal)
+        .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))
 });
 
 #[cfg(feature = "remote")]
@@ -488,7 +395,7 @@ async fn remote_tell<A, M>(
 ) -> Result<(), error::RemoteSendError<<A::Reply as Reply>::Error>>
 where
     A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize,
+    M: serde::Serialize + Send + 'static,
     <A::Reply as Reply>::Error: for<'de> serde::Deserialize<'de>,
 {
     use remote::*;

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -360,14 +360,9 @@ impl_message_trait!(local, async => TryMessageSend::try_send, UnboundedMailbox, 
 ////////////////////////////////
 // === TryMessageSendSync === //
 ////////////////////////////////
-impl_message_trait!(local, => TryMessageSendSync::try_send_sync, BoundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.try_send(req.location.signal)?;
-    Ok(())
-});
-
-impl_message_trait!(local, => TryMessageSendSync::try_send_sync, UnboundedMailbox, WithoutRequestTimeout, |req| {
-    req.location.mailbox.0.send(req.location.signal)?;
-    Ok(())
+impl_message_trait!(local, => TryMessageSendSync::try_send_sync, WithoutRequestTimeout, |req| {
+    req.location.mailbox.try_send(req.location.signal)
+        .map_err(|err| err.map_msg(|signal| signal.downcast_message().unwrap()))
 });
 
 ////////////////////////////////


### PR DESCRIPTION
This PR relaxes the implementation of the mailbox for the following traits:
- `MessageSend` :: `send`
- `TryMessageSend` :: `try_send`
- `BlockingMessageSend` :: `blocking_send`
- `TryBlockingMessageSend` :: `try_blocking_send`

Previously, sending a message to a generic actor reference required explicitly specifying the mailbox type:
```rust
async fn send_message<A, M>(actor_ref: ActorRef<A>, msg: M)
where
    A: Actor + Message<M>,
    M: Send + 'static,
{
    let _ = actor_ref.tell(msg).send().await; // Error: `.send` isn't available here because the actor mailbox was not specified
}
```
To resolve this, the mailbox had to be declared as `A: Actor<Mailbox = BoundedMailbox<A>>`. However, this restricted flexibility when we wanted to support both bounded and unbounded mailboxes.

**With this PR, this code will now work seamlessly**, as the `MessageSend::send` method is now generic over any mailbox type. There's no longer a need to specify the mailbox. The only method that still requires a specified mailbox is `send_sync`, which is only applicable for **unbounded** tell requests.

The `Message` trait now requires `T` to implement `Send + 'static`. This is necessary because sending a message to an actor requires these bounds. Without this constraint, if a user writes `A: Actor + Message<M>` but forgets to specify `M: Send + 'static`, they'll encounter issues when messaging the actor, and the resulting error message won't clearly indicate what's missing.

Before this PR, specifying a generic actor capable of handling a message required a complex and verbose trait bound like this:

```rust
where
    for<'a> TellRequest<LocalTellRequest<'a, A, A::Mailbox>, A::Mailbox, M, T>:
        MessageSend<Ok = (), Error = SendError<M, <A::Reply as Reply>::Error>>,
```

You needed separate bounds for each message type, and for both tell and ask requests, which made the code unnecessarily verbose. This PR significantly improves the developer experience by simplifying these trait bounds, making Kameo much more ergonomic to use.

---

A nice resource for checking which requests types are supported when can be found here: https://docs.page/tqwewe/kameo/core-concepts/requests#request-methods

This PR fixes and relates to this discussion: https://github.com/tqwewe/kameo/discussions/38