### PR TITLE
feat!: remove lifetime from `Context` and borrow mutably instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ struct Inc { amount: i64 }
 impl Message<Inc> for Counter {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Inc, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.count += msg.amount;
         self.count
     }

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -26,7 +26,7 @@ impl Actor for BoundedActor {
 impl Message<u32> for BoundedActor {
     type Reply = u32;
 
-    async fn handle(&mut self, msg: u32, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: u32, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         msg
     }
 }
@@ -42,7 +42,7 @@ impl Actor for UnboundedActor {
 impl Message<u32> for UnboundedActor {
     type Reply = u32;
 
-    async fn handle(&mut self, msg: u32, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: u32, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         msg
     }
 }

--- a/docs/core-concepts/messages.mdx
+++ b/docs/core-concepts/messages.mdx
@@ -19,7 +19,7 @@ pub trait Message<T>: Actor {
     async fn handle(
         &mut self,
         msg: T,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply;
 }
 ```

--- a/docs/core-concepts/replies.mdx
+++ b/docs/core-concepts/replies.mdx
@@ -34,7 +34,7 @@ impl Message<MyRequest> for MyActor {
     async fn handle(
         &mut self,
         msg: MyRequest,
-        _: Context<'_, Self, Self::Reply>,
+        _: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         // Logic to process the message and generate a reply
         MyReply {

--- a/docs/distributed-actors/messaging-remote-actors.mdx
+++ b/docs/distributed-actors/messaging-remote-actors.mdx
@@ -53,7 +53,7 @@ pub struct MyActor;
 impl Message<Inc> for MyActor {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Inc, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.count += msg.amount as i64;
         self.count
     }

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -43,7 +43,7 @@ impl Message<Greet> for HelloWorldActor {
     async fn handle(
         &mut self,
         Greet(greeting): Greet, // Destructure the Greet message to get the greeting string
-        _: Context<'_, Self, Self::Reply>, // The message handling context
+        _: &mut Context<Self, Self::Reply>, // The message handling context
     ) -> Self::Reply {
         println!("{greeting}"); // Print the greeting to the console
     }

--- a/examples/ask.rs
+++ b/examples/ask.rs
@@ -32,7 +32,7 @@ pub struct Inc {
 impl Message<Inc> for MyActor {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Inc, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.count += msg.amount as i64;
         self.count
     }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -30,7 +30,7 @@ pub struct Inc {
 impl Message<Inc> for MyActor {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Inc, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.count += msg.amount as i64;
         self.count
     }
@@ -45,7 +45,7 @@ impl Message<ForceErr> for MyActor {
     async fn handle(
         &mut self,
         _msg: ForceErr,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         Err(3)
     }

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -18,7 +18,7 @@ impl Message<PrintActorID> for MyActor {
     async fn handle(
         &mut self,
         _: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("{}", ctx.actor_ref().id());
     }
@@ -30,7 +30,7 @@ struct ForceStop;
 impl Message<ForceStop> for MyActor {
     type Reply = ();
 
-    async fn handle(&mut self, _: ForceStop, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, _: ForceStop, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         ctx.actor_ref().kill();
         ctx.actor_ref().wait_for_stop().await;
     }

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -17,7 +17,7 @@ impl Message<PrintActorID> for ActorA {
     async fn handle(
         &mut self,
         _: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorA: {}", ctx.actor_ref().id());
     }
@@ -32,7 +32,7 @@ impl Message<PrintActorID> for ActorB {
     async fn handle(
         &mut self,
         _: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorB: {}", ctx.actor_ref().id());
     }

--- a/examples/pubsub_filter.rs
+++ b/examples/pubsub_filter.rs
@@ -17,7 +17,7 @@ impl Message<PrintActorID> for ActorA {
     async fn handle(
         &mut self,
         m: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorA: {} - {:?}", ctx.actor_ref().id(), m);
     }
@@ -32,7 +32,7 @@ impl Message<PrintActorID> for ActorB {
     async fn handle(
         &mut self,
         m: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorB: {} - {:?}", ctx.actor_ref().id(), m);
     }
@@ -47,7 +47,7 @@ impl Message<PrintActorID> for ActorC {
     async fn handle(
         &mut self,
         m: PrintActorID,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorC: {} - {:?}", ctx.actor_ref().id(), m);
     }

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -25,7 +25,7 @@ pub struct Inc {
 impl Message<Inc> for MyActor {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Inc, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Inc, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         println!("incrementing");
         self.count += msg.amount as i64;
         self.count
@@ -41,7 +41,7 @@ pub struct Dec {
 impl Message<Dec> for MyActor {
     type Reply = i64;
 
-    async fn handle(&mut self, msg: Dec, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    async fn handle(&mut self, msg: Dec, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         println!("decrementing");
         self.count -= msg.amount as i64;
         self.count

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -42,7 +42,7 @@ impl Message<StreamMessage<i64, &'static str, &'static str>> for MyActor {
     async fn handle(
         &mut self,
         msg: StreamMessage<i64, &'static str, &'static str>,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         match msg {
             StreamMessage::Next(amount) => {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -54,7 +54,7 @@ use syn::parse_macro_input;
 /// impl kameo::message::Message<Inc> for Counter {
 ///     type Reply = i64;
 ///
-///     async fn handle(&mut self, msg: Counter, _ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply {
+///     async fn handle(&mut self, msg: Counter, _ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply {
 ///         self.inc(msg.amount)
 ///     }
 /// }
@@ -67,7 +67,7 @@ use syn::parse_macro_input;
 /// impl kameo::message::Message<Dec> for Counter {
 ///     type Reply = ();
 ///
-///     async fn handle(&mut self, msg: Counter, _ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply {
+///     async fn handle(&mut self, msg: Counter, _ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply {
 ///         self.dec(msg.amount)
 ///     }
 /// }

--- a/macros/src/messages.rs
+++ b/macros/src/messages.rs
@@ -357,7 +357,7 @@ impl Messages {
                     impl #impl_generics ::kameo::message::#trait_name<#msg_ident #msg_ty_generics> for #actor_ident #actor_ty_generics #where_clause {
                         type Reply = #reply;
 
-                        async fn handle(#self_ref, #[allow(unused_variables)] #msg, _ctx: ::kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply {
+                        async fn handle(#self_ref, #[allow(unused_variables)] #msg, _ctx: &mut ::kameo::message::Context<Self, Self::Reply>) -> Self::Reply {
                             self.#fn_ident(#( #params ),*) #await_tokens
                         }
                     }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -326,7 +326,7 @@ where
     /// #
     /// # impl kameo::message::Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// # tokio_test::block_on(async {
@@ -377,7 +377,7 @@ where
     /// #
     /// # impl kameo::message::Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// # tokio_test::block_on(async {
@@ -653,7 +653,7 @@ where
     /// impl Message<StreamMessage<u32, (), ()>> for MyActor {
     ///     type Reply = ();
     ///
-    ///     async fn handle(&mut self, msg: StreamMessage<u32, (), ()>, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+    ///     async fn handle(&mut self, msg: StreamMessage<u32, (), ()>, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
     ///         match msg {
     ///             StreamMessage::Next(num) => {
     ///                 println!("Received item: {num}");
@@ -865,7 +865,7 @@ impl<A: Actor> RemoteActorRef<A> {
     /// # #[kameo::remote_message("id")]
     /// # impl kameo::message::Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// # tokio_test::block_on(async {
@@ -920,7 +920,7 @@ impl<A: Actor> RemoteActorRef<A> {
     /// # #[kameo::remote_message("id")]
     /// # impl kameo::message::Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: kameo::message::Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut kameo::message::Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// # tokio_test::block_on(async {

--- a/src/actor/pool.rs
+++ b/src/actor/pool.rs
@@ -26,7 +26,7 @@
 //! #
 //! # impl Message<&'static str> for MyWorker {
 //! #     type Reply = ();
-//! #     async fn handle(&mut self, msg: &'static str, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+//! #     async fn handle(&mut self, msg: &'static str, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply { }
 //! # }
 //!
 //! # tokio_test::block_on(async {
@@ -268,7 +268,7 @@ where
     async fn handle(
         &mut self,
         WorkerMsg(mut msg): WorkerMsg<M>,
-        mut ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let (_, mut reply_sender) = ctx.reply_sender();
         for _ in 0..self.workers.len() {
@@ -329,7 +329,7 @@ where
     async fn handle(
         &mut self,
         BroadcastMsg(msg): BroadcastMsg<M>,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         join_all(
             self.workers
@@ -373,7 +373,7 @@ where
             msg,
             counter: _counter,
         }: WorkerMsgWrapper<M>,
-        ctx: Context<'_, Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.handle(msg, ctx).await
     }

--- a/src/actor/pubsub.rs
+++ b/src/actor/pubsub.rs
@@ -26,7 +26,7 @@
 //! #
 //! # impl Message<&'static str> for MyActor {
 //! #     type Reply = ();
-//! #     async fn handle(&mut self, msg: &'static str, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+//! #     async fn handle(&mut self, msg: &'static str, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply { }
 //! # }
 //!
 //! # tokio_test::block_on(async {
@@ -147,7 +147,7 @@ impl<M> PubSub<M> {
     /// #
     /// # impl Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// #[derive(Clone)]
@@ -191,7 +191,7 @@ impl<M> PubSub<M> {
     /// #
     /// # impl Message<Msg> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: Msg, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: Msg, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// #[derive(Clone)]
@@ -247,7 +247,7 @@ where
     async fn handle(
         &mut self,
         Publish(msg): Publish<M>,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.publish(msg).await
     }
@@ -272,7 +272,7 @@ where
     async fn handle(
         &mut self,
         Subscribe(actor_ref): Subscribe<A>,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.subscribe(actor_ref)
     }
@@ -299,7 +299,7 @@ where
     async fn handle(
         &mut self,
         SubscribeFilter(actor_ref, filter): SubscribeFilter<A, M>,
-        _ctx: Context<'_, Self, Self::Reply>,
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.subscribe_filter(actor_ref, filter)
     }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -122,7 +122,7 @@ where
 /// impl Message<Flush> for MyActor {
 ///     type Reply = io::Result<()>;
 ///
-///     async fn handle(&mut self, _: Flush, _ctx: Context<'_, Self, Self::Reply>) -> Self::Reply {
+///     async fn handle(&mut self, _: Flush, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
 ///         self.file.flush() // This blocking operation is handled in its own thread
 ///     }
 /// }
@@ -226,7 +226,7 @@ impl<A: Actor> PreparedActor<A> {
     /// #
     /// # impl Message<&'static str> for MyActor {
     /// #     type Reply = ();
-    /// #     async fn handle(&mut self, msg: &'static str, ctx: Context<'_, Self, Self::Reply>) -> Self::Reply { }
+    /// #     async fn handle(&mut self, msg: &'static str, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply { }
     /// # }
     /// #
     /// # tokio_test::block_on(async {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -1019,7 +1019,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 true
             }
@@ -1065,7 +1065,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 true
             }
@@ -1112,7 +1112,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 true
             }
@@ -1164,7 +1164,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 true
             }
@@ -1220,7 +1220,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 true
@@ -1268,7 +1268,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 Sleep(duration): Sleep,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(duration).await;
                 true
@@ -1326,7 +1326,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 Sleep(duration): Sleep,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(duration).await;
                 true
@@ -1373,7 +1373,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 Sleep(duration): Sleep,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(duration).await;
                 true

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -543,7 +543,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
             }
         }
@@ -581,7 +581,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
             }
         }
@@ -617,7 +617,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
             }
         }
@@ -672,7 +672,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
             }
         }
@@ -735,7 +735,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 _msg: Msg,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(Duration::from_secs(10)).await;
             }
@@ -790,7 +790,7 @@ mod tests {
             async fn handle(
                 &mut self,
                 Sleep(duration): Sleep,
-                _ctx: Context<'_, Self, Self::Reply>,
+                _ctx: &mut Context<Self, Self::Reply>,
             ) -> Self::Reply {
                 tokio::time::sleep(duration).await;
             }


### PR DESCRIPTION
Fixes https://github.com/tqwewe/kameo/issues/143

As explained in the issue #143, sometimes the `async` keyword when implementing `Message` doesn't compile, and manually returning `-> impl Future<Output = Self::Reply> + Send` is necessary.

I don't understand exactly why, but removing the lifetime from `Context`, and instead borrowing mutably solves this, and as a bonus it removes the need for `'_` which can be considered slightly more user friendly and cleaner.