### PR TITLE
feat!: add support for remote actor links

### DIFF
--- a/macros/src/derive_remote_actor.rs
+++ b/macros/src/derive_remote_actor.rs
@@ -2,17 +2,23 @@ use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    DeriveInput, Expr, ExprAssign, ExprLit, Ident, Lit, LitStr,
+    DeriveInput, Expr, ExprAssign, ExprLit, Generics, Ident, Lit, LitStr,
 };
 
 pub struct DeriveRemoteActor {
     attrs: DeriveRemoteActorAttrs,
+    generics: Generics,
     ident: Ident,
 }
 
 impl ToTokens for DeriveRemoteActor {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Self { attrs, ident } = self;
+        let Self {
+            attrs,
+            generics,
+            ident,
+        } = self;
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let id = match &attrs.id {
             Some(id) => quote! { #id },
@@ -23,9 +29,52 @@ impl ToTokens for DeriveRemoteActor {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            impl ::kameo::remote::RemoteActor for #ident {
+            impl #impl_generics ::kameo::remote::RemoteActor for #ident #ty_generics #where_clause {
                 const REMOTE_ID: &'static str = #id;
             }
+
+            const _: () = {
+                #[::kameo::remote::_internal::linkme::distributed_slice(
+                    ::kameo::remote::_internal::REMOTE_ACTORS
+                )]
+                #[linkme(crate = ::kameo::remote::_internal::linkme)]
+                static REG: (
+                    &'static str,
+                    ::kameo::remote::_internal::RemoteActorFns,
+                ) = (
+                    <#ident #ty_generics as ::kameo::remote::RemoteActor>::REMOTE_ID,
+                    ::kameo::remote::_internal::RemoteActorFns {
+                        link: (
+                            |
+                              actor_id: ::kameo::actor::ActorID,
+                              sibbling_id: ::kameo::actor::ActorID,
+                              sibbling_remote_id: ::std::borrow::Cow<'static, str>,
+                            | {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::link::<
+                                    #ident #ty_generics,
+                                >(
+                                    actor_id,
+                                    sibbling_id,
+                                    sibbling_remote_id,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteLinkFn,
+                        signal_link_died: (
+                            |
+                              dead_actor_id: ::kameo::actor::ActorID,
+                              notified_actor_id: ::kameo::actor::ActorID,
+                              stop_reason: kameo::error::ActorStopReason,
+                            | {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::signal_link_died::<
+                                    #ident #ty_generics,
+                                >(
+                                    dead_actor_id,
+                                    notified_actor_id,
+                                    stop_reason,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteSignalLinkDiedFn,
+                    },
+                );
+            };
         });
     }
 }
@@ -49,6 +98,7 @@ impl Parse for DeriveRemoteActor {
 
         Ok(DeriveRemoteActor {
             attrs: attrs.unwrap_or_default(),
+            generics: input.generics,
             ident,
         })
     }

--- a/macros/src/derive_remote_actor.rs
+++ b/macros/src/derive_remote_actor.rs
@@ -58,6 +58,18 @@ impl ToTokens for DeriveRemoteActor {
                                     sibbling_remote_id,
                                 ))
                             }) as ::kameo::remote::_internal::RemoteLinkFn,
+                        unlink: (
+                            |
+                              actor_id: ::kameo::actor::ActorID,
+                              sibbling_id: ::kameo::actor::ActorID,
+                            | {
+                                ::std::boxed::Box::pin(::kameo::remote::_internal::unlink::<
+                                    #ident #ty_generics,
+                                >(
+                                    actor_id,
+                                    sibbling_id,
+                                ))
+                            }) as ::kameo::remote::_internal::RemoteUnlinkFn,
                         signal_link_died: (
                             |
                               dead_actor_id: ::kameo::actor::ActorID,

--- a/macros/src/remote_message.rs
+++ b/macros/src/remote_message.rs
@@ -153,10 +153,6 @@ impl Parse for RemoteMessage {
                 "expected angle bracket arguments",
             ));
         };
-        // let mut trait_path_segments_iter = trait_path.segments.into_iter();
-        // let trait_ident = trait_path_segments_iter.next().ok_or_else(|| {
-        //     syn::Error::new(trait_path_span, "expected trait");
-        // });
 
         Ok(RemoteMessage {
             item_impl,

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -192,6 +192,8 @@ pub trait Actor: Sized + Send + 'static {
                     id,
                     reason: Box::new(reason),
                 })),
+                #[cfg(feature = "remote")]
+                ActorStopReason::PeerDisconnected => Ok(Some(ActorStopReason::PeerDisconnected)),
             }
         }
     }

