### PR TITLE
feat!: add `ReplyError` trait for better `PanicError` downcasting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = "0.1"
 tracing = { version = "0.1", optional = true }
+mopa-maintained = "0.2.3"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/macros/src/derive_reply.rs
+++ b/macros/src/derive_reply.rs
@@ -27,7 +27,7 @@ impl ToTokens for DeriveReply {
                 }
 
                 #[inline]
-                fn into_any_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::any::Any + ::std::marker::Send>> {
+                fn into_any_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::kameo::reply::ReplyError>> {
                     ::std::option::Option::None
                 }
 

--- a/macros/src/derive_reply.rs
+++ b/macros/src/derive_reply.rs
@@ -27,7 +27,7 @@ impl ToTokens for DeriveReply {
                 }
 
                 #[inline]
-                fn into_boxed_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::fmt::Debug + ::std::marker::Send + 'static>> {
+                fn into_any_err(self) -> ::std::option::Option<::std::boxed::Box<dyn ::std::any::Any + ::std::marker::Send>> {
                     ::std::option::Option::None
                 }
 

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -110,8 +110,10 @@ where
             .await;
         match res {
             Ok(None) => None,
-            Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))), // The reply was an error
-            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))), // The handler panicked
+            Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))), // The reply was an error
+            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_from_panic_any(
+                err,
+            ))), // The handler panicked
         }
     }
 
@@ -132,8 +134,10 @@ where
         match res {
             Ok(Ok(Some(reason))) => Some(reason),
             Ok(Ok(None)) => None,
-            Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))),
-            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))),
+            Ok(Err(err)) => Some(ActorStopReason::Panicked(PanicError::new(Box::new(err)))),
+            Err(err) => Some(ActorStopReason::Panicked(PanicError::new_from_panic_any(
+                err,
+            ))),
         }
     }
 
@@ -151,7 +155,7 @@ where
                 match self.state.on_panic(self.actor_ref.clone(), err).await {
                     Ok(Some(reason)) => Some(reason),
                     Ok(None) => None,
-                    Err(err) => Some(ActorStopReason::Panicked(PanicError::new(err))),
+                    Err(err) => Some(ActorStopReason::Panicked(PanicError::new(Box::new(err)))),
                 }
             }
             ActorStopReason::LinkDied { id, reason } => {

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -110,7 +110,7 @@ where
             .await;
         match res {
             Ok(None) => None,
-            Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new(err))), // The reply was an error
+            Ok(Some(err)) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))), // The reply was an error
             Err(err) => Some(ActorStopReason::Panicked(PanicError::new_boxed(err))), // The handler panicked
         }
     }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -302,8 +302,8 @@ where
     let start_res = AssertUnwindSafe(actor.on_start(actor_ref.clone()))
         .catch_unwind()
         .await
-        .map(|res| res.map_err(PanicError::new))
-        .map_err(PanicError::new_boxed)
+        .map(|res| res.map_err(|err| PanicError::new(Box::new(err))))
+        .map_err(PanicError::new_from_panic_any)
         .and_then(convert::identity);
 
     let mut startup_finished = false;

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ use tokio::{
     time::error::Elapsed,
 };
 
-use crate::{actor::ActorID, mailbox::Signal, message::BoxDebug, Actor};
+use crate::{actor::ActorID, mailbox::Signal, Actor};
 
 /// A dyn boxed error.
 pub type BoxError = Box<dyn error::Error + Send + Sync + 'static>;
@@ -594,7 +594,7 @@ impl PanicError {
         PanicError(Arc::new(Mutex::new(err)))
     }
 
