### PR TITLE
feat: add `Actor::next` method

### DIFF
--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -27,7 +27,7 @@ use crate::{
         Actor, ActorRef, Link, Links, CURRENT_ACTOR_ID,
     },
     error::{ActorStopReason, PanicError, SendError},
-    mailbox::{Mailbox, MailboxReceiver, Signal},
+    mailbox::{Mailbox, Signal},
 };
 
 use super::ActorID;
@@ -456,7 +456,7 @@ where
     S: ActorState<A>,
 {
     loop {
-        match mailbox_rx.recv().await {
+        match state.next(mailbox_rx).await {
             Some(Signal::StartupFinished) => {
                 startup_semaphore.add_permits(Semaphore::MAX_PERMITS);
                 if let ControlFlow::Break(reason) = state.handle_startup_finished().await {

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,32 @@ impl<M, E> SendError<M, E> {
             }
         }
     }
+
+    /// Unwraps the inner message, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the error does not contain the inner message.
+    pub fn unwrap_msg(self) -> M {
+        match self {
+            SendError::ActorNotRunning(msg) => msg,
+            SendError::MailboxFull(msg) => msg,
+            SendError::Timeout(msg) => msg.unwrap(),
+            _ => panic!("called `SendError::unwrap_msg()` on a non message error"),
+        }
+    }
+
+    /// Unwraps the inner handler error, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the error does not contain a handler error.
+    pub fn unwrap_err(self) -> E {
+        match self {
+            SendError::HandlerError(err) => err,
+            _ => panic!("called `SendError::unwrap_err()` on a non error"),
+        }
+    }
 }
 
 impl<M, E> SendError<M, SendError<M, E>> {


### PR DESCRIPTION
Adds an `Actor::next` method for processing messages beyond just the actors mailbox.