### PR TITLE
feat!: use anyhow for actor error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = "0.1"
 tracing = { version = "0.1", optional = true }
+anyhow = "1.0.97"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,6 +1,7 @@
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::error::Infallible;
 use kameo::mailbox::bounded::BoundedMailbox;
 use kameo::request::MessageSend;
 use kameo::{
@@ -12,6 +13,7 @@ struct FibActor {}
 
 impl Actor for FibActor {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 }
 
 struct Fib(u64);

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -1,5 +1,6 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
+use kameo::error::Infallible;
 use kameo::mailbox::unbounded::UnboundedMailbox;
 use kameo::request::MessageSend;
 use kameo::{
@@ -20,6 +21,7 @@ fn actor(c: &mut Criterion) {
 
     impl Actor for BenchActor {
         type Mailbox = UnboundedMailbox<Self>;
+        type Error = Infallible;
     }
 
     impl Message<u32> for BenchActor {

--- a/docs/core-concepts/actors.mdx
+++ b/docs/core-concepts/actors.mdx
@@ -52,8 +52,9 @@ struct MyActor;
 
 impl Actor for MyActor {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         println!("Actor started");
         Ok(())
     }

--- a/examples/ask.rs
+++ b/examples/ask.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use kameo::{
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
     request::MessageSendSync,
@@ -16,6 +17,7 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
     fn name() -> &'static str {
         "MyActor"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,7 @@
+use std::num::ParseIntError;
+
 use kameo::{
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message},
     request::MessageSendSync,
@@ -14,6 +17,7 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
     fn name() -> &'static str {
         "MyActor"
@@ -38,14 +42,14 @@ impl Message<Inc> for MyActor {
 pub struct ForceErr;
 
 impl Message<ForceErr> for MyActor {
-    type Reply = Result<(), i32>;
+    type Reply = Result<i32, ParseIntError>;
 
     async fn handle(
         &mut self,
         _msg: ForceErr,
         _ctx: Context<'_, Self, Self::Reply>,
     ) -> Self::Reply {
-        Err(3)
+        "invalid int".parse()
     }
 }
 

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, num::ParseIntError};
 
 use kameo::{messages, request::MessageSendSync, Actor};
 use tracing::info;
@@ -22,8 +22,8 @@ impl MyActor {
     }
 
     #[message]
-    fn force_err(&self) -> Result<(), i32> {
-        Err(3)
+    fn force_err(&self) -> Result<i32, ParseIntError> {
+        "invalid int".parse()
     }
 
     /// Prints a message

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -3,7 +3,7 @@ use std::{future::pending, time};
 use futures::stream;
 use kameo::{
     actor::ActorRef,
-    error::BoxError,
+    error::Infallible,
     mailbox::unbounded::UnboundedMailbox,
     message::{Context, Message, StreamMessage},
     Actor,
@@ -19,8 +19,9 @@ pub struct MyActor {
 
 impl Actor for MyActor {
     type Mailbox = UnboundedMailbox<Self>;
+    type Error = Infallible;
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         let stream = Box::pin(
             stream::repeat(1)
                 .take(5)

--- a/macros/src/derive_actor.rs
+++ b/macros/src/derive_actor.rs
@@ -50,6 +50,7 @@ impl ToTokens for DeriveActor {
             #[automatically_derived]
             impl #impl_generics ::kameo::actor::Actor for #ident #ty_generics #where_clause {
                 type Mailbox = #mailbox_expanded;
+                type Error = ::kameo::error::Infallible;
 
                 fn name() -> &'static str {
                     #name

--- a/macros/src/derive_reply.rs
+++ b/macros/src/derive_reply.rs
@@ -27,7 +27,7 @@ impl ToTokens for DeriveReply {
                 }
 
                 #[inline]
-                fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + 'static>> {
+                fn into_anyhow_err(self) -> ::std::option::Option<::kameo::error::AnyhowError> {
                     ::std::option::Option::None
                 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -28,12 +28,12 @@ pub mod pool;
 pub mod pubsub;
 mod spawn;
 
-use std::any;
+use std::{any, error};
 
 use futures::Future;
 
 use crate::{
-    error::{ActorStopReason, BoxError, PanicError},
+    error::{ActorStopReason, PanicError},
     mailbox::Mailbox,
 };
 
@@ -49,7 +49,7 @@ pub use spawn::*;
 /// The actor runs within its own task and processes messages asynchronously from a mailbox.
 /// Each actor can be linked to others, allowing for robust supervision and failure recovery mechanisms.
 ///
-/// Methods in this trait that return [`BoxError`] will cause the actor to stop with the reason
+/// Methods in this trait that return [`Actor::Error`] will cause the actor to stop with the reason
 /// [`ActorStopReason::Panicked`] if an error occurs. This enables graceful handling of actor panics
 /// or errors.
 ///
@@ -66,15 +66,16 @@ pub use spawn::*;
 ///
 /// ```
 /// use kameo::actor::{Actor, ActorRef, WeakActorRef};
-/// use kameo::error::{ActorStopReason, BoxError};
+/// use kameo::error::{ActorStopReason, Infallible};
 /// use kameo::mailbox::unbounded::UnboundedMailbox;
 ///
 /// struct MyActor;
 ///
 /// impl Actor for MyActor {
 ///     type Mailbox = UnboundedMailbox<Self>;
+///     type Error = Infallible;
 ///
-///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
 ///         println!("actor started");
 ///         Ok(())
 ///     }
@@ -83,7 +84,7 @@ pub use spawn::*;
 ///         &mut self,
 ///         actor_ref: WeakActorRef<Self>,
 ///         reason: ActorStopReason,
-///     ) -> Result<(), BoxError> {
+///     ) -> Result<(), Self::Error> {
 ///         println!("actor stopped");
 ///         Ok(())
 ///     }
@@ -117,6 +118,9 @@ pub trait Actor: Sized + Send + 'static {
     /// - **Unbounded Mailbox**: Allows an infinite number of messages, but can consume large amounts of memory.
     type Mailbox: Mailbox<Self>;
 
+    /// The actor's error type.
+    type Error: error::Error + Send + Sync + 'static;
+
     /// The name of the actor, which can be useful for logging or debugging.
     ///
     /// # Default Implementation
@@ -145,7 +149,7 @@ pub trait Actor: Sized + Send + 'static {
     fn on_start(
         &mut self,
         actor_ref: ActorRef<Self>,
-    ) -> impl Future<Output = Result<(), BoxError>> + Send {
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async { Ok(()) }
     }
 
@@ -165,7 +169,7 @@ pub trait Actor: Sized + Send + 'static {
         &mut self,
         actor_ref: WeakActorRef<Self>,
         err: PanicError,
-    ) -> impl Future<Output = Result<Option<ActorStopReason>, BoxError>> + Send {
+    ) -> impl Future<Output = Result<Option<ActorStopReason>, Self::Error>> + Send {
         async move { Ok(Some(ActorStopReason::Panicked(err))) }
     }
 
@@ -182,7 +186,7 @@ pub trait Actor: Sized + Send + 'static {
         actor_ref: WeakActorRef<Self>,
         id: ActorID,
         reason: ActorStopReason,
-    ) -> impl Future<Output = Result<Option<ActorStopReason>, BoxError>> + Send {
+    ) -> impl Future<Output = Result<Option<ActorStopReason>, Self::Error>> + Send {
         async move {
             match &reason {
                 ActorStopReason::Normal => Ok(None),
@@ -209,7 +213,7 @@ pub trait Actor: Sized + Send + 'static {
         &mut self,
         actor_ref: WeakActorRef<Self>,
         reason: ActorStopReason,
-    ) -> impl Future<Output = Result<(), BoxError>> + Send {
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async { Ok(()) }
     }
 }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -207,7 +207,7 @@ where
     /// use std::time::Duration;
     ///
     /// use kameo::actor::{Actor, ActorRef};
-    /// use kameo::error::BoxError;
+    /// use kameo::error::Infallible;
     /// use kameo::mailbox::unbounded::UnboundedMailbox;
     /// use tokio::time::sleep;
     ///
@@ -215,8 +215,9 @@ where
     ///
     /// impl Actor for MyActor {
     ///     type Mailbox = UnboundedMailbox<Self>;
+    ///     type Error = Infallible;
     ///
-    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), BoxError> {
+    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     ///         sleep(Duration::from_secs(2)).await; // Some io operation
     ///         Ok(())
     ///     }

--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -245,7 +245,7 @@ impl Hash for PeerIdKind {
 
 #[cfg(test)]
 mod tests {
-    use std::hash::DefaultHasher;
+    use std::hash::{DefaultHasher, Hasher};
 
     #[cfg(feature = "remote")]
     use libp2p::PeerId;

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -111,7 +111,10 @@ where
         match res {
             Ok(None) => None,
             Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))), // The reply was an error
-            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))), // The handler panicked
+            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_from_panic_any(
+                err,
+                "panicked while handling message",
+            ))), // The handler panicked
         }
     }
 
@@ -132,8 +135,13 @@ where
         match res {
             Ok(Ok(Some(reason))) => Some(reason),
             Ok(Ok(None)) => None,
-            Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))),
-            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))),
+            Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(
+                anyhow::Error::new(err),
+            ))),
+            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_from_panic_any(
+                err,
+                "panicked while handling link died",
+            ))),
         }
     }
 
