### PR TITLE
feat: add `blocking_link` and `blocking_unlink` methods to `ActorRef`

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -403,6 +403,8 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```
+    ///
+    /// [`link`]: ActorRef::link
     #[inline]
     pub fn blocking_link<B: Actor>(&self, sibbling_ref: &ActorRef<B>) {
         if self.id == sibbling_ref.id() {
@@ -457,7 +459,8 @@ where
     /// Blockingly unlinks two previously linked sibling actors.
     ///
     /// This method is intended for use cases where you need to link actors in synchronous code.
-    /// For async contexts, [`link`] is preferred.
+    /// For async contexts, [`unlink`] is preferred.
+    ///
     ///
     /// # Example
     ///
@@ -481,6 +484,8 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```
+    ///
+    /// [`unlink`]: ActorRef::unlink
     #[inline]
     pub fn blocking_unlink<B>(&self, sibbling_ref: &ActorRef<B>)
     where

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -385,6 +385,8 @@ where
     /// # Example
     ///
     /// ```
+    /// # use std::thread;
+    /// #
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
     /// #
@@ -399,7 +401,9 @@ where
     /// let actor_ref = kameo::spawn(MyActor);
     /// let sibbling_ref = kameo::spawn(MyActor);
     ///
-    /// actor_ref.blocking_link(&sibbling_ref);
+    /// thread::spawn(move || {
+    ///     actor_ref.blocking_link(&sibbling_ref);
+    /// });
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```
@@ -465,6 +469,8 @@ where
     /// # Example
     ///
     /// ```
+    /// # use std::thread;
+    /// #
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
     /// #
@@ -479,8 +485,10 @@ where
     /// let actor_ref = kameo::spawn(MyActor);
     /// let sibbling_ref = kameo::spawn(MyActor);
     ///
-    /// actor_ref.blocking_link(&sibbling_ref);
-    /// actor_ref.blocking_unlink(&sibbling_ref);
+    /// thread::spawn(move || {
+    ///     actor_ref.blocking_link(&sibbling_ref);
+    ///     actor_ref.blocking_unlink(&sibbling_ref);
+    /// });
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```


### PR DESCRIPTION
Adds `blocking_link` and `blocking_unlink` variants for synchronous code.