--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -91,8 +91,8 @@ impl ActorID {
     ///
     /// An `Option<PeerId>`. `None` indicates a local actor.
     #[cfg(feature = "remote")]
-    pub fn peer_id(&self) -> Option<libp2p::PeerId> {
-        self.peer_id.map(|peer_id| *peer_id)
+    pub fn peer_id(&self) -> Option<&libp2p::PeerId> {
+        self.peer_id.as_deref()
     }
 
     /// Serializes the `ActorID` into a byte vector.

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -155,6 +155,8 @@ where
             ActorStopReason::LinkDied { id, reason } => {
                 Some(ActorStopReason::LinkDied { id, reason })
             }
+            #[cfg(feature = "remote")]
+            ActorStopReason::PeerDisconnected => Some(ActorStopReason::PeerDisconnected),
         }
     }
 

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -121,13 +121,15 @@ where
         id: ActorID,
         reason: ActorStopReason,
     ) -> Option<ActorStopReason> {
-        match AssertUnwindSafe(
-            self.state
-                .on_link_died(self.actor_ref.clone(), id, reason.clone()),
-        )
+        let res = AssertUnwindSafe(self.state.on_link_died(
+            self.actor_ref.clone(),
+            id,
+            reason.clone(),
+        ))
         .catch_unwind()
-        .await
-        {
+        .await;
+        self.actor_ref.links.lock().await.remove(&id);
+        match res {
             Ok(Ok(Some(reason))) => Some(reason),
             Ok(Ok(None)) => None,
             Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))),

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -362,7 +362,6 @@ where
                         let reason = reason.clone();
                         link_notificication_futures.push(
                             async move {
-                                println!("notifying {} that {} died", link_actor_id, id);
                                 let res = swarm
                                     .signal_link_died(
                                         id,
@@ -472,6 +471,10 @@ fn log_actor_stop_reason(id: ActorID, name: &str, reason: &ActorStopReason) {
         }
         reason @ ActorStopReason::Panicked(_) => {
             error!(%id, %name, %reason, "actor stopped")
+        }
+        #[cfg(feature = "remote")]
+        reason @ ActorStopReason::PeerDisconnected => {
+            trace!(%id, %name, %reason, "actor stopped");
         }
     }
 }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -380,6 +380,7 @@ where
                                     )
                                     .await;
                                 if let Err(err) = res {
+                                    #[cfg(feature = "tracing")]
                                     error!("failed to notify actor a link died: {err}");
                                 }
                             }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -12,6 +12,9 @@ use tokio::{
 #[cfg(feature = "tracing")]
 use tracing::{error, trace};
 
+#[cfg(feature = "remote")]
+use crate::remote;
+
 use crate::{
     actor::{
         kind::{ActorBehaviour, ActorState},
@@ -19,7 +22,6 @@ use crate::{
     },
     error::{ActorStopReason, PanicError, SendError},
     mailbox::{Mailbox, MailboxReceiver, Signal},
-    remote::{ActorSwarm, REMOTE_REGISTRY},
 };
 
 use super::ActorID;
@@ -291,6 +293,7 @@ where
     A: Actor,
     S: ActorState<A>,
 {
+    #[allow(unused_mut)]
     let mut id = actor_ref.id();
     let name = A::name();
     #[cfg(feature = "tracing")]
@@ -341,9 +344,13 @@ where
     let mut actor = state.shutdown().await;
 
     let mut link_notificication_futures = FuturesUnordered::new();
-    id = id.with_hydrate_peer_id();
+    #[cfg(feature = "remote")]
+    {
+        id = id.with_hydrate_peer_id();
+    }
     {
         let mut links = links.lock().await;
+        #[allow(unused_variables)]
         for (link_actor_id, link) in links.drain() {
             match link {
                 Link::Local(mailbox) => {
@@ -351,14 +358,16 @@ where
                     link_notificication_futures.push(
                         async move {
                             if let Err(err) = mailbox.signal_link_died(id, reason).await {
+                                #[cfg(feature = "tracing")]
                                 error!("failed to notify actor a link died: {err}");
                             }
                         }
                         .boxed(),
                     );
                 }
+                #[cfg(feature = "remote")]
                 Link::Remote(notified_actor_remote_id) => {
-                    if let Some(swarm) = ActorSwarm::get() {
+                    if let Some(swarm) = remote::ActorSwarm::get() {
                         let reason = reason.clone();
                         link_notificication_futures.push(
                             async move {
@@ -386,7 +395,8 @@ where
     log_actor_stop_reason(id, name, &reason);
 
     while let Some(()) = link_notificication_futures.next().await {}
-    REMOTE_REGISTRY.lock().await.remove(&id);
+    #[cfg(feature = "remote")]
+    remote::REMOTE_REGISTRY.lock().await.remove(&id);
 
     on_stop_res.unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -538,6 +538,9 @@ pub enum ActorStopReason {
         /// Actor died reason.
         reason: Box<ActorStopReason>,
     },
+    /// The peer was disconnected.
+    #[cfg(feature = "remote")]
+    PeerDisconnected,
 }
 
 impl fmt::Debug for ActorStopReason {
@@ -551,6 +554,8 @@ impl fmt::Debug for ActorStopReason {
                 .field("id", id)
                 .field("reason", &reason)
                 .finish(),
+            #[cfg(feature = "remote")]
+            ActorStopReason::PeerDisconnected => write!(f, "PeerDisconnected"),
         }
     }
 }
@@ -564,6 +569,8 @@ impl fmt::Display for ActorStopReason {
             ActorStopReason::LinkDied { id, reason: _ } => {
                 write!(f, "link {id} died")
             }
+            #[cfg(feature = "remote")]
+            ActorStopReason::PeerDisconnected => write!(f, "peer disconnected"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -318,7 +318,7 @@ pub enum RemoteSendError<E> {
     /// The actor's remote ID was not found.
     UnknownActor {
         /// The remote ID of the actor.
-        actor_remote_id: String,
+        actor_remote_id: std::borrow::Cow<'static, str>,
     },
     /// The message remote ID was not found for the actor.
     UnknownMessage {
@@ -346,6 +346,8 @@ pub enum RemoteSendError<E> {
     /// Failed to deserialize the handler error.
     DeserializeHandlerError(String),
 
+    /// The actor swarm has not been bootstrapped.
+    SwarmNotBootstrapped,
     /// The request could not be sent because a dialing attempt failed.
     DialFailure,
     /// The request timed out before a response was received.
@@ -358,6 +360,8 @@ pub enum RemoteSendError<E> {
     /// It is not known whether the request may have been
     /// received (and processed) by the remote peer.
     ConnectionClosed,
+    /// The remote supports none of the requested protocols.
+    UnsupportedProtocols,
     /// An IO failure happened on an outbound stream.
     #[serde(skip)]
     Io(Option<std::io::Error>),
@@ -396,9 +400,11 @@ impl<E> RemoteSendError<E> {
             RemoteSendError::DeserializeHandlerError(err) => {
                 RemoteSendError::DeserializeHandlerError(err)
             }
+            RemoteSendError::SwarmNotBootstrapped => RemoteSendError::SwarmNotBootstrapped,
             RemoteSendError::DialFailure => RemoteSendError::DialFailure,
             RemoteSendError::NetworkTimeout => RemoteSendError::NetworkTimeout,
             RemoteSendError::ConnectionClosed => RemoteSendError::ConnectionClosed,
+            RemoteSendError::UnsupportedProtocols => RemoteSendError::UnsupportedProtocols,
             RemoteSendError::Io(err) => RemoteSendError::Io(err),
         }
     }
@@ -441,9 +447,11 @@ impl<E> RemoteSendError<RemoteSendError<E>> {
             DeserializeHandlerError(err) | HandlerError(DeserializeHandlerError(err)) => {
                 RemoteSendError::DeserializeHandlerError(err)
             }
+            SwarmNotBootstrapped | HandlerError(SwarmNotBootstrapped) => SwarmNotBootstrapped,
             DialFailure | HandlerError(DialFailure) => DialFailure,
             NetworkTimeout | HandlerError(NetworkTimeout) => NetworkTimeout,
             ConnectionClosed | HandlerError(ConnectionClosed) => ConnectionClosed,
+            UnsupportedProtocols | HandlerError(UnsupportedProtocols) => UnsupportedProtocols,
             Io(err) | HandlerError(Io(err)) => Io(err),
         }
     }
@@ -500,9 +508,11 @@ where
             RemoteSendError::DeserializeHandlerError(err) => {
                 write!(f, "failed to deserialize handler error: {err}")
             }
+            RemoteSendError::SwarmNotBootstrapped => write!(f, "swarm not bootstrapped"),
             RemoteSendError::DialFailure => write!(f, "dial failure"),
             RemoteSendError::NetworkTimeout => write!(f, "network timeout"),
             RemoteSendError::ConnectionClosed => write!(f, "connection closed"),
+            RemoteSendError::UnsupportedProtocols => write!(f, "unsupported protocols"),
             RemoteSendError::Io(Some(err)) => err.fmt(f),
             RemoteSendError::Io(None) => write!(f, "io error"),
         }
@@ -513,7 +523,7 @@ where
 impl<E> error::Error for RemoteSendError<E> where E: fmt::Debug + fmt::Display {}
 
 /// Reason for an actor being stopped.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum ActorStopReason {
     /// Actor stopped normally.
     Normal,
@@ -645,6 +655,25 @@ impl fmt::Display for PanicError {
         })
         .ok()
         .unwrap_or_else(|| write!(f, "panicked"))
+    }
+}
+
+impl Serialize for PanicError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for PanicError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(PanicError::new(s))
     }
 }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -98,7 +98,7 @@ impl<A: Actor> Signal<A> {
 }
 
 #[doc(hidden)]
-pub trait SignalMailbox: DynClone + Send {
+pub trait SignalMailbox: DynClone + Send + Sync {
     fn signal_startup_finished(&self) -> Result<(), SendError>;
     fn signal_link_died(
         &self,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -114,9 +114,9 @@ static REMOTE_MESSAGES_MAP: Lazy<HashMap<RemoteMessageRegistrationID<'static>, R
 /// ## Example with Derive
 ///
 /// ```
-/// use kameo::RemoteActor;
+/// use kameo::{Actor, RemoteActor};
 ///
-/// #[derive(RemoteActor)]
+/// #[derive(Actor, RemoteActor)]
 /// pub struct MyActor;
 /// ```
 ///

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -209,6 +209,18 @@ pub(crate) async fn link(
     (fns.link)(actor_id, sibbling_id, sibbling_remote_id).await
 }
 
+pub(crate) async fn unlink(
+    actor_id: ActorID,
+    actor_remote_id: Cow<'static, str>,
+    sibbling_id: ActorID,
+) -> Result<(), RemoteSendError<Infallible>> {
+    let Some(fns) = REMOTE_ACTORS_MAP.get(&*actor_remote_id) else {
+        return Err(RemoteSendError::UnknownActor { actor_remote_id });
+    };
+
+    (fns.unlink)(actor_id, sibbling_id).await
+}
+
 pub(crate) async fn signal_link_died(
     dead_actor_id: ActorID,
     notified_actor_id: ActorID,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -62,8 +62,9 @@ use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 
 use crate::{
-    actor::ActorID,
+    actor::{ActorID, Links},
     error::{ActorStopReason, Infallible, RemoteSendError},
+    mailbox::SignalMailbox,
 };
 
 #[doc(hidden)]
@@ -72,8 +73,14 @@ mod swarm;
 
 pub use swarm::*;
 
-pub(crate) static REMOTE_REGISTRY: Lazy<Mutex<HashMap<ActorID, Box<dyn any::Any + Send + Sync>>>> =
+pub(crate) static REMOTE_REGISTRY: Lazy<Mutex<HashMap<ActorID, RemoteRegistryActorRef>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) struct RemoteRegistryActorRef {
+    pub(crate) actor_ref: Box<dyn any::Any + Send + Sync>,
+    pub(crate) signal_mailbox: Box<dyn SignalMailbox>,
+    pub(crate) links: Links,
+}
 
 static REMOTE_ACTORS_MAP: Lazy<HashMap<&'static str, RemoteActorFns>> = Lazy::new(|| {
     let mut existing_ids = HashSet::new();

--- a/src/remote/_internal.rs
+++ b/src/remote/_internal.rs
@@ -102,6 +102,7 @@ where
         remote_actors
             .get(&actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()
@@ -152,6 +153,7 @@ where
         remote_actors
             .get(&actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()
@@ -193,6 +195,7 @@ where
         remote_actors
             .get(&actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()
@@ -229,6 +232,7 @@ where
         remote_actors
             .get(&actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()
@@ -265,12 +269,11 @@ where
         remote_actors
             .get(&actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()
     };
-
-    println!("Handling link request {actor_id} <-> {sibbling_id}");
 
     actor_ref
         .links
@@ -289,13 +292,12 @@ pub async fn signal_link_died<A>(
 where
     A: Actor,
 {
-    println!("Signalling to {notified_actor_id} that {dead_actor_id} died");
-
     let actor_ref = {
         let remote_actors = REMOTE_REGISTRY.lock().await;
         remote_actors
             .get(&notified_actor_id)
             .ok_or(RemoteSendError::ActorNotRunning)?
+            .actor_ref
             .downcast_ref::<ActorRef<A>>()
             .ok_or(RemoteSendError::BadActorType)?
             .clone()

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -757,7 +757,6 @@ impl ActorSwarmHandler {
     ) {
         match event {
             ActorSwarmEvent::ConnectionClosed { peer_id, .. } => {
-                // TODO: Notify all actors which have links to this peer that the links have died
                 tokio::spawn(async move {
                     let mut futures = FuturesUnordered::new();
                     for RemoteRegistryActorRef {


### PR DESCRIPTION
Checklist:

- [x] Add linking from local to remote `ActorRef::link_remote(&RemoteActorRef<B>)`
- [x] Add linking from remote to remote `RemoteActorRef::link(&RemoteActorRef<B>)`
- [x] Add unlinking from local to remote `ActorRef::unlink_remote(&RemoteActorRef<B>)`
- [x] Add unlinking from remote to remote `RemoteActorRef::unlink(&RemoteActorRef<B>)`
- [x] Notify remote actors when an actor dies
- [x] Notify local actors when a peer connection is closed