### PR TITLE
feat!: add `on_message` hook to `Actor` trait

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -35,6 +35,8 @@ use futures::Future;
 use crate::{
     error::{ActorStopReason, PanicError},
     mailbox::Mailbox,
+    message::BoxMessage,
+    reply::{BoxReplySender, ReplyError},
 };
 
 pub use actor_ref::*;
@@ -93,6 +95,7 @@ pub use spawn::*;
 ///
 /// # Lifecycle Hooks
 /// - `on_start`: Called when the actor starts. This is where initialization happens.
+/// - `on_message`: Called when the actor receives a message to be processed.
 /// - `on_panic`: Called when the actor encounters a panic or an error while processing a "tell" message.
 /// - `on_stop`: Called before the actor is stopped. This allows for cleanup tasks.
 /// - `on_link_died`: Hook that is invoked when a linked actor dies.
@@ -125,6 +128,7 @@ pub trait Actor: Sized + Send + 'static {
     ///
     /// # Default Implementation
     /// By default, this returns the type name of the actor.
+    #[inline]
     fn name() -> &'static str {
         any::type_name::<Self>()
     }
@@ -135,6 +139,7 @@ pub trait Actor: Sized + Send + 'static {
     /// A tuple containing:
     /// - The created mailbox for sending messages.
     /// - The receiver for processing messages.
+    #[inline]
     fn new_mailbox() -> (Self::Mailbox, <Self::Mailbox as Mailbox<Self>>::Receiver) {
         Self::Mailbox::default_mailbox()
     }
@@ -146,11 +151,44 @@ pub trait Actor: Sized + Send + 'static {
     ///
     /// This ensures that the actor can properly initialize before handling external messages.
     #[allow(unused_variables)]
+    #[inline]
     fn on_start(
         &mut self,
         actor_ref: ActorRef<Self>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async { Ok(()) }
+    }
+
+    /// Called when the actor receives a message to be processed.
+    ///
+    /// By default, this method handles the incoming message immediately using the actor's standard message handling logic.
+    ///
+    /// Advanced use cases can override this method to customize how messages are processed, such as buffering messages for later processing or implementing custom scheduling.
+    ///
+    /// # Parameters
+    /// - `msg`: The incoming message, wrapped in a `BoxMessage<Self>`.
+    /// - `actor_ref`: A reference to the actor itself.
+    /// - `tx`: An optional reply sender, used when the message expects a response.
+    ///
+    /// # Returns
+    /// A future that resolves to `Result<(), BoxDebug>`. An `Ok(())` indicates successful processing, while an `Err` indicates an error occurred during message handling.
+    ///
+    /// # Default Implementation
+    /// The default implementation handles the message immediately by calling `msg.handle_dyn(self, actor_ref, tx).await`.
+    ///
+    /// # Notes
+    /// - Overriding this method allows you to intercept and manipulate messages before they are processed.
+    /// - Be cautious when buffering messages, as unbounded buffering can lead to increased memory usage.
+    /// - Custom implementations should ensure that messages are eventually handled or appropriately discarded to prevent message loss.
+    /// - The `tx` (reply sender) is tied to the specific `BoxMessage` it corresponds to, and passing an incorrect or mismatched `tx` can lead to a panic.
+    #[inline]
+    fn on_message(
+        &mut self,
+        msg: BoxMessage<Self>,
+        actor_ref: ActorRef<Self>,
+        tx: Option<BoxReplySender>,
+    ) -> impl Future<Output = Result<(), Box<dyn ReplyError>>> + Send {
+        async move { msg.handle_dyn(self, actor_ref, tx).await }
     }
 
     /// Called when the actor encounters a panic or an error during "tell" message handling.
@@ -165,6 +203,7 @@ pub trait Actor: Sized + Send + 'static {
     /// - `Some(ActorStopReason)`: Stops the actor.
     /// - `None`: Allows the actor to continue processing messages.
     #[allow(unused_variables)]