@@ -151,7 +159,9 @@ where
                 match self.state.on_panic(self.actor_ref.clone(), err).await {
                     Ok(Some(reason)) => Some(reason),
                     Ok(None) => None,
-                    Err(err) => Some(ActorStopReason::Panicked(PanicError::new(err))),
+                    Err(err) => Some(ActorStopReason::Panicked(PanicError::new(
+                        anyhow::Error::new(err),
+                    ))),
                 }
             }
             ActorStopReason::LinkDied { id, reason } => {

--- a/src/actor/pubsub.rs
+++ b/src/actor/pubsub.rs
@@ -50,7 +50,7 @@ use std::collections::HashMap;
 use futures::future::{join_all, BoxFuture};
 
 use crate::{
-    error::SendError,
+    error::{Infallible, SendError},
     mailbox::bounded::BoundedMailbox,
     message::{Context, Message},
     request::{LocalTellRequest, MessageSend, TellRequest, WithoutRequestTimeout},
@@ -222,6 +222,7 @@ impl<M> PubSub<M> {
 
 impl<M: 'static> Actor for PubSub<M> {
     type Mailbox = BoundedMailbox<Self>;
+    type Error = Infallible;
 }
 
 impl<M> Default for PubSub<M> {

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -302,8 +302,8 @@ where
     let start_res = AssertUnwindSafe(actor.on_start(actor_ref.clone()))
         .catch_unwind()
         .await
-        .map(|res| res.map_err(PanicError::new))
-        .map_err(PanicError::new_boxed)
+        .map(|res| res.map_err(|err| PanicError::new(anyhow::Error::new(err))))
+        .map_err(|err| PanicError::new_from_panic_any(err, "panicked while starting"))
         .and_then(convert::identity);
 
     let mut startup_finished = false;

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -992,7 +992,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        error::SendError,
+        error::{Infallible, SendError},
         mailbox::{
             bounded::{BoundedMailbox, BoundedMailboxReceiver},
             unbounded::UnboundedMailbox,
@@ -1008,6 +1008,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -1053,6 +1054,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -1098,6 +1100,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1149,6 +1152,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1200,6 +1204,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -1247,6 +1252,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -1308,6 +1314,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1354,6 +1361,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -513,7 +513,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        error::SendError,
+        error::{Infallible, SendError},
         mailbox::{
             bounded::{BoundedMailbox, BoundedMailboxReceiver},
             unbounded::UnboundedMailbox,
@@ -532,6 +532,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -569,6 +570,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         struct Msg;
@@ -603,6 +605,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -657,6 +660,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = UnboundedMailbox<Self>;
+            type Error = Infallible;
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -715,6 +719,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)
@@ -769,6 +774,7 @@ mod tests {
 
         impl Actor for MyActor {
             type Mailbox = BoundedMailbox<Self>;
+            type Error = Infallible;
 
             fn new_mailbox() -> (BoundedMailbox<Self>, BoundedMailboxReceiver<Self>) {
                 BoundedMailbox::new(1)


### PR DESCRIPTION
Adds a new `type Error` associated type to the `Actor` trait, and internally uses `anyhow::Error` for better error handling.

Downcasting can be done to downcast errors to their concrete types using `PanicError::with_downcast_ref(|err: &MyError| { ... })`. Previously, this wasn't working, and errors could only be downcasted into `Box<dyn fmt::Debug + Send + 'static>`.