### PR TITLE
feat!: add `Recipient` type for type erased actor refs

### DIFF
--- a/actors/src/pool.rs
+++ b/actors/src/pool.rs
@@ -390,7 +390,15 @@ where
                             counter: Arc::downgrade(counter),
                         })
                         .send()
-                        .map_err(|err| err.map_msg(|msg| msg.msg).flatten())
+                        .map_err(|err| {
+                            err.map_msg(|msg| msg.msg)
+                                .map_err(|_| {
+                                    panic!(
+                                        "reset err infallible called on a `SendError::HandlerError`"
+                                    )
+                                })
+                                .flatten()
+                        })
                 }),
         )
         .await

--- a/examples/manual_swarm.rs
+++ b/examples/manual_swarm.rs
@@ -276,7 +276,7 @@ impl SwarmBehaviour for CustomBehaviour {
     fn send_tell_response(
         &mut self,
         channel: ResponseChannel<kameo::remote::SwarmResponse>,
-        result: Result<(), RemoteSendError<Vec<u8>>>,
+        result: Result<(), RemoteSendError>,
     ) -> Result<(), SwarmResponse> {
         self.actor_request_response
             .send_response(channel, SwarmResponse::Tell(result))

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -206,7 +206,7 @@ where
 ///     mailbox::bounded(100)
 /// );
 /// actor_ref.tell(Flush).blocking_send()?;
-/// # Ok::<(), kameo::error::SendError<Flush, io::Error>>(())
+/// # Ok::<(), kameo::error::SendError<Flush>>(())
 /// ```
 pub fn spawn_in_thread_with_mailbox<A>(
     actor: A,
@@ -257,7 +257,7 @@ where
 ///     MyActor { file: File::create("output.txt").unwrap() }
 /// );
 /// actor_ref.tell(Flush).blocking_send()?;
-/// # Ok::<(), kameo::error::SendError<Flush, io::Error>>(())
+/// # Ok::<(), kameo::error::SendError<Flush>>(())
 /// ```
 ///
 /// This function is useful for actors that require or benefit from running blocking operations while still

--- a/src/message.rs
+++ b/src/message.rs
@@ -20,6 +20,7 @@ use futures::{future::BoxFuture, Future, FutureExt};
 
 use crate::{
     actor::ActorRef,
+    error::SendError,
     reply::{BoxReplySender, DelegatedReply, ForwardedReply, Reply, ReplyError, ReplySender},
     Actor,
 };
@@ -176,7 +177,11 @@ where
                 ForwardedReply::new(res)
             }
             None => {
-                let res = actor_ref.tell(message).send().await;
+                let res = actor_ref
+                    .tell(message)
+                    .send()
+                    .await
+                    .map_err(SendError::reset_err_infallible);
                 ForwardedReply::new(res)
             }
         }
@@ -207,7 +212,10 @@ where
                 ForwardedReply::new(res)
             }
             None => {
-                let res = actor_ref.tell(message).try_send();
+                let res = actor_ref
+                    .tell(message)
+                    .try_send()
+                    .map_err(SendError::reset_err_infallible);
                 ForwardedReply::new(res)
             }
         }