+    #[inline]
     fn on_panic(
         &mut self,
         actor_ref: WeakActorRef<Self>,
@@ -181,6 +220,7 @@ pub trait Actor: Sized + Send + 'static {
     /// # Returns
     /// Whether the actor should stop or continue processing messages.
     #[allow(unused_variables)]
+    #[inline]
     fn on_link_died(
         &mut self,
         actor_ref: WeakActorRef<Self>,
@@ -209,6 +249,7 @@ pub trait Actor: Sized + Send + 'static {
     /// # Parameters
     /// - `reason`: The reason why the actor is being stopped.
     #[allow(unused_variables)]
+    #[inline]
     fn on_stop(
         &mut self,
         actor_ref: WeakActorRef<Self>,

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -161,9 +161,11 @@ pub trait Actor: Sized + Send + 'static {
 
     /// Called when the actor receives a message to be processed.
     ///
-    /// By default, this method handles the incoming message immediately using the actor's standard message handling logic.
+    /// By default, this method handles the incoming message immediately using the
+    /// actor's standard message handling logic.
     ///
-    /// Advanced use cases can override this method to customize how messages are processed, such as buffering messages for later processing or implementing custom scheduling.
+    /// Advanced use cases can override this method to customize how messages are processed,
+    /// such as buffering messages for later processing or implementing custom scheduling.
     ///
     /// # Parameters
     /// - `msg`: The incoming message, wrapped in a `BoxMessage<Self>`.
@@ -171,16 +173,20 @@ pub trait Actor: Sized + Send + 'static {
     /// - `tx`: An optional reply sender, used when the message expects a response.
     ///
     /// # Returns
-    /// A future that resolves to `Result<(), BoxDebug>`. An `Ok(())` indicates successful processing, while an `Err` indicates an error occurred during message handling.
+    /// A future that resolves to `Result<(), BoxDebug>`. An `Ok(())` indicates successful processing,
+    /// while an `Err` indicates an error occurred during message handling.
     ///
     /// # Default Implementation
-    /// The default implementation handles the message immediately by calling `msg.handle_dyn(self, actor_ref, tx).await`.
+    /// The default implementation handles the message immediately by calling
+    /// `msg.handle_dyn(self, actor_ref, tx).await`.
     ///
     /// # Notes
     /// - Overriding this method allows you to intercept and manipulate messages before they are processed.
     /// - Be cautious when buffering messages, as unbounded buffering can lead to increased memory usage.
-    /// - Custom implementations should ensure that messages are eventually handled or appropriately discarded to prevent message loss.
-    /// - The `tx` (reply sender) is tied to the specific `BoxMessage` it corresponds to, and passing an incorrect or mismatched `tx` can lead to a panic.
+    /// - Custom implementations should ensure that messages are eventually handled or appropriately discarded to
+    ///   prevent message loss.
+    /// - The `tx` (reply sender) is tied to the specific `BoxMessage` it corresponds to,
+    ///   and passing an incorrect or mismatched `tx` can lead to a panic.
     #[inline]
     fn on_message(
         &mut self,

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -6,7 +6,7 @@ use crate::{
     actor::{Actor, ActorRef, WeakActorRef},
     error::{ActorStopReason, PanicError},
     mailbox::Signal,
-    message::DynMessage,
+    message::BoxMessage,
     reply::BoxReplySender,
 };
 
@@ -19,7 +19,7 @@ pub(crate) trait ActorState<A: Actor>: Sized {
 
     fn handle_message(
         &mut self,
-        message: Box<dyn DynMessage<A>>,
+        message: BoxMessage<A>,
         actor_ref: ActorRef<A>,
         reply: Option<BoxReplySender>,
         sent_within_actor: bool,
@@ -89,7 +89,7 @@ where
     #[inline]
     async fn handle_message(
         &mut self,
-        message: Box<dyn DynMessage<A>>,
+        message: BoxMessage<A>,
         actor_ref: ActorRef<A>,
         reply: Option<BoxReplySender>,
         sent_within_actor: bool,
@@ -105,12 +105,12 @@ where
             return None;
         }
 
-        let res = AssertUnwindSafe(message.handle_dyn(&mut self.state, actor_ref, reply))
+        let res = AssertUnwindSafe(self.state.on_message(message, actor_ref, reply))
             .catch_unwind()
             .await;
         match res {
-            Ok(None) => None,
-            Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))), // The reply was an error
+            Ok(Ok(())) => None,
+            Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))), // The reply was an error
             Err(err) => Some(ActorStopReason::Panicked(PanicError::new_from_panic_any(
                 err,
             ))), // The handler panicked

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 use crate::{
     actor::{ActorID, ActorRef},
     error::{ActorStopReason, SendError},
-    message::DynMessage,
+    message::BoxMessage,
     reply::BoxReplySender,
     Actor,
 };
@@ -73,7 +73,7 @@ pub trait WeakMailbox: SignalMailbox + Clone + Send + Sync {
 pub enum Signal<A: Actor> {
     StartupFinished,
     Message {
-        message: Box<dyn DynMessage<A>>,
+        message: BoxMessage<A>,
         actor_ref: ActorRef<A>,
         reply: Option<BoxReplySender>,
         sent_within_actor: bool,


### PR DESCRIPTION
This PR introduces a new `on_message` hook to the `Actor` trait.

### Overview:
The `on_message` method allows actors to customize how incoming messages are handled. By default, the method processes the message immediately using the actor’s standard message handling logic (`msg.handle_dyn`). However, this method is designed to offer flexibility for advanced use cases where immediate handling may not be ideal. For example, developers can override `on_message` to:
- Buffer messages for delayed processing.
- Implement custom scheduling or prioritization logic.
- Manipulate or filter raw messages before they are handled.

### Key Changes:
- **New `on_message` Method**: Handles the incoming message, with the option to override for custom processing behavior.
- **Default Behavior**: Processes the message using `msg.handle_dyn(self, actor_ref, tx).await`.
- **Advanced Use Cases**: Supports scenarios where buffering or deferring message handling is required.

This addition provides more control over how messages are processed, enhancing the flexibility of actor behavior in complex systems.