### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Kameo is not just for distributed applications; it's equally powerful for local 
 
 ### Installation
 
-Add kameo as a dependency in your `Cargo.toml` file:
+Add Kameo as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -343,7 +343,7 @@ where
 
     let mut actor = state.shutdown().await;
 
-    let mut link_notificication_futures = FuturesUnordered::new();
+    let mut link_notification_futures = FuturesUnordered::new();
     {
         let mut links = links.lock().await;
         #[allow(unused_variables)]
@@ -351,7 +351,7 @@ where
             match link {
                 Link::Local(mailbox) => {
                     let reason = reason.clone();
-                    link_notificication_futures.push(
+                    link_notification_futures.push(
                         async move {
                             if let Err(err) = mailbox.signal_link_died(id, reason).await {
                                 #[cfg(feature = "tracing")]
@@ -365,7 +365,7 @@ where
                 Link::Remote(notified_actor_remote_id) => {
                     if let Some(swarm) = remote::ActorSwarm::get() {
                         let reason = reason.clone();
-                        link_notificication_futures.push(
+                        link_notification_futures.push(
                             async move {
                                 let res = swarm
                                     .signal_link_died(
@@ -391,7 +391,7 @@ where
     let on_stop_res = actor.on_stop(actor_ref, reason.clone()).await;
     log_actor_stop_reason(id, name, &reason);
 
-    while let Some(()) = link_notificication_futures.next().await {}
+    while let Some(()) = link_notification_futures.next().await {}
     #[cfg(feature = "remote")]
     remote::REMOTE_REGISTRY.lock().await.remove(&id);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -594,7 +594,7 @@ impl PanicError {
         PanicError(Arc::new(Mutex::new(err)))
     }
 
-    /// Calls the passed closure `f` with an option containing the boxed any type downcasted into a `Cow<'static, str>`,
+    /// Calls the passed closure `f` with an option containing the boxed any type downcast into a `Cow<'static, str>`,
     /// or `None` if it's not a string type.
     pub fn with_str<F, R>(
         &self,
@@ -611,7 +611,7 @@ impl PanicError {
         })
     }
 
-    /// Calls the passed closure `f` with the inner type downcasted into `T`, otherwise returns `None`.
+    /// Calls the passed closure `f` with the inner type downcast into `T`, otherwise returns `None`.
     pub fn with_downcast_ref<T, F, R>(
         &self,
         f: F,
@@ -646,13 +646,13 @@ impl fmt::Display for PanicError {
                 return write!(f, "panicked: {s}");
             }
 
-            // Types are `BoxError` if the panic occured because of an actor hook returning an error
+            // Types are `BoxError` if the panic occurred because of an actor hook returning an error
             let box_err = any.downcast_ref::<BoxError>();
             if let Some(err) = box_err {
                 return write!(f, "panicked: {err}");
             }
 
-            // Types are `BoxDebug` if the panic occured as a result of a `tell` message returning an error
+            // Types are `BoxDebug` if the panic occurred as a result of a `tell` message returning an error
             let box_err = any.downcast_ref::<BoxDebug>();
             if let Some(err) = box_err {
                 return write!(f, "panicked: {:?}", Err::<(), _>(err));

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -55,7 +55,7 @@ pub trait MailboxReceiver<A: Actor>: Send + 'static {
     fn recv(&mut self) -> impl Future<Output = Option<Signal<A>>> + Send + '_;
 }
 
-/// A weak mailbox which can be upraded.
+/// A weak mailbox which can be upgraded.
 pub trait WeakMailbox: SignalMailbox + Clone + Send + Sync {
     /// Strong mailbox type.
     type StrongMailbox;

--- a/src/mailbox/bounded.rs
+++ b/src/mailbox/bounded.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{Mailbox, MailboxReceiver, Signal, SignalMailbox, WeakMailbox};
 
-/// An unbounded mailbox, where the sending messages to a full mailbox causes backpressure.
+/// A bounded mailbox, where sending messages to a full mailbox causes backpressure.
 pub struct BoundedMailbox<A: Actor>(pub(crate) mpsc::Sender<Signal<A>>);
 
 impl<A: Actor> BoundedMailbox<A> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
-//! Messaging infrastructure for actor communication in kameo.
+//! Messaging infrastructure for actor communication in Kameo.
 //!
-//! This module provides the constructs necessary for handling messages within kameo,
+//! This module provides the constructs necessary for handling messages within Kameo,
 //! defining how actors communicate and interact. It equips actors with the ability to receive and respond
 //! to both commands that might change their internal state and requests for information which do not alter their state.
 //!
@@ -101,7 +101,7 @@ where
     /// is a marker type indicating that the message handler will delegate the task of replying to another part of the
     /// system. It should be returned by the message handler to signify this intention. The `ReplySender`, if present,
     /// should be used to actually send the response back to the caller. The `ReplySender` will not be present if the
-    /// message was sent as a "tell" request (no repsonse is needed by the caller).
+    /// message was sent as a "tell" request (no response is needed by the caller).
     ///
     /// # Usage
     ///

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -1,4 +1,4 @@
-//! Constructs for handling replies and errors in kameo's actor communication.
+//! Constructs for handling replies and errors in Kameo's actor communication.
 //!
 //! This module provides the [`Reply`] trait and associated structures for managing message replies within the actor
 //! system. It enables actors to communicate effectively, handling both successful outcomes and errors through a
@@ -6,7 +6,7 @@
 //!
 //! **Reply Trait Overview**
 //!
-//! The `Reply` trait plays a crucial role in kameo by defining how actors respond to messages.
+//! The `Reply` trait plays a crucial role in Kameo by defining how actors respond to messages.
 //! It is implemented for a variety of common types, facilitating easy adoption and use.
 //! Special attention is given to the `Result` and [`DelegatedReply`] types:
 //! - Implementations for `Result` allow errors returned by actor handlers to be communicated back as
@@ -49,20 +49,20 @@ use crate::{
     message::{BoxDebug, BoxReply},
 };
 
-/// A boxed reply sender which will be downcasted to the correct type when receiving a reply.
+/// A boxed reply sender which will be downcast to the correct type when receiving a reply.
 ///
 /// This is reserved for advanced use cases, and misuse of this can result in panics.
 pub type BoxReplySender = oneshot::Sender<Result<BoxReply, BoxSendError>>;
 
-/// A deligated reply that has been forwarded to another actor.
+/// A delegated reply that has been forwarded to another actor.
 pub type ForwardedReply<T, M, E = ()> = DelegatedReply<Result<T, SendError<M, E>>>;
 
 /// A reply value.
 ///
-/// If an Err is returned by a handler, and is unhandled by the caller (ie, the message was sent asyncronously with `tell`),
+/// If an Err is returned by a handler, and is unhandled by the caller (ie, the message was sent asynchronously with `tell`),
 /// then the error is treated as a panic in the actor.
 ///
-/// This is implemented for all many std lib types, and can be implemented on custom types manually or with the derive
+/// This is implemented for all std lib types, and can be implemented on custom types manually or with the derive
 /// macro.
 ///
 /// # Example
@@ -138,7 +138,7 @@ where
 
 /// A mechanism for sending replies back to the original requester in a message exchange.
 ///
-/// `ReplySender` encapsulates the functionality to send a response back to whereever
+/// `ReplySender` encapsulates the functionality to send a response back to wherever
 /// a request was initiated. It is typically used in scenarios where the
 /// processing of a request is delegated to another actor within the system.
 /// Upon completion of the request handling, `ReplySender` is used to send the result back,

--- a/src/request.rs
+++ b/src/request.rs
@@ -104,7 +104,7 @@ pub trait TryMessageSendSync {
     /// Error value.
     type Error;
 
-    /// Attemps to send a message synchronously without waiting for mailbox capacity.
+    /// Attempts to send a message synchronously without waiting for mailbox capacity.
     fn try_send_sync(self) -> Result<Self::Ok, Self::Error>;
 }
 


### PR DESCRIPTION
I was snooping through the docs and code base to get a better understanding of Kameo and fixed a couple typos along the way.