@@ -239,7 +247,10 @@ where
                 ForwardedReply::new(res)
             }
             None => {
-                let res = actor_ref.tell(message).blocking_send();
+                let res = actor_ref
+                    .tell(message)
+                    .blocking_send()
+                    .map_err(SendError::reset_err_infallible);
                 ForwardedReply::new(res)
             }
         }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -179,7 +179,7 @@ pub(crate) async fn tell(
     payload: Vec<u8>,
     mailbox_timeout: Option<Duration>,
     immediate: bool,
-) -> Result<(), RemoteSendError<Vec<u8>>> {
+) -> Result<(), RemoteSendError> {
     let Some(fns) = REMOTE_MESSAGES_MAP.get(&RemoteMessageRegistrationID {
         actor_remote_id: &actor_remote_id,
         message_remote_id: &message_remote_id,

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -1125,7 +1125,7 @@ pub enum SwarmCommand {
     /// Send a tell response.
     SendTellResponse {
         /// Tell result.
-        result: Result<(), RemoteSendError<Vec<u8>>>,
+        result: Result<(), RemoteSendError>,
         /// Response channel.
         channel: ResponseChannel<SwarmResponse>,
     },
@@ -1309,7 +1309,7 @@ pub enum SwarmResponse {
     /// Represents the response to a `Tell` request.
     ///
     /// Contains either a successful acknowledgment or an error indicating why the send failed.
-    Tell(Result<(), RemoteSendError<Vec<u8>>>),
+    Tell(Result<(), RemoteSendError>),
 
     /// Represents the response to a link request.
     Link(Result<(), RemoteSendError<Infallible>>),
@@ -1400,7 +1400,7 @@ pub trait SwarmBehaviour: NetworkBehaviour {
     fn send_tell_response(
         &mut self,
         channel: ResponseChannel<SwarmResponse>,
-        result: Result<(), RemoteSendError<Vec<u8>>>,
+        result: Result<(), RemoteSendError>,
     ) -> Result<(), SwarmResponse>;
 
     /// Sends a response to a previously received `link` request.
@@ -1645,7 +1645,7 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
     fn send_tell_response(
         &mut self,
         channel: ResponseChannel<SwarmResponse>,
-        result: Result<(), RemoteSendError<Vec<u8>>>,
+        result: Result<(), RemoteSendError>,
     ) -> Result<(), SwarmResponse> {
         self.request_response
             .send_response(channel, SwarmResponse::Tell(result))

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,7 @@ pub use ask::RemoteAskRequest;
 pub use tell::RemoteTellRequest;
 
 pub use ask::{AskRequest, BlockingPendingReply, PendingReply};
-pub use tell::TellRequest;
+pub use tell::{RecipientTellRequest, TellRequest};
 
 /// A type for requests without any timeout set.
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -22,6 +22,7 @@ use super::{WithRequestTimeout, WithoutRequestTimeout};
 
 /// A request to send a message to an actor, waiting for a reply.
 #[allow(missing_debug_implementations)]
+#[must_use = "request won't be sent without awaiting, or calling a send method"]
 pub struct AskRequest<'a, A, M, Tm, Tr>
 where
     A: Actor + Message<M>,
@@ -594,6 +595,7 @@ where
 ///
 /// This is returned by [`AskRequest::enqueue`] and [`AskRequest::try_enqueue`].
 #[allow(missing_debug_implementations)]
+#[must_use = "reply wont be received without awaiting"]
 pub struct PendingReply<'a, M, R>
 where
     R: Reply,
@@ -619,6 +621,7 @@ where
 ///
 /// This is returned by [`AskRequest::blocking_enqueue`].
 #[allow(missing_debug_implementations)]
+#[must_use = "reply wont be received without calling .recv()"]
 pub struct BlockingPendingReply<'a, M, R>
 where
     R: Reply,
@@ -640,6 +643,7 @@ where
 /// A request to send a message to an actor, waiting for a reply.
 #[cfg(feature = "remote")]
 #[allow(missing_debug_implementations)]
+#[must_use = "request won't be sent without awaiting, or calling a send method"]
 pub struct RemoteAskRequest<'a, A, M, Tm, Tr>
 where
     A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,


### PR DESCRIPTION
Adds a new `Recipient` type, which is returned by calling `ActorRef::recipeint()`, which provides a type erased actor ref, which supports a single message type.

This only supports `tell` requests as of now, since the reply types from ask requests could be different for each actor.

This PR also removes the error type generic from tell requests, since this variant is never created when using tell requests.

TODO:

- [x] `Recipient::id`
- [x] `Recipient::is_alive`
- [x] `Recipient::downgrade`
- [x] `Recipient::strong_count`
- [x] `Recipient::weak_count`
- [x] `Recipient::is_current`
- [x] `Recipient::stop_gracefully`
- [x] `Recipient::kill`
- [x] `Recipient::wait_startup`
- [x] `Recipient::wait_for_stop`
- [x] `Recipient::tell`
- [ ] ~`Recipient::link`~
- [ ] ~`Recipient::blocking_link`~
- [ ] ~`Recipient::unlink`~
- [ ] ~`Recipient::blocking_unlink`~
- [x] `WeakRecipient::id`
- [x] `WeakRecipient::upgrade`
- [x] `WeakRecipient::strong_count`
- [x] `WeakRecipient::weak_count`

Related: https://github.com/tqwewe/kameo/discussions/158#discussioncomment-12707953