### PR TITLE
fix!: derive Reply macro now uses kameo Infallible instead of ()

### DIFF
--- a/macros/src/derive_reply.rs
+++ b/macros/src/derive_reply.rs
@@ -18,7 +18,7 @@ impl ToTokens for DeriveReply {
             #[automatically_derived]
             impl #impl_generics ::kameo::Reply for #ident #ty_generics #where_clause {
                 type Ok = Self;
-                type Error = ();
+                type Error = ::kameo::error::Infallible;
                 type Value = Self;
 
                 #[inline]


### PR DESCRIPTION
I believe the derive macro using `type Error = ()` was not intended? I was getting some annoying errors saying that the error did not implement `Display`, and this was the cause.

`std` types implement `Reply` with `kameo::error::Infallible`, so this PR changes the derive `Reply` macro to do the same.