### PR TITLE
feat!: use `ForwardMessageSend` trait for `Context::forward` methods

### DIFF
--- a/examples/forward.rs
+++ b/examples/forward.rs
@@ -26,7 +26,7 @@ where
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let player_ref = self.player_map.get(&msg.player_id).unwrap();
-        ctx.forward_sync(player_ref, msg.message).await
+        ctx.forward_sync(player_ref, msg.message)
     }
 }
 
@@ -67,12 +67,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let players_ref = kameo::spawn(PlayersActor { player_map });
 
-    players_ref
+    let health = players_ref
         .ask(ForwardToPlayer {
             player_id: 0,
             message: Damage { amount: 38.2 },
         })
         .await?;
+    println!("Player health: {health:.1}");
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,6 @@ use std::{
     any::{self},
     cmp, error, fmt,
     hash::{Hash, Hasher},
-    ops::Deref,
     sync::{Arc, Mutex},
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use std::{
     any::{self},
     cmp, error, fmt,
     hash::{Hash, Hasher},
+    ops::Deref,
     sync::{Arc, Mutex},
 };
 
@@ -124,12 +125,34 @@ impl BoxSendError {
         M: 'static,
         E: 'static,
     {
+        self.try_downcast().unwrap()
+    }
+
+    /// Downcasts the inner error types to a concrete type, returning an error if its the wrong type.
+    pub fn try_downcast<M, E>(self) -> Result<SendError<M, E>, Self>
+    where
+        M: 'static,
+        E: 'static,
+    {
         match self {
-            SendError::ActorNotRunning(err) => SendError::ActorNotRunning(*err.downcast().unwrap()),
-            SendError::ActorStopped => SendError::ActorStopped,
-            SendError::MailboxFull(err) => SendError::MailboxFull(*err.downcast().unwrap()),
-            SendError::HandlerError(err) => SendError::HandlerError(*err.downcast().unwrap()),
-            SendError::Timeout(err) => SendError::Timeout(err.map(|err| *err.downcast().unwrap())),
+            SendError::ActorNotRunning(err) => Ok(SendError::ActorNotRunning(
+                *err.downcast::<M>().map_err(SendError::ActorNotRunning)?,
+            )),
+            SendError::ActorStopped => Ok(SendError::ActorStopped),
+            SendError::MailboxFull(err) => Ok(SendError::MailboxFull(
+                *err.downcast().map_err(SendError::MailboxFull)?,
+            )),
+            SendError::HandlerError(err) => Ok(SendError::HandlerError(
+                *err.downcast().map_err(SendError::HandlerError)?,
+            )),
+            SendError::Timeout(err) => Ok(SendError::Timeout(
+                err.map(|err| {
+                    err.downcast()
+                        .map(|v| *v)
+                        .map_err(|err| SendError::Timeout(Some(err)))
+                })
+                .transpose()?,
+            )),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ pub mod prelude {
     pub use crate::message::{Context, Message};
     #[cfg(feature = "remote")]
     pub use crate::remote::{ActorSwarm, RemoteActor, RemoteMessage};
-    pub use crate::reply::{DelegatedReply, Reply, ReplyError, ReplySender};
+    pub use crate::reply::{DelegatedReply, ForwardedReply, Reply, ReplyError, ReplySender};
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -62,71 +62,6 @@ use crate::{
 /// This is reserved for advanced use cases, and misuse of this can result in panics.
 pub type BoxReplySender = oneshot::Sender<Result<BoxReply, BoxSendError>>;
 
-/// A delegated reply that has been forwarded to another actor.
-#[derive(Debug)]
-pub struct ForwardedReply<M, R>
-where
-    R: Reply,
-{
-    res: Result<(), SendError<M, R::Error>>,
-}
-
-impl<M, R> ForwardedReply<M, R>
-where
-    R: Reply,
-{
-    pub(crate) fn new(res: Result<(), SendError<M, R::Error>>) -> Self {
-        ForwardedReply { res }
-    }
-}
-
-impl<M, R> Reply for ForwardedReply<M, R>
-where
-    R: Reply,
-    M: Send + 'static,
-{
-    type Ok = R::Ok;
-    type Error = SendError<M, R::Error>;
-    type Value = Result<Self::Ok, Self::Error>;
-
-    fn to_result(self) -> Result<Self::Ok, Self::Error> {
-        self.res
-            .map(|_| unreachable!("forwarded reply is only converted to a result if its an error"))
-    }
-
-    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
-        self.res
-            .err()
-            .map(|err| Box::new(err) as Box<dyn ReplyError>)
-    }
-
-    fn into_value(self) -> Self::Value {
-        self.res.map(|_| {
-            unreachable!("forwarded reply is only an error if it failed to forward the message")
-        })
-    }
-
-    /// If the forwarded reply succeeded, the we can safely assume
-    /// the `Box<dyn Any>` we have here is the ok value of the inner `R`.
-    fn downcast_ok(ok: Box<dyn any::Any>) -> Self::Ok {
-        *ok.downcast().unwrap()
-    }
-
-    /// The error is either from the inner `R`, or our outer `SendError`.
-    /// We'll try both.
-    fn downcast_err<N: 'static>(err: BoxSendError) -> SendError<N, Self::Error> {
-        err.try_downcast::<N, R::Error>()
-            .map(|err| err.map_err(SendError::HandlerError))
-            .unwrap_or_else(|err| {
-                err.downcast::<M, SendError<M, R::Error>>().map_msg(|_| {
-                    unreachable!(
-                        "forwarded reply is only an error if it failed to forward the message"
-                    )
-                })
-            })
-    }
-}
-
 /// A reply value.
 ///
 /// If an Err is returned by a handler, and is unhandled by the caller (ie, the message was sent asynchronously with `tell`),
@@ -172,47 +107,6 @@ pub trait Reply: Send + 'static {
     /// Downcasts a `Box<dyn Any>` into a `Self::Error` type.
     fn downcast_err<M: 'static>(err: BoxSendError) -> SendError<M, Self::Error> {
         err.downcast()
-    }
-}
-
-/// A marker type indicating that the reply to a message will be handled elsewhere.
-///
-/// This structure is created by the [`reply_sender`] method on [`Context`].
-///
-/// [`reply_sender`]: method@crate::message::Context::reply_sender
-/// [`Context`]: struct@crate::message::Context
-#[must_use = "the deligated reply should be returned by the handler"]
-#[derive(Clone, Copy, Debug)]
-pub struct DelegatedReply<R> {
-    phantom: PhantomData<fn() -> R>,
-}
-
-impl<R> DelegatedReply<R> {
-    pub(crate) fn new() -> Self {
-        DelegatedReply {
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<R> Reply for DelegatedReply<R>
-where
-    R: Reply,
-{
-    type Ok = R::Ok;
-    type Error = R::Error;
-    type Value = R::Value;
-
-    fn to_result(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!("a DeligatedReply cannot be converted to a result and is only a marker type")
-    }
-
-    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
-        None
-    }
-
-    fn into_value(self) -> Self::Value {
-        unimplemented!("a DeligatedReply cannot be converted to a value and is only a marker type")
     }
 }
 
@@ -306,6 +200,112 @@ impl<R: ?Sized> fmt::Debug for ReplySender<R> {
 pub trait ReplyError: DowncastSend + fmt::Debug + 'static {}
 impl<T> ReplyError for T where T: fmt::Debug + Send + 'static {}
 impl_downcast!(ReplyError);
+
+/// A marker type indicating that the reply to a message will be handled elsewhere.
+///
+/// This structure is created by the [`reply_sender`] method on [`Context`].
+///
+/// [`reply_sender`]: method@crate::message::Context::reply_sender
+/// [`Context`]: struct@crate::message::Context
+#[must_use = "the deligated reply should be returned by the handler"]
+#[derive(Clone, Copy, Debug)]
+pub struct DelegatedReply<R> {
+    phantom: PhantomData<fn() -> R>,
+}
+
+impl<R> DelegatedReply<R> {
+    pub(crate) fn new() -> Self {
+        DelegatedReply {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<R> Reply for DelegatedReply<R>
+where
+    R: Reply,
+{
+    type Ok = R::Ok;
+    type Error = R::Error;
+    type Value = R::Value;
+
+    fn to_result(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!("a DeligatedReply cannot be converted to a result and is only a marker type")
+    }
+
+    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
+        None
+    }
+
+    fn into_value(self) -> Self::Value {
+        unimplemented!("a DeligatedReply cannot be converted to a value and is only a marker type")
+    }
+}
+
+/// A delegated reply that has been forwarded to another actor.
+#[derive(Debug)]
+pub struct ForwardedReply<M, R>
+where
+    R: Reply,
+{
+    res: Result<(), SendError<M, R::Error>>,
+}
+
+impl<M, R> ForwardedReply<M, R>
+where
+    R: Reply,
+{
+    pub(crate) fn new(res: Result<(), SendError<M, R::Error>>) -> Self {
+        ForwardedReply { res }
+    }
+}
+
+impl<M, R> Reply for ForwardedReply<M, R>
+where
+    R: Reply,
+    M: Send + 'static,
+{
+    type Ok = R::Ok;
+    type Error = SendError<M, R::Error>;
+    type Value = Result<Self::Ok, Self::Error>;
+
+    fn to_result(self) -> Result<Self::Ok, Self::Error> {
+        self.res
+            .map(|_| unreachable!("forwarded reply is only converted to a result if its an error"))
+    }
+
+    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
+        self.res
+            .err()
+            .map(|err| Box::new(err) as Box<dyn ReplyError>)
+    }
+
+    fn into_value(self) -> Self::Value {
+        self.res.map(|_| {
+            unreachable!("forwarded reply is only an error if it failed to forward the message")
+        })
+    }
+
+    /// If the forwarded reply succeeded, the we can safely assume
+    /// the `Box<dyn Any>` we have here is the ok value of the inner `R`.
+    fn downcast_ok(ok: Box<dyn any::Any>) -> Self::Ok {
+        *ok.downcast().unwrap()
+    }
+
+    /// The error is either from the inner `R`, or our outer `SendError`.
+    /// We'll try both.
+    fn downcast_err<N: 'static>(err: BoxSendError) -> SendError<N, Self::Error> {
+        err.try_downcast::<N, R::Error>()
+            .map(|err| err.map_err(SendError::HandlerError))
+            .unwrap_or_else(|err| {
+                err.downcast::<M, SendError<M, R::Error>>().map_msg(|_| {
+                    unreachable!(
+                        "forwarded reply is only an error if it failed to forward the message"
+                    )
+                })
+            })
+    }
+}
 
 impl<T, E> Reply for Result<T, E>
 where

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -22,6 +22,7 @@
 //! ensures that actors can manage their communication responsibilities efficiently and effectively.
 
 use std::{
+    any,
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
     fmt,
@@ -62,7 +63,69 @@ use crate::{
 pub type BoxReplySender = oneshot::Sender<Result<BoxReply, BoxSendError>>;
 
 /// A delegated reply that has been forwarded to another actor.
-pub type ForwardedReply<T, M, E = ()> = DelegatedReply<Result<T, SendError<M, E>>>;
+#[derive(Debug)]
+pub struct ForwardedReply<M, R>
+where
+    R: Reply,
+{
+    res: Result<(), SendError<M, R::Error>>,
+}
+
+impl<M, R> ForwardedReply<M, R>
+where
+    R: Reply,
+{
+    pub(crate) fn new(res: Result<(), SendError<M, R::Error>>) -> Self {
+        ForwardedReply { res }
+    }
+}
+
+impl<M, R> Reply for ForwardedReply<M, R>
+where
+    R: Reply,
+    M: Send + 'static,
+{
+    type Ok = R::Ok;
+    type Error = SendError<M, R::Error>;
+    type Value = Result<Self::Ok, Self::Error>;
+
+    fn to_result(self) -> Result<Self::Ok, Self::Error> {
+        self.res
+            .map(|_| unreachable!("forwarded reply is only converted to a result if its an error"))
+    }
+
+    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
+        self.res
+            .err()
+            .map(|err| Box::new(err) as Box<dyn ReplyError>)
+    }
+
+    fn into_value(self) -> Self::Value {
+        self.res.map(|_| {
+            unreachable!("forwarded reply is only an error if it failed to forward the message")
+        })
+    }
+
+    /// If the forwarded reply succeeded, the we can safely assume
+    /// the `Box<dyn Any>` we have here is the ok value of the inner `R`.
+    fn downcast_ok(ok: Box<dyn any::Any>) -> Self::Ok {
+        *ok.downcast().unwrap()
+    }
+
+    /// The error is either from the inner `R`, or our outer `SendError`.
+    /// We'll try both.
+    fn downcast_err<N: 'static>(err: BoxSendError) -> SendError<N, Self::Error> {
+        err.try_downcast::<N, R::Error>()
+            .map(|err| err.map_err(SendError::HandlerError))
+            .unwrap_or_else(|err| {
+                err.downcast::<M, SendError<M, R::Error>>().map_msg(|_| {
+                    unreachable!(
+                        "forwarded reply is only an error if it failed to forward the message"
+                    )
+                })
+            })
+    }
+}
 
 /// A reply value.
 ///
@@ -100,6 +163,16 @@ pub trait Reply: Send + 'static {
     ///
     /// In almost all cases, this will simply return itself.
     fn into_value(self) -> Self::Value;
+
+    /// Downcasts a `Box<dyn Any>` into the `Self::Ok` type.
+    fn downcast_ok(ok: Box<dyn any::Any>) -> Self::Ok {
+        *ok.downcast().unwrap()
+    }
+
+    /// Downcasts a `Box<dyn Any>` into a `Self::Error` type.
+    fn downcast_err<M: 'static>(err: BoxSendError) -> SendError<M, Self::Error> {
+        err.downcast()
+    }
 }
 
 /// A marker type indicating that the reply to a message will be handled elsewhere.
@@ -208,6 +281,13 @@ impl<R> ReplySender<R> {
                 .map(|value| Box::new(value) as BoxReply)
                 .map_err(|err| BoxSendError::HandlerError(Box::new(err))),
         );
+    }
+
+    pub(crate) fn cast<R2>(self) -> ReplySender<R2> {
+        ReplySender {
+            tx: self.tx,
+            phantom: PhantomData,
+        }
     }
 }
 

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -364,8 +364,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.send(req.location.signal).await?;
         match req.location.rx.await? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -378,8 +378,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.0.send(req.location.signal).await?;
         match timeout(req.reply_timeout.0, req.location.rx).await?? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -396,8 +396,8 @@ impl_message_trait!(
             .send_timeout(req.location.signal, req.mailbox_timeout.0)
             .await?;
         match req.location.rx.await? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -414,8 +414,8 @@ impl_message_trait!(
             .send_timeout(req.location.signal, req.mailbox_timeout.0)
             .await?;
         match timeout(req.reply_timeout.0, req.location.rx).await?? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -429,8 +429,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.0.send(req.location.signal)?;
         match timeout(req.reply_timeout.0, req.location.rx).await?? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -597,8 +597,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.try_send(req.location.signal)?;
         match req.location.rx.await? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -611,8 +611,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.0.try_send(req.location.signal)?;
         match timeout(req.reply_timeout.0, req.location.rx).await?? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -626,8 +626,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.0.send(req.location.signal)?;
         match timeout(req.reply_timeout.0, req.location.rx).await?? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -755,8 +755,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.blocking_send(req.location.signal)?;
         match req.location.rx.blocking_recv()? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );
@@ -772,8 +772,8 @@ impl_message_trait!(
     |req| {
         req.location.mailbox.try_send(req.location.signal)?;
         match req.location.rx.blocking_recv()? {
-            Ok(val) => Ok(*val.downcast().unwrap()),
-            Err(err) => Err(err.downcast()),
+            Ok(val) => Ok(<A::Reply as Reply>::downcast_ok(val)),
+            Err(err) => Err(<A::Reply as Reply>::downcast_err(err)),
         }
     }
 );


### PR DESCRIPTION
This PR uses the `ForwardMessageSend` trait for `Context::forward` method.

- uses the `ForwardMessageSend` trait for `Context::forward` method
- adds a `Context::forward_sync` method
- modifies the `ForwardedReply` type to be a struct
- adds `downcast_ok` and `downcast_err` methods to the `Reply` trait