### PR TITLE
feat!: add error type to Actor trait

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,6 +1,7 @@
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::error::Infallible;
 use kameo::mailbox::bounded::BoundedMailbox;
 use kameo::request::MessageSend;
 use kameo::{
@@ -12,6 +13,7 @@ struct FibActor {}
 
 impl Actor for FibActor {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 }
 
 struct Fib(u64);

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -1,5 +1,6 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::error::Infallible;
 use kameo::mailbox::unbounded::UnboundedMailbox;
 use kameo::request::MessageSend;
 use kameo::{
@@ -20,6 +21,7 @@ fn actor(c: &mut Criterion) {
 
     impl Actor for BenchActor {
         type Mailbox = UnboundedMailbox<Self>;
+        type Error = Infallible;
     }
 
     impl Message<u32> for BenchActor {

--- a/examples/ask.rs
+++ b/examples/ask.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use kameo::{
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
     request::MessageSendSync,
@@ -16,6 +17,7 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
     fn name() -> &'static str {
         "MyActor"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 use kameo::{
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
     request::MessageSendSync,
@@ -14,6 +15,7 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
     fn name() -> &'static str {
         "MyActor"

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -3,7 +3,7 @@ use std::{future::pending, time};
 use futures::stream;
 use kameo::{
     actor::ActorRef,
-    error::BoxError,
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message, StreamMessage},
     Actor,
@@ -19,8 +19,9 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         let stream = Box::pin(
             stream::repeat(1)
                 .take(5)

--- a/macros/src/derive_actor.rs
+++ b/macros/src/derive_actor.rs
@@ -50,6 +50,7 @@ impl ToTokens for DeriveActor {
             #[automatically_derived]
             impl #impl_generics ::kameo::actor::Actor for #ident #ty_generics #where_clause {
                 type Mailbox = #mailbox_expanded;
+                type Error = ::kameo::error::Infallible;
 
                 fn name() -> &'static str {
                     #name

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -66,15 +66,16 @@ pub use spawn::*;
 ///
 /// ```
 /// use kameo::actor::{Actor, ActorRef, WeakActorRef};
-/// use kameo::error::{ActorStopReason, BoxError};
+/// use kameo::error::{ActorStopReason, Infallible};
 /// use kameo::mailbox::unbounded::UnboundedMailbox;
 ///
 /// struct MyActor;
 ///
 /// impl Actor for MyActor {
 ///     type Mailbox = UnboundedMailbox<Self>;
+///     type Error = Infallible;
 ///
-///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Infallible> {
 ///         println!("actor started");
 ///         Ok(())
 ///     }
@@ -83,7 +84,7 @@ pub use spawn::*;
 ///         &mut self,
 ///         actor_ref: WeakActorRef<Self>,
 ///         reason: ActorStopReason,
-///     ) -> Result<(), BoxError> {
+///     ) -> Result<(), Infallible> {
 ///         println!("actor stopped");
 ///         Ok(())
 ///     }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -177,7 +177,7 @@ where
     /// use std::time::Duration;
     ///
     /// use kameo::actor::{Actor, ActorRef};
-    /// use kameo::error::BoxError;
+    /// use kameo::error::Infallible;
     /// use kameo::mailbox::unbounded::UnboundedMailbox;
     /// use tokio::time::sleep;
     ///
@@ -185,8 +185,9 @@ where
     ///
     /// impl Actor for MyActor {
     ///     type Mailbox = UnboundedMailbox<Self>;
+    ///     type Error = Infallible;
     ///
-    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Infallible> {
     ///         sleep(Duration::from_secs(2)).await; // Some io operation
     ///         Ok(())
     ///     }

--- a/src/actor/pool.rs
+++ b/src/actor/pool.rs
@@ -50,7 +50,7 @@ use itertools::repeat_n;
 
 use crate::{
     actor::{Actor, ActorRef},
-    error::{ActorStopReason, BoxError, SendError},
+    error::{ActorStopReason, Infallible, SendError},
     mailbox::bounded::BoundedMailbox,
     message::{BoxDebug, Context, Message},
     reply::Reply,
@@ -165,12 +165,13 @@ where
     A: Actor,
 {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 
     fn name() -> &'static str {
         "ActorPool"
     }
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         for worker in &self.workers {
             worker.link(&actor_ref).await;
         }
@@ -183,7 +184,7 @@ where
         actor_ref: WeakActorRef<Self>,
         id: ActorID,
         _reason: ActorStopReason,
-    ) -> Result<Option<ActorStopReason>, BoxError> {
+    ) -> Result<Option<ActorStopReason>, Self::Error> {
         let Some(actor_ref) = actor_ref.upgrade() else {
             return Ok(None);
         };

--- a/src/actor/pubsub.rs
+++ b/src/actor/pubsub.rs
@@ -49,7 +49,7 @@ use std::collections::HashMap;
 use futures::future::{join_all, BoxFuture};
 
 use crate::{
-    error::SendError,
+    error::{Infallible, SendError},
     mailbox::bounded::BoundedMailbox,
     message::{Context, Message},
     request::{LocalTellRequest, MessageSend, TellRequest, WithoutRequestTimeout},
@@ -166,6 +166,7 @@ impl<M> PubSub<M> {
 
 impl<M: 'static> Actor for PubSub<M> {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 }
 
 impl<M> Default for PubSub<M> {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -997,7 +997,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        error::SendError,
+        error::{Infallible, SendError},
         mailbox::{
             bounded::{BoundedMailbox, BoundedMailboxReceiver},
             unbounded::UnboundedMailbox,
@@ -1013,6 +1013,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -1060,6 +1061,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -1107,6 +1109,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1158,6 +1161,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1209,6 +1213,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -1256,6 +1261,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -1317,6 +1323,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1363,6 +1370,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -518,7 +518,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        error::SendError,
+        error::{Infallible, SendError},
         mailbox::{
             bounded::{BoundedMailbox, BoundedMailboxReceiver},
             unbounded::UnboundedMailbox,
@@ -537,6 +537,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -574,6 +575,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -608,6 +610,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -662,6 +665,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -720,6 +724,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -774,6 +779,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)


### PR DESCRIPTION
Related to https://github.com/tqwewe/kameo/issues/74

This PR adds an associated type `Error` to the Actor trait for better error handling.