### PR TITLE
refactor!: remove internment dependency and simplify peer ID handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["actor", "tokio"]
 [features]
 default = ["macros", "tracing"]
 macros = ["dep:kameo_macros"]
-remote = ["dep:internment", "dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde"]
+remote = ["dep:libp2p", "dep:libp2p-identity", "dep:linkme", "dep:rmp-serde"]
 tracing = ["dep:tracing", "tokio/tracing"]
 
 [dependencies]
@@ -32,7 +32,6 @@ kameo_macros = { version = "0.14.0", path = "./macros", optional = true }
 
 dyn-clone = "1.0"
 futures = "0.3"
-internment = { version = "0.8.5", features = ["serde"], optional = true }
 libp2p = { version = "0.55.0", features = ["cbor", "dns", "kad", "mdns", "macros", "quic", "request-response", "rsa", "serde", "tokio"], optional = true }
 libp2p-identity = { version = "0.2.9", features = ["rand", "rsa"], optional = true }
 linkme = { version= "0.3.28", optional = true }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -464,10 +464,7 @@ where
         );
         remote::ActorSwarm::get()
             .ok_or(RemoteSendError::SwarmNotBootstrapped)?
-            .link::<A, B>(
-                self.id.with_hydrate_peer_id(),
-                sibbling_ref.id.with_hydrate_peer_id(),
-            )
+            .link::<A, B>(self.id, sibbling_ref.id)
             .await
     }
 
@@ -574,10 +571,7 @@ where
         self.links.lock().await.remove(&sibbling_ref.id);
         remote::ActorSwarm::get()
             .ok_or(RemoteSendError::SwarmNotBootstrapped)?
-            .unlink::<B>(
-                self.id.with_hydrate_peer_id(),
-                sibbling_ref.id.with_hydrate_peer_id(),
-            )
+            .unlink::<B>(self.id, sibbling_ref.id)
             .await
     }
 

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -344,10 +344,6 @@ where
     let mut actor = state.shutdown().await;
 
     let mut link_notificication_futures = FuturesUnordered::new();
-    #[cfg(feature = "remote")]
-    {
-        id = id.with_hydrate_peer_id();
-    }
     {
         let mut links = links.lock().await;
         #[allow(unused_variables)]

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -3,7 +3,7 @@ use std::{future::IntoFuture, marker::PhantomData, time::Duration};
 use tokio::{sync::oneshot, time::timeout};
 
 #[cfg(feature = "remote")]
-use crate::remote::{ActorSwarm, RemoteActor, RemoteMessage, SwarmCommand, SwarmResponse};
+use crate::remote::{RemoteActor, RemoteMessage, SwarmCommand, SwarmResponse};
 
 use crate::{
     actor,
@@ -955,10 +955,9 @@ where
     let actor_id = actor_ref.id();
     let (reply_tx, reply_rx) = oneshot::channel();
     actor_ref.send_to_swarm(SwarmCommand::Ask {
-        peer_id: actor_id
-            .peer_id_intern()
-            .cloned()
-            .unwrap_or_else(|| *ActorSwarm::get().unwrap().local_peer_id_intern()),
+        peer_id: *actor_id
+            .peer_id()
+            .expect("actor swarm should be bootstrapped"),
         actor_id,
         actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
         message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -478,10 +478,9 @@ where
     let actor_id = actor_ref.id();
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     actor_ref.send_to_swarm(SwarmCommand::Tell {
-        peer_id: actor_id
-            .peer_id_intern()
-            .cloned()
-            .unwrap_or_else(|| *ActorSwarm::get().unwrap().local_peer_id_intern()),
+        peer_id: *actor_id
+            .peer_id()
+            .expect("actor swarm should be bootstrapped"),
         actor_id,
         actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
         message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),


### PR DESCRIPTION
Removes the use of interned peer ids, and instead simply references the actor swarm's peer ID whenever its needed. When serialized, the peer ID is included, so a deserialized peer ID should never be `local` if the actor swarm has been bootstrapped.

This also removes any need of "hydrating" actor IDs, which could be a potential cause for bugs if not used where it needs to be, and a performance issue if overused.