### PR TITLE
refactor!: modularize features and improve conditional compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
-      - run: cargo build --features remote --verbose
+      - run: cargo build --no-default-features --verbose
+      - run: cargo build --no-default-features --features macros --verbose
+      - run: cargo build --no-default-features --features tracing --verbose
+      - run: cargo build --no-default-features --features remote --verbose
       - run: RUSTFLAGS="--cfg tokio_unstable" cargo build --verbose
       - run: cargo test --features remote --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,13 @@ categories = ["asynchronous", "concurrency", "rust-patterns"]
 keywords = ["actor", "tokio"]
 
 [features]
-remote = ["dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde", "dep:internment"]
+default = ["macros", "tracing"]
+macros = ["dep:kameo_macros"]
+remote = ["dep:internment", "dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:once_cell", "dep:rmp-serde"]
+tracing = ["dep:tracing", "tokio/tracing"]
 
 [dependencies]
-kameo_macros = { version = "0.13.0", path = "./macros" }
+kameo_macros = { version = "0.13.0", path = "./macros", optional = true }
 
 dyn-clone = "1.0"
 futures = "0.3"
@@ -33,12 +36,12 @@ internment = { version = "0.8.5", features = ["serde"], optional = true }
 libp2p = { version = "0.54.1", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"], optional = true }
 libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"], optional = true }
 linkme = { version= "0.3.28", optional = true }
-once_cell = "1.19"
+once_cell = { version = "1.19", optional = true }
 rmp-serde = { version = "1.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.37", features = ["macros", "rt", "sync", "time", "tracing"] }
+tokio = { version = "1.37", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = "0.1"
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -9,6 +9,7 @@ use tokio::{
     sync::Semaphore,
     task::JoinHandle,
 };
+#[cfg(feature = "tracing")]
 use tracing::{error, trace};
 
 use crate::{
@@ -285,6 +286,7 @@ where
 {
     let id = actor_ref.id();
     let name = A::name();
+    #[cfg(feature = "tracing")]
     trace!(%id, %name, "actor started");
 
     let start_res = AssertUnwindSafe(actor.on_start(actor_ref.clone()))
@@ -413,6 +415,7 @@ where
 }
 
 #[inline]
+#[cfg(feature = "tracing")]
 fn log_actor_stop_reason(id: ActorID, name: &str, reason: &ActorStopReason) {
     match reason {
         reason @ ActorStopReason::Normal
@@ -425,3 +428,6 @@ fn log_actor_stop_reason(id: ActorID, name: &str, reason: &ActorStopReason) {
         }
     }
 }
+
+#[cfg(not(feature = "tracing"))]
+fn log_actor_stop_reason(_id: ActorID, _name: &str, _reason: &ActorStopReason) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,6 @@ pub mod reply;
 pub mod request;
 
 pub use actor::{spawn, Actor};
+#[cfg(feature = "macros")]
 pub use kameo_macros::{messages, remote_message, Actor, RemoteActor, Reply};
 pub use reply::Reply;

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -21,6 +21,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
+#[cfg(feature = "tracing")]
 use tracing::trace;
 
 use crate::{
@@ -514,6 +515,7 @@ impl SwarmActor {
 
     fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent>) {
         match event {
+            #[cfg(feature = "tracing")]
             SwarmEvent::NewListenAddr { address, .. } => {
                 trace!("listening on {address:?}");
             }

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -99,7 +99,7 @@ impl<'a, A, M, Tm, Tr> AskRequest<LocalAskRequest<'a, A, A::Mailbox>, A::Mailbox
 where
     A: Actor,
 {
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, feature = "tracing"))]
     fn warn_deadlock(&self, msg: &'static str) {
         use tracing::warn;
 
@@ -112,6 +112,8 @@ where
             _ => {}
         }
     }
+    #[cfg(not(all(debug_assertions, feature = "tracing")))]
+    fn warn_deadlock(&self, _msg: &'static str) {}
 }
 
 #[cfg(feature = "remote")]
@@ -258,7 +260,6 @@ macro_rules! impl_message_trait {
 
             #[inline]
             $($async)? fn $method(self) -> Result<Self::Ok, Self::Error> {
-                #[cfg(debug_assertions)]
                 self.warn_deadlock("An actor is sending an `ask` request to itself, which will likely lead to a deadlock. To avoid this, use a `tell` request instead.");
 
                 let $req = self;


### PR DESCRIPTION
- Split features into `default`, `macros`, `tracing`, and `remote` for better modularity
- Make `kameo_macros`, `once_cell`, and `tracing` optional dependencies
- Add conditional compilation for `tracing`-related code to avoid unnecessary dependencies
- Update CI workflow to test builds with different feature combinations
- Fix deadlock warnings to only log when both `debug_assertions` and `tracing` are enabled