### PR TITLE
feat!: add local actor registry for non-remote environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["actor", "tokio"]
 [features]
 default = ["macros", "tracing"]
 macros = ["dep:kameo_macros"]
-remote = ["dep:internment", "dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:once_cell", "dep:rmp-serde"]
+remote = ["dep:internment", "dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde"]
 tracing = ["dep:tracing", "tokio/tracing"]
 
 [dependencies]
@@ -36,7 +36,7 @@ internment = { version = "0.8.5", features = ["serde"], optional = true }
 libp2p = { version = "0.54.1", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"], optional = true }
 libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"], optional = true }
 linkme = { version= "0.3.28", optional = true }
-once_cell = { version = "1.19", optional = true }
+once_cell = "1.19"
 rmp-serde = { version = "1.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "sync", "time"] }

--- a/docs/distributed-actors/registering-looking-up-actors.mdx
+++ b/docs/distributed-actors/registering-looking-up-actors.mdx
@@ -84,7 +84,7 @@ A simple retry loop can help ensure that your node eventually finds the actor, e
 use std::time::Duration;
 use tokio::time::sleep;
 
-async fn retry_lookup() -> Result<Option<RemoteActorRef<MyActor>>, RegistrationError> {
+async fn retry_lookup() -> Result<Option<RemoteActorRef<MyActor>>, RegistryError> {
     for _ in 0..5 {
         if let Some(actor) = RemoteActorRef::<MyActor>::lookup("my_actor").await? {
             return Ok(Some(actor));

--- a/examples/registry.rs
+++ b/examples/registry.rs
@@ -1,0 +1,16 @@
+use kameo::{actor::ActorRef, Actor};
+
+#[derive(Actor)]
+pub struct MyActor;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let actor_ref = kameo::spawn(MyActor);
+    actor_ref.register("my awesome actor")?;
+
+    let other_actor_ref = ActorRef::<MyActor>::lookup("my awesome actor")?.unwrap();
+
+    assert_eq!(actor_ref.id(), other_actor_ref.id());
+
+    Ok(())
+}

--- a/examples/registry.rs
+++ b/examples/registry.rs
@@ -1,14 +1,33 @@
 use kameo::{actor::ActorRef, Actor};
 
 #[derive(Actor)]
+#[cfg_attr(feature = "remote", derive(kameo::RemoteActor))]
 pub struct MyActor;
 
+#[cfg(not(feature = "remote"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let actor_ref = kameo::spawn(MyActor);
     actor_ref.register("my awesome actor")?;
 
     let other_actor_ref = ActorRef::<MyActor>::lookup("my awesome actor")?.unwrap();
+
+    assert_eq!(actor_ref.id(), other_actor_ref.id());
+
+    Ok(())
+}
+
+#[cfg(feature = "remote")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _swarm = kameo::remote::ActorSwarm::bootstrap()?;
+
+    let actor_ref = kameo::spawn(MyActor);
+    actor_ref.register("my awesome actor").await?;
+
+    let other_actor_ref = ActorRef::<MyActor>::lookup("my awesome actor")
+        .await?
+        .unwrap();
 
     assert_eq!(actor_ref.id(), other_actor_ref.id());
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -271,38 +271,41 @@ impl fmt::Display for BootstrapError {
 impl error::Error for BootstrapError {}
 
 /// An error that can occur when registering & looking up actors by name.
-#[cfg(feature = "remote")]
 #[derive(Clone, Debug)]
-pub enum RegistrationError {
+pub enum RegistryError {
     /// The actor swarm has not been bootstrapped.
+    #[cfg(feature = "remote")]
     SwarmNotBootstrapped,
     /// The remote actor was found given the ID, but was not the correct type.
     BadActorType,
     /// Quorum failed.
+    #[cfg(feature = "remote")]
     QuorumFailed {
         /// Required quorum.
         quorum: std::num::NonZero<usize>,
     },
     /// Timeout.
+    #[cfg(feature = "remote")]
     Timeout,
 }
 
-#[cfg(feature = "remote")]
-impl fmt::Display for RegistrationError {
+impl fmt::Display for RegistryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RegistrationError::SwarmNotBootstrapped => write!(f, "actor swarm not bootstrapped"),
-            RegistrationError::BadActorType => write!(f, "bad actor type"),
-            RegistrationError::QuorumFailed { quorum } => {
+            #[cfg(feature = "remote")]
+            RegistryError::SwarmNotBootstrapped => write!(f, "actor swarm not bootstrapped"),
+            RegistryError::BadActorType => write!(f, "bad actor type"),
+            #[cfg(feature = "remote")]
+            RegistryError::QuorumFailed { quorum } => {
                 write!(f, "the quorum failed; needed {quorum} peers")
             }
-            RegistrationError::Timeout => write!(f, "the request timed out"),
+            #[cfg(feature = "remote")]
+            RegistryError::Timeout => write!(f, "the request timed out"),
         }
     }
 }
 
-#[cfg(feature = "remote")]
-impl error::Error for RegistrationError {}
+impl error::Error for RegistryError {}
 
 /// Error that can occur when sending a message to an actor.
 #[cfg(feature = "remote")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod actor;
 pub mod error;
 pub mod mailbox;
 pub mod message;
+#[cfg(not(feature = "remote"))]
+pub mod registry;
 #[cfg(feature = "remote")]
 pub mod remote;
 pub mod reply;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,122 @@
+//! Local actor registry for registering and looking up actors by arbitrary names.
+
+use std::{
+    any::Any,
+    borrow::{Borrow, Cow},
+    collections::{hash_map::Keys, HashMap},
+    hash::Hash,
+    sync::{Arc, Mutex},
+};
+
+use once_cell::sync::Lazy;
+
+use crate::{actor::ActorRef, error::RegistryError, Actor};
+
+/// Global actor registry for local actors.
+pub static ACTOR_REGISTRY: Lazy<Arc<Mutex<ActorRegistry>>> =
+    Lazy::new(|| Arc::new(Mutex::new(ActorRegistry::new())));
+
+type AnyActorRef = Box<dyn Any + Send>;
+
+/// A local actor registry storing actor refs by name.
+#[derive(Debug)]
+pub struct ActorRegistry {
+    actor_refs: HashMap<Cow<'static, str>, AnyActorRef>,
+}
+
+impl ActorRegistry {
+    /// Creates a new empty actor registry.
+    pub fn new() -> Self {
+        ActorRegistry {
+            actor_refs: HashMap::new(),
+        }
+    }
+
+    /// Creates a new empty actor registry with at least the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        ActorRegistry {
+            actor_refs: HashMap::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the number of actor refs that can be held without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.actor_refs.capacity()
+    }
+
+    /// An iterator visiting all registered actor refs in arbitrary order.
+    pub fn names(&self) -> Keys<'_, Cow<'static, str>, AnyActorRef> {
+        self.actor_refs.keys()
+    }
+
+    /// The number of registered actor refs.
+    pub fn len(&self) -> usize {
+        self.actor_refs.len()
+    }
+
+    /// Returns `true` if the registry contains no actor refs.
+    pub fn is_empty(&self) -> bool {
+        self.actor_refs.is_empty()
+    }
+
+    /// Clears the registry, removing all actor refs. Keeps the allocated memory for reuse.
+    pub fn clear(&mut self) {
+        self.actor_refs.clear()
+    }
+
+    /// Gets an actor ref previously registered for a given actor type.
+    ///
+    /// If the actor type does not match the one it was registered with,
+    /// a [`RegistryError::BadActorType`] error will be returned.
+    pub fn get<A, Q>(&mut self, name: &Q) -> Result<Option<ActorRef<A>>, RegistryError>
+    where
+        A: Actor,
+        Q: Hash + Eq + ?Sized,
+        Cow<'static, str>: Borrow<Q>,
+    {
+        self.actor_refs
+            .get(name)
+            .map(|actor_ref| {
+                actor_ref
+                    .downcast_ref()
+                    .cloned()
+                    .ok_or(RegistryError::BadActorType)
+            })
+            .transpose()
+    }
+
+    /// Returns `true` if an actor has been registered under a given name.
+    pub fn contains_name<Q>(&self, name: &Q) -> bool
+    where
+        Q: Hash + Eq + ?Sized,
+        Cow<'static, str>: Borrow<Q>,
+    {
+        self.actor_refs.contains_key(name)
+    }
+
+    /// Inserts a new actor ref under a given name, which can be used later to be looked up.
+    pub fn insert<A: Actor>(
+        &mut self,
+        name: impl Into<Cow<'static, str>>,
+        actor_ref: ActorRef<A>,
+    ) -> bool {
+        self.actor_refs
+            .insert(name.into(), Box::new(actor_ref))
+            .is_some()
+    }
+
+    /// Removes a previously registered actor ref under a given name.
+    pub fn remove<Q>(&mut self, name: &Q) -> bool
+    where
+        Q: Hash + Eq + ?Sized,
+        Cow<'static, str>: Borrow<Q>,
+    {
+        self.actor_refs.remove(name).is_some()
+    }
+}
+
+impl Default for ActorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Adds actor lookup and register functionality for local environments.

Closes https://github.com/tqwewe/kameo/issues/105

See example:
https://github.com/tqwewe/kameo/blob/b5da4bdbd8927cc7a3021cc8e4e94bf6cbe8f68b/examples/registry.rs#L10-L15