-    /// Calls the passed closure `f` with an option containing the boxed any type downcast into a `Cow<'static, str>`,
+    /// Calls the passed closure `f` with an option containing the boxed any type downcast into a string,
     /// or `None` if it's not a string type.
     pub fn with_str<F, R>(
         &self,
@@ -650,12 +650,6 @@ impl fmt::Display for PanicError {
             let box_err = any.downcast_ref::<BoxError>();
             if let Some(err) = box_err {
                 return write!(f, "panicked: {err}");
-            }
-
-            // Types are `BoxDebug` if the panic occurred as a result of a `tell` message returning an error
-            let box_err = any.downcast_ref::<BoxDebug>();
-            if let Some(err) = box_err {
-                return write!(f, "panicked: {:?}", Err::<(), _>(err));
             }
 
             write!(f, "panicked")

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,10 +5,10 @@
 //! a consistent set of errors that can occur in the operation of actors and their communications.
 
 use std::{
-    any::{self, Any},
+    any::{self},
     cmp, error, fmt,
     hash::{Hash, Hasher},
-    sync::{Arc, Mutex, MutexGuard, PoisonError},
+    sync::{Arc, Mutex},
 };
 
 use serde::{Deserialize, Serialize};
@@ -17,7 +17,7 @@ use tokio::{
     time::error::Elapsed,
 };
 
-use crate::{actor::ActorID, mailbox::Signal, Actor};
+use crate::{actor::ActorID, mailbox::Signal, reply::ReplyError, Actor};
 
 /// A dyn boxed error.
 pub type BoxError = Box<dyn error::Error + Send + Sync + 'static>;
@@ -578,33 +578,32 @@ impl fmt::Display for ActorStopReason {
 /// A shared error that occurs when an actor panics or returns an error from a hook in the [Actor] trait.
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
-pub struct PanicError(Arc<Mutex<Box<dyn Any + Send>>>);
+pub struct PanicError(Arc<Mutex<Box<dyn ReplyError>>>);
 
 impl PanicError {
-    /// Creates a new PanicError from a generic error.
-    pub fn new<E>(err: E) -> Self
-    where
-        E: Send + 'static,
-    {
-        PanicError(Arc::new(Mutex::new(Box::new(err))))
+    /// Creates a new PanicError from a generic boxed reply error.
+    pub fn new(err: Box<dyn ReplyError>) -> Self {
+        PanicError(Arc::new(Mutex::new(err)))
     }
 
-    /// Creates a new PanicError from a generic boxed error.
-    pub fn new_boxed(err: Box<dyn Any + Send>) -> Self {
-        PanicError(Arc::new(Mutex::new(err)))
+    pub(crate) fn new_from_panic_any(err: Box<dyn any::Any + Send>) -> Self {
+        err.downcast::<&'static str>()
+            .map(|s| PanicError::new(Box::new(*s)))
+            .or_else(|err| {
+                err.downcast::<String>()
+                    .map(|s| PanicError::new(Box::new(*s)))
+            })
+            .unwrap_or_else(|err| PanicError::new(Box::new(err)))
     }
 
     /// Calls the passed closure `f` with an option containing the boxed any type downcast into a string,
     /// or `None` if it's not a string type.
-    pub fn with_str<F, R>(
-        &self,
-        f: F,
-    ) -> Result<Option<R>, PoisonError<MutexGuard<'_, Box<dyn Any + Send>>>>
+    pub fn with_str<F, R>(&self, f: F) -> Option<R>
     where
         F: FnOnce(&str) -> R,
     {
         self.with(|any| {
-            any.downcast_ref::<&'static str>()
+            any.downcast_ref::<&str>()
                 .copied()
                 .or_else(|| any.downcast_ref::<String>().map(String::as_str))
                 .map(f)
@@ -612,50 +611,65 @@ impl PanicError {
     }
 
     /// Calls the passed closure `f` with the inner type downcast into `T`, otherwise returns `None`.
-    pub fn with_downcast_ref<T, F, R>(
-        &self,
-        f: F,
-    ) -> Result<Option<R>, PoisonError<MutexGuard<'_, Box<dyn Any + Send>>>>
+    pub fn with_downcast_ref<T, F, R>(&self, f: F) -> Option<R>
     where
-        T: 'static,
+        T: fmt::Debug + Send + 'static,
         F: FnOnce(&T) -> R,
     {
-        let lock = self.0.lock()?;
-        Ok(lock.downcast_ref().map(f))
+        match self.0.lock() {
+            Ok(lock) => lock.downcast_ref().map(f),
+            Err(err) => err.get_ref().downcast_ref().map(f),
+        }
     }
 
-    /// Returns a reference to the error as a `Box<dyn Any + Send>`.
-    pub fn with<F, R>(&self, f: F) -> Result<R, PoisonError<MutexGuard<'_, Box<dyn Any + Send>>>>
+    /// Returns a reference to the error as a `&Box<dyn ReplyError>`.
+    pub fn with<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&Box<dyn Any + Send>) -> R,
+        F: FnOnce(&Box<dyn ReplyError>) -> R,
     {
-        let lock = self.0.lock()?;
-        Ok(f(&lock))
+        match self.0.lock() {
+            Ok(lock) => f(&lock),
+            Err(err) => f(err.get_ref()),
+        }
     }
 }
 
 impl fmt::Display for PanicError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.with_str(|s| write!(f, "panicked: {s}"))
+            .unwrap_or_else(|| {
+                self.with_downcast_ref(|err: &BoxError| write!(f, "panicked: {err}"))
+                    .unwrap_or_else(|| write!(f, "panicked"))
+            })
+    }
+}
+
+impl fmt::Debug for PanicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dbg_struct = f.debug_struct("PanicError");
+
         self.with(|any| {
             // Types are strings if panicked with the `std::panic!` macro
             let s = any
-                .downcast_ref::<&'static str>()
+                .downcast_ref::<&str>()
                 .copied()
                 .or_else(|| any.downcast_ref::<String>().map(String::as_str));
             if let Some(s) = s {
-                return write!(f, "panicked: {s}");
+                dbg_struct.field("err", &s);
+                return;
             }
 
             // Types are `BoxError` if the panic occurred because of an actor hook returning an error
             let box_err = any.downcast_ref::<BoxError>();
             if let Some(err) = box_err {
-                return write!(f, "panicked: {err}");
+                dbg_struct.field("err", &err);
+                return;
             }
 
-            write!(f, "panicked")
-        })
-        .ok()
-        .unwrap_or_else(|| write!(f, "panicked"))
+            dbg_struct.field("err", any);
+        });
+
+        dbg_struct.finish()
     }
 }
 
@@ -674,7 +688,7 @@ impl<'de> Deserialize<'de> for PanicError {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(PanicError::new(s))
+        Ok(PanicError::new(Box::new(s)))
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,7 +14,7 @@
 //! (Command Query Responsibility Segregation) principle and enhancing the clarity and maintainability of actor
 //! interactions. It also provides some performance benefits in that sequential queries can be processed concurrently.
 
-use std::{any, fmt};
+use std::any;
 
 use futures::{future::BoxFuture, Future, FutureExt};
 
@@ -26,7 +26,6 @@ use crate::{
     Actor,
 };
 
-pub(crate) type BoxDebug = Box<dyn fmt::Debug + Send + 'static>;
 pub(crate) type BoxReply = Box<dyn any::Any + Send>;
 
 /// A message that can modify an actors state.
@@ -162,11 +161,10 @@ where
     ) -> ForwardedReply<R::Ok, M, E>
     where
         B: Message<M, Reply = R2>,
-        M: Unpin + Send + Sync + 'static,
+        M: Send + 'static,
         R: Reply<Error = SendError<M, E>, Value = Result<<R as Reply>::Ok, SendError<M, E>>>,
         R2: Reply<Ok = R::Ok, Error = E, Value = Result<R::Ok, E>>,
-        E: fmt::Debug + Unpin + Send + Sync + 'static,
-        R::Ok: Unpin,
+        E: Send + 'static,
         for<'a> AskRequest<
             LocalAskRequest<'a, B, B::Mailbox>,
             B::Mailbox,
@@ -202,7 +200,7 @@ where
         state: &mut A,
         actor_ref: ActorRef<A>,
         tx: Option<BoxReplySender>,
-    ) -> BoxFuture<'_, Option<BoxDebug>>;
+    ) -> BoxFuture<'_, Option<Box<dyn any::Any + Send>>>;
 
     /// Casts the type to a `Box<dyn Any>`.
     fn as_any(self: Box<Self>) -> Box<dyn any::Any>;
@@ -218,7 +216,7 @@ where
         state: &mut A,
         actor_ref: ActorRef<A>,
         tx: Option<BoxReplySender>,
-    ) -> BoxFuture<'_, Option<BoxDebug>> {
+    ) -> BoxFuture<'_, Option<Box<dyn any::Any + Send>>> {
         async move {
             let mut reply_sender = tx.map(ReplySender::new);
             let ctx: Context<'_, A, <A as Message<T>>::Reply> =
@@ -228,7 +226,7 @@ where
                 tx.send(reply.into_value());
                 None
             } else {
-                reply.into_boxed_err()
+                reply.into_any_err()
             }
         }
         .boxed()


### PR DESCRIPTION
Improved error handling of `PanicError` using a new `ReplyError` trait which requires all reply error types be `Debug + Send + 'static`.