### PR TITLE
feat!: add `unregister` method to `ActorSwarm`

### DIFF
--- a/examples/manual_swarm.rs
+++ b/examples/manual_swarm.rs
@@ -337,4 +337,12 @@ impl SwarmBehaviour for CustomBehaviour {
     fn kademlia_put_record_local(&mut self, record: kad::Record) -> Result<(), kad::store::Error> {
         self.kademlia.store_mut().put(record)
     }
+
+    fn kademlia_remove_record(&mut self, key: &kad::RecordKey) {
+        self.kademlia.remove_record(key);
+    }
+
+    fn kademlia_remove_record_local(&mut self, key: &kad::RecordKey) {
+        self.kademlia.store_mut().remove(key);
+    }
 }


### PR DESCRIPTION
Adds a method to unregister actors under a given name.

Internally, this pushes a "tombstone" record to the DHT, and locally the record is deleted. After some time (at most 24 hours by default), the tombstone should be removed from the DHT.