### PR TITLE
feat!: add `Actor::Args` associated type and actor spawn methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ impl Message<Inc> for Counter {
 
 ```rust,ignore
 // Spawn the actor and obtain its reference
-let actor_ref = kameo::spawn(Counter { count: 0 });
+let actor_ref = Counter::spawn(Counter { count: 0 });
 
 // Send messages to the actor
 let count = actor_ref.ask(Inc { amount: 42 }).await?;
@@ -110,7 +110,7 @@ Kameo provides built-in support for distributed actors, allowing you to send mes
 
 ```rust,ignore
 // Spawn and register the actor
-let actor_ref = kameo::spawn(MyActor::default());
+let actor_ref = MyActor::spawn(MyActor::default());
 actor_ref.register("my_actor").await?;
 ```
 

--- a/actors/src/broker.rs
+++ b/actors/src/broker.rs
@@ -38,10 +38,10 @@
 //! # tokio_test::block_on(async {
 //! // Create a broker with best effort delivery
 //! let broker = Broker::<TemperatureUpdate>::new(DeliveryStrategy::BestEffort);
-//! let broker_ref = kameo::spawn(broker);
+//! let broker_ref = MyActor::spawn(broker);
 //!
 //! // Create a display actor and subscribe to kitchen temperature updates
-//! let display = kameo::spawn(DisplayActor);
+//! let display = MyActor::spawn(DisplayActor);
 //! broker_ref.tell(Subscribe {
 //!     topic: Pattern::new("sensors/kitchen/*").unwrap(),
 //!     recipient: display.recipient(),

--- a/actors/src/message_bus.rs
+++ b/actors/src/message_bus.rs
@@ -36,10 +36,10 @@
 //! # tokio_test::block_on(async {
 //! // Create a message bus with best effort delivery
 //! let message_bus = MessageBus::new(DeliveryStrategy::BestEffort);
-//! let message_bus_ref = kameo::spawn(message_bus);
+//! let message_bus_ref = MessageBuf::spawn(message_bus);
 //!
 //! // Create a display actor and register it for temperature updates
-//! let display = kameo::spawn(DisplayActor);
+//! let display = MessageBuf::spawn(DisplayActor);
 //! message_bus_ref.tell(Register(display.recipient::<TemperatureUpdate>())).await?;
 //!
 //! // Publish a temperature update - automatically routes to all registered handlers

--- a/actors/src/pubsub.rs
+++ b/actors/src/pubsub.rs
@@ -31,14 +31,14 @@
 //!
 //! # tokio_test::block_on(async {
 //! let mut pubsub = PubSub::new();
-//! let actor_ref = kameo::spawn(MyActor);
+//! let actor_ref = MyActor::spawn(MyActor);
 //!
 //! // Use PubSub as a standalone object
 //! pubsub.subscribe(actor_ref.clone());
 //! pubsub.publish("Hello, World!").await;
 //!
 //! // Or spawn PubSub as an actor and use messages
-//! let pubsub_actor_ref = kameo::spawn(PubSub::new());
+//! let pubsub_actor_ref = MyActor::spawn(PubSub::new());
 //! pubsub_actor_ref.tell(Subscribe(actor_ref)).await?;
 //! pubsub_actor_ref.tell(Publish("Hello, spawned world!")).await?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
@@ -147,7 +147,7 @@ impl<M> PubSub<M> {
     /// # tokio_test::block_on(async {
     /// let mut pubsub: PubSub<Msg> = PubSub::new();
     ///
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// pubsub.subscribe(actor_ref);
     /// # })
     /// ```
@@ -189,7 +189,7 @@ impl<M> PubSub<M> {
     /// # tokio_test::block_on(async {
     /// let mut pubsub = PubSub::new();
     ///
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// pubsub.subscribe_filter(actor_ref, |Msg(msg)| msg.starts_with("my-topic:"));
     /// # })
     /// ```
@@ -208,7 +208,12 @@ impl<M> PubSub<M> {
 }
 
 impl<M: 'static> Actor for PubSub<M> {
+    type Args = Self;
     type Error = Infallible;
+
+    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(state)
+    }
 }
 
 impl<M> Default for PubSub<M> {

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -23,7 +23,7 @@ fn actor_benchmarks(c: &mut Criterion) {
         let rt = Builder::new_current_thread().build().unwrap();
         let _guard = rt.enter();
         let actor_ref = rt.block_on(async {
-            let actor_ref = kameo::actor::spawn_with_mailbox(MyActor, mailbox::bounded(10));
+            let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(10));
             actor_ref.ask(0).send().await.unwrap(); // Ask an initial message to make sure the actor is ready
             actor_ref
         });
@@ -37,7 +37,7 @@ fn actor_benchmarks(c: &mut Criterion) {
         let rt = Builder::new_current_thread().build().unwrap();
         let _guard = rt.enter();
         let actor_ref = rt.block_on(async {
-            let actor_ref = kameo::actor::spawn_with_mailbox(MyActor, mailbox::unbounded());
+            let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
             actor_ref.ask(0).send().await.unwrap(); // Ask an initial message to make sure the actor is ready
             actor_ref
         });

--- a/docs/core-concepts/actors.mdx
+++ b/docs/core-concepts/actors.mdx
@@ -43,7 +43,7 @@ struct MyActor { }
 
 ## Actor Creation and Messaging
 
-Creating an actor involves implementing the `Actor` trait and then spawning the actor using `kameo::spawn`. Upon spawning, an `ActorRef<T>` is returned, which is used to send messages to the actor. The actor processes messages using the `handle` method from the `Message` trait, optionally returning a reply.
+Creating an actor involves implementing the `Actor` trait and then spawning the actor using `Actor::spawn`. Upon spawning, an `ActorRef<T>` is returned, which is used to send messages to the actor. The actor processes messages using the `handle` method from the `Message` trait, optionally returning a reply.
 
 ### Example Usage
 
@@ -62,7 +62,7 @@ impl Actor for MyActor {
 }
 
 // Spawning the actor
-let actor_ref = kameo::spawn(MyActor);
+let actor_ref = MyActor::spawn(MyActor);
 ```
 
 The above example demonstrates defining a simple actor and spawning it. The actor prints a message upon starting, showcasing the use of the `on_start` lifecycle hook.

--- a/docs/distributed-actors/registering-looking-up-actors.mdx
+++ b/docs/distributed-actors/registering-looking-up-actors.mdx
@@ -12,7 +12,7 @@ To register an actor, use the `ActorRef::register` method, which registers the a
 
 ```rust
 // Spawn and register an actor
-let actor_ref = kameo::spawn(MyActor::default());
+let actor_ref = MyActor::spawn(MyActor::default());
 actor_ref.register("my_actor").await?;
 ```
 
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let actor_swarm = ActorSwarm::bootstrap()?;
     // Listen so we can handle requests from other nodes
     actor_swarm.listen_on("/ip4/0.0.0.0/udp/8020/quic-v1".parse()?).await?;
-    let actor_ref = kameo::spawn(MyActor::default());
+    let actor_ref = MyActor::spawn(MyActor::default());
     actor_ref.register("my_actor").await?;
     
     // Node 2: Bootstrap, and lookup the actor and send a message

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -37,7 +37,7 @@ impl Message<ForceErr> for MyActor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let my_actor_ref = kameo::spawn(MyActor::default());
+    let my_actor_ref = MyActor::spawn(MyActor::default());
 
     // Increment the count by 3
     let count = my_actor_ref.ask(Inc { amount: 3 }).await?;

--- a/examples/broker.rs
+++ b/examples/broker.rs
@@ -22,10 +22,10 @@ impl Message<Echo> for MyActor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let broker_ref = kameo::spawn(Broker::new(DeliveryStrategy::Guaranteed));
+    let broker_ref = Broker::spawn(Broker::new(DeliveryStrategy::Guaranteed));
 
     // Subscribe
-    let my_actor_ref = kameo::spawn(MyActor);
+    let my_actor_ref = MyActor::spawn(MyActor);
     broker_ref
         .tell(Subscribe {
             topic: "my-topic".parse()?,
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
-    let my_actor_ref2 = kameo::spawn(MyActor);
+    let my_actor_ref2 = MyActor::spawn(MyActor);
     broker_ref
         .tell(Subscribe {
             topic: "my-*".parse()?,

--- a/examples/forward.rs
+++ b/examples/forward.rs
@@ -53,12 +53,12 @@ impl Message<Damage> for Player {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let player_ref = kameo::spawn(Player { health: 100.0 });
+    let player_ref = Player::spawn(Player { health: 100.0 });
 
     let mut player_map = HashMap::new();
     player_map.insert(0, player_ref.clone());
 
-    let players_ref = kameo::spawn(PlayersActor { player_map });
+    let players_ref = PlayersActor::spawn(PlayersActor { player_map });
 
     let health = players_ref
         .ask(ForwardToPlayer {

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -33,7 +33,7 @@ impl MyActor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let my_actor_ref = kameo::spawn(MyActor::new());
+    let my_actor_ref = MyActor::spawn(MyActor::new());
 
     // Increment the count by 3
     let count = my_actor_ref.ask(Inc { amount: 3 }).await?;

--- a/examples/message_bus.rs
+++ b/examples/message_bus.rs
@@ -22,15 +22,15 @@ impl Message<Echo> for MyActor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let message_bus_ref = kameo::spawn(MessageBus::new(DeliveryStrategy::Guaranteed));
+    let message_bus_ref = MessageBus::spawn(MessageBus::new(DeliveryStrategy::Guaranteed));
 
     // Subscribe
-    let my_actor_ref = kameo::spawn(MyActor);
+    let my_actor_ref = MyActor::spawn(MyActor);
     message_bus_ref
         .tell(Register(my_actor_ref.clone().recipient()))
         .await?;
 
-    let my_actor_ref2 = kameo::spawn(MyActor);
+    let my_actor_ref2 = MyActor::spawn(MyActor);
     message_bus_ref
         .tell(Register(my_actor_ref2.clone().recipient()))
         .await?;

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -34,7 +34,7 @@ impl Message<ForceStop> for MyActor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pool = kameo::spawn(ActorPool::new(5, || kameo::spawn(MyActor)));
+    let pool = ActorPool::spawn(ActorPool::new(5, || MyActor::spawn(MyActor)));
 
     // Print IDs 0, 2, 4, 6, 8
     for _ in 0..5 {

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -36,10 +36,10 @@ impl Message<PrintActorID> for ActorB {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pubsub = kameo::spawn(PubSub::<PrintActorID>::new());
+    let pubsub = PubSub::spawn(PubSub::<PrintActorID>::new());
 
-    let actor_a = kameo::spawn(ActorA);
-    let actor_b = kameo::spawn(ActorB);
+    let actor_a = ActorA::spawn(ActorA);
+    let actor_b = ActorB::spawn(ActorB);
 
     pubsub.ask(Subscribe(actor_a)).await?;
     pubsub.ask(Subscribe(actor_b)).await?;

--- a/examples/pubsub_filter.rs
+++ b/examples/pubsub_filter.rs
@@ -51,11 +51,11 @@ impl Message<PrintActorID> for ActorC {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pubsub = kameo::spawn(PubSub::<PrintActorID>::new());
+    let pubsub = PubSub::spawn(PubSub::<PrintActorID>::new());
 
-    let actor_a = kameo::spawn(ActorA);
-    let actor_b = kameo::spawn(ActorB);
-    let actor_c = kameo::spawn(ActorC);
+    let actor_a = ActorA::spawn(ActorA);
+    let actor_b = ActorB::spawn(ActorB);
+    let actor_c = ActorC::spawn(ActorC);
 
     pubsub
         .ask(SubscribeFilter(actor_a, |m: &PrintActorID| {

--- a/examples/registry.rs
+++ b/examples/registry.rs
@@ -7,7 +7,7 @@ pub struct MyActor;
 #[cfg(not(feature = "remote"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let actor_ref = kameo::spawn(MyActor);
+    let actor_ref = MyActor::spawn(MyActor);
     actor_ref.register("my awesome actor")?;
 
     let other_actor_ref = ActorRef::<MyActor>::lookup("my awesome actor")?.unwrap();
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _swarm = kameo::remote::ActorSwarm::bootstrap()?;
 
-    let actor_ref = kameo::spawn(MyActor);
+    let actor_ref = MyActor::spawn(MyActor);
     actor_ref.register("my awesome actor").await?;
 
     let other_actor_ref = ActorRef::<MyActor>::lookup("my awesome actor")

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if is_host {
-        let actor_ref = kameo::spawn(MyActor { count: 0 });
+        let actor_ref = MyActor::spawn(MyActor { count: 0 });
         info!("registering actor");
         actor_ref.register("my_actor").await?;
     } else {

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -11,16 +11,17 @@ pub struct MyActor {
 }
 
 impl Actor for MyActor {
+    type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+    async fn on_start(state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
         let stream = Box::pin(stream::repeat(1).take(5).throttle(Duration::from_secs(1)));
         actor_ref.attach_stream(stream, "1st stream", "1st stream");
 
         let stream = stream::repeat(1).take(5);
         actor_ref.attach_stream(stream, "2nd stream", "2nd stream");
 
-        Ok(())
+        Ok(state)
     }
 }
 
@@ -53,7 +54,7 @@ impl Message<StreamMessage<i64, &'static str, &'static str>> for MyActor {
 
 #[tokio::main]
 async fn main() {
-    let actor_ref = kameo::spawn(MyActor::default());
+    let actor_ref = MyActor::spawn(MyActor::default());
 
     actor_ref.wait_for_shutdown().await;
 }

--- a/macros/src/derive_actor.rs
+++ b/macros/src/derive_actor.rs
@@ -29,10 +29,18 @@ impl ToTokens for DeriveActor {
         tokens.extend(quote! {
             #[automatically_derived]
             impl #impl_generics ::kameo::actor::Actor for #ident #ty_generics #where_clause {
+                type Args = Self;
                 type Error = ::kameo::error::Infallible;
 
                 fn name() -> &'static str {
                     #name
+                }
+
+                async fn on_start(
+                    state: Self::Args,
+                    _actor_ref: ::kameo::actor::ActorRef<Self>,
+                ) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::result::Result::Ok(state)
                 }
             }
         });

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -590,11 +590,12 @@ where
     ///
     /// ```no_run
     /// # use kameo::actor::RemoteActorRef;
+    /// # use kameo::Actor;
     /// #
-    /// # #[derive(kameo::Actor, kameo::RemoteActor)]
+    /// # #[derive(Actor, kameo::RemoteActor)]
     /// # struct MyActor;
     /// #
-    /// # #[derive(kameo::Actor, kameo::RemoteActor)]
+    /// # #[derive(Actor, kameo::RemoteActor)]
     /// # struct OtherActor;
     /// #
     /// # tokio_test::block_on(async {
@@ -713,11 +714,12 @@ where
     ///
     /// ```
     /// # use kameo::actor::RemoteActorRef;
+    /// # use kameo::Actor;
     /// #
-    /// # #[derive(kameo::Actor, kameo::RemoteActor)]
+    /// # #[derive(Actor, kameo::RemoteActor)]
     /// # struct MyActor;
     /// #
-    /// # #[derive(kameo::Actor, kameo::RemoteActor)]
+    /// # #[derive(Actor, kameo::RemoteActor)]
     /// # struct OtherActor;
     /// #
     /// # tokio_test::block_on(async {

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -240,16 +240,20 @@ where
     /// struct MyActor;
     ///
     /// impl Actor for MyActor {
+    ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+    ///     async fn on_start(
+    ///         state: Self::Args,
+    ///         _actor_ref: ActorRef<Self>,
+    ///     ) -> Result<Self, Self::Error> {
     ///         sleep(Duration::from_secs(2)).await; // Some io operation
-    ///         Ok(())
+    ///         Ok(state)
     ///     }
     /// }
     ///
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// actor_ref.wait_for_startup().await;
     /// println!("Actor ready to handle messages!");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -285,15 +289,19 @@ where
     /// struct MyActor;
     ///
     /// impl Actor for MyActor {
+    ///     type Args = Self;
     ///     type Error = ParseIntError;
     ///
-    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
-    ///         "invalid int".parse().map(|_: i32| ()) // Will always error
+    ///     async fn on_start(
+    ///         _state: Self::Args,
+    ///         _actor_ref: ActorRef<Self>,
+    ///     ) -> Result<Self, Self::Error> {
+    ///         "invalid int".parse().map(|_: i32| MyActor) // Will always error
     ///     }
     /// }
     ///
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// let startup_result = actor_ref.wait_for_startup_result().await;
     /// assert!(startup_result.is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -367,13 +375,21 @@ where
     /// use std::num::ParseIntError;
     /// use std::time::Duration;
     ///
-    /// use kameo::actor::{Actor, WeakActorRef};
+    /// use kameo::actor::{Actor, ActorRef, WeakActorRef};
     /// use kameo::error::ActorStopReason;
     ///
     /// struct MyActor;
     ///
     /// impl Actor for MyActor {
+    ///     type Args = Self;
     ///     type Error = ParseIntError;
+    ///
+    ///     async fn on_start(
+    ///         state: Self::Args,
+    ///         _actor_ref: ActorRef<Self>,
+    ///     ) -> Result<Self, Self::Error> {
+    ///         Ok(state)
+    ///     }
     ///
     ///     async fn on_stop(&mut self, actor_ref: WeakActorRef<Self>, reason: ActorStopReason) -> Result<(), Self::Error> {
     ///         "invalid int".parse().map(|_: i32| ()) // Will always error
@@ -381,7 +397,7 @@ where
     /// }
     ///
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// actor_ref.stop_gracefully().await;
     /// let shutdown_result = actor_ref.wait_for_shutdown_result().await;
     /// assert!(shutdown_result.is_err());
@@ -413,7 +429,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kameo::actor::ActorRef;
+    /// use kameo::actor::{Actor, ActorRef};
     ///
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
@@ -426,7 +442,7 @@ where
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// # let msg = Msg;
     /// let reply = actor_ref.ask(msg).await?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -459,7 +475,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kameo::actor::ActorRef;
+    /// use kameo::actor::{Actor, ActorRef};
     ///
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
@@ -472,7 +488,7 @@ where
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// # let msg = Msg;
     /// actor_ref.tell(msg).await?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -499,12 +515,14 @@ where
     /// # Example
     ///
     /// ```
-    /// # #[derive(kameo::Actor)]
+    /// # use kameo::Actor;
+    /// #
+    /// # #[derive(Actor)]
     /// # struct MyActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
-    /// let sibbling_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
+    /// let sibbling_ref = MyActor::spawn(MyActor);
     ///
     /// actor_ref.link(&sibbling_ref).await;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -535,12 +553,14 @@ where
     /// ```
     /// use std::thread;
     ///
-    /// # #[derive(kameo::Actor)]
+    /// # use kameo::Actor;
+    /// #
+    /// # #[derive(Actor)]
     /// # struct MyActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
-    /// let sibbling_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
+    /// let sibbling_ref = MyActor::spawn(MyActor);
     ///
     /// thread::spawn(move || {
     ///     actor_ref.blocking_link(&sibbling_ref);
@@ -578,7 +598,7 @@ where
     /// # struct OtherActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// let sibbling_ref = RemoteActorRef::<OtherActor>::lookup("other_actor").await?.unwrap();
     ///
     /// actor_ref.link_remote(&sibbling_ref).await?;
@@ -622,12 +642,14 @@ where
     /// # Example
     ///
     /// ```
-    /// # #[derive(kameo::Actor)]
+    /// # use kameo::Actor;
+    /// #
+    /// # #[derive(Actor)]
     /// # struct MyActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
-    /// let sibbling_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
+    /// let sibbling_ref = MyActor::spawn(MyActor);
     ///
     /// actor_ref.link(&sibbling_ref).await;
     /// actor_ref.unlink(&sibbling_ref).await;
@@ -656,12 +678,14 @@ where
     /// ```
     /// # use std::thread;
     /// #
-    /// # #[derive(kameo::Actor)]
+    /// # use kameo::Actor;
+    /// #
+    /// # #[derive(Actor)]
     /// # struct MyActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
-    /// let sibbling_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
+    /// let sibbling_ref = MyActor::spawn(MyActor);
     ///
     /// thread::spawn(move || {
     ///     actor_ref.blocking_link(&sibbling_ref);
@@ -697,7 +721,7 @@ where
     /// # struct OtherActor;
     /// #
     /// # tokio_test::block_on(async {
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// let sibbling_ref = RemoteActorRef::<OtherActor>::lookup("other_actor").await?.unwrap();
     ///
     /// actor_ref.unlink_remote(&sibbling_ref).await?;
@@ -760,7 +784,7 @@ where
     /// # tokio_test::block_on(async {
     /// let stream = futures::stream::iter(vec![17, 19, 24]);
     ///
-    /// let actor_ref = kameo::spawn(MyActor);
+    /// let actor_ref = MyActor::spawn(MyActor);
     /// actor_ref.attach_stream(stream, (), ()).await?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -27,247 +27,10 @@ use crate::{
         Actor, ActorRef, Link, Links, CURRENT_ACTOR_ID,
     },
     error::{invoke_actor_error_hook, ActorStopReason, PanicError, SendError},
-    mailbox::{self, MailboxReceiver, MailboxSender, Signal},
+    mailbox::{MailboxReceiver, MailboxSender, Signal},
 };
 
 use super::ActorID;
-
-const DEFAULT_MAILBOX_CAPACITY: usize = 64;
-
-/// Spawns an actor in a Tokio task with a specific mailbox configuration.
-///
-/// This function allows you to explicitly specify a mailbox when spawning an actor.
-/// Use this when you need custom mailbox behavior or capacity.
-///
-/// # Example
-///
-/// ```
-/// use kameo::Actor;
-/// use kameo::mailbox;
-///
-/// #[derive(Actor)]
-/// struct MyActor;
-///
-/// # tokio_test::block_on(async {
-/// // Using a bounded mailbox with custom capacity
-/// let actor_ref = kameo::actor::spawn_with_mailbox(MyActor, mailbox::bounded(1000));
-///
-/// // Using an unbounded mailbox
-/// let actor_ref = kameo::actor::spawn_with_mailbox(MyActor, mailbox::unbounded());
-/// # })
-/// ```
-pub fn spawn_with_mailbox<A>(
-    actor: A,
-    (mailbox_tx, mailbox_rx): (MailboxSender<A>, MailboxReceiver<A>),
-) -> ActorRef<A>
-where
-    A: Actor,
-{
-    let prepared_actor = PreparedActor::new((mailbox_tx, mailbox_rx));
-    let actor_ref = prepared_actor.actor_ref().clone();
-    prepared_actor.spawn(actor);
-    actor_ref
-}
-
-/// Spawns an actor in a Tokio task, running asynchronously with a default bounded mailbox.
-///
-/// This function spawns the actor in a non-blocking Tokio task, making it suitable for actors that need to
-/// perform asynchronous operations. The actor runs in the background and can be interacted with through
-/// the returned [`ActorRef`].
-///
-/// By default, a bounded mailbox with capacity 64 is used to provide backpressure.
-/// For custom mailbox configuration, use [`spawn_with_mailbox`].
-///
-/// # Example
-///
-/// ```
-/// use kameo::Actor;
-///
-/// #[derive(Actor)]
-/// struct MyActor;
-///
-/// # tokio_test::block_on(async {
-/// // Spawns with a default bounded mailbox (capacity 64)
-/// let actor_ref = kameo::spawn(MyActor);
-/// # })
-/// ```
-///
-/// The actor will continue running in the background, and messages can be sent to it via `actor_ref`.
-pub fn spawn<A>(actor: A) -> ActorRef<A>
-where
-    A: Actor,
-{
-    spawn_with_mailbox(actor, mailbox::bounded(DEFAULT_MAILBOX_CAPACITY))
-}
-
-/// Spawns and links an actor in a Tokio task with a specific mailbox configuration.
-///
-/// This function is used to ensure an actor is linked with another actor before it's truly spawned,
-/// which avoids possible edge cases where the actor could die before having the chance to be linked.
-///
-/// # Example
-///
-/// ```
-/// use kameo::Actor;
-/// use kameo::mailbox;
-///
-/// #[derive(Actor)]
-/// struct FooActor;
-///
-/// #[derive(Actor)]
-/// struct BarActor;
-///
-/// # tokio_test::block_on(async {
-/// let link_ref = kameo::spawn(FooActor);
-/// // Using a custom mailbox
-/// let actor_ref = kameo::actor::spawn_link_with_mailbox(&link_ref, BarActor, mailbox::unbounded()).await;
-/// # })
-/// ```
-pub async fn spawn_link_with_mailbox<A, L>(
-    link_ref: &ActorRef<L>,
-    actor: A,
-    (mailbox_tx, mailbox_rx): (MailboxSender<A>, MailboxReceiver<A>),
-) -> ActorRef<A>
-where
-    A: Actor,
-    L: Actor,
-{
-    let prepared_actor = PreparedActor::new((mailbox_tx, mailbox_rx));
-    let actor_ref = prepared_actor.actor_ref().clone();
-    actor_ref.link(link_ref).await;
-    prepared_actor.spawn(actor);
-    actor_ref
-}
-
-/// Spawns and links an actor in a Tokio task with a default bounded mailbox.
-///
-/// This function is used to ensure an actor is linked with another actor before it's truly spawned,
-/// which avoids possible edge cases where the actor could die before having the chance to be linked.
-///
-/// By default, a bounded mailbox with capacity 64 is used to provide backpressure.
-/// For custom mailbox configuration, use [`spawn_link_with_mailbox`].
-///
-/// # Example
-///
-/// ```
-/// use kameo::Actor;
-///
-/// #[derive(Actor)]
-/// struct FooActor;
-///
-/// #[derive(Actor)]
-/// struct BarActor;
-///
-/// # tokio_test::block_on(async {
-/// let link_ref = kameo::spawn(FooActor);
-/// // Spawns with default bounded mailbox (capacity 64)
-/// let actor_ref = kameo::actor::spawn_link(&link_ref, BarActor).await;
-/// # })
-/// ```
-pub async fn spawn_link<A, L>(link_ref: &ActorRef<L>, actor: A) -> ActorRef<A>
-where
-    A: Actor,
-    L: Actor,
-{
-    spawn_link_with_mailbox(link_ref, actor, mailbox::bounded(DEFAULT_MAILBOX_CAPACITY)).await
-}
-
-/// Spawns an actor in its own dedicated thread with a specific mailbox configuration.
-///
-/// This function allows you to explicitly specify a mailbox when spawning an actor in a dedicated thread.
-/// Use this when you need custom mailbox behavior or capacity for actors that perform blocking operations.
-///
-/// # Example
-///
-/// ```no_run
-/// use std::io::{self, Write};
-/// use std::fs::File;
-///
-/// use kameo::Actor;
-/// use kameo::mailbox;
-/// use kameo::message::{Context, Message};
-///
-/// #[derive(Actor)]
-/// struct MyActor {
-///     file: File,
-/// }
-///
-/// struct Flush;
-/// impl Message<Flush> for MyActor {
-///     type Reply = io::Result<()>;
-///
-///     async fn handle(&mut self, _: Flush, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-///         self.file.flush() // This blocking operation is handled in its own thread
-///     }
-/// }
-///
-/// let actor_ref = kameo::actor::spawn_in_thread_with_mailbox(
-///     MyActor { file: File::create("output.txt").unwrap() },
-///     mailbox::bounded(100)
-/// );
-/// actor_ref.tell(Flush).blocking_send()?;
-/// # Ok::<(), kameo::error::SendError<Flush>>(())
-/// ```
-pub fn spawn_in_thread_with_mailbox<A>(
-    actor: A,
-    (mailbox_tx, mailbox_rx): (MailboxSender<A>, MailboxReceiver<A>),
-) -> ActorRef<A>
-where
-    A: Actor,
-{
-    let prepared_actor = PreparedActor::new((mailbox_tx, mailbox_rx));
-    let actor_ref = prepared_actor.actor_ref().clone();
-    prepared_actor.spawn_in_thread(actor);
-    actor_ref
-}
-
-/// Spawns an actor in its own dedicated thread with a default bounded mailbox.
-///
-/// This function spawns the actor in a separate thread, making it suitable for actors that perform blocking
-/// operations, such as file I/O or other tasks that cannot be efficiently executed in an asynchronous context.
-/// Despite running in a blocking thread, the actor can still communicate asynchronously with other actors.
-///
-/// By default, a bounded mailbox with capacity 64 is used to provide backpressure.
-/// For custom mailbox configuration, use [`spawn_in_thread_with_mailbox`].
-///
-/// # Example
-///
-/// ```no_run
-/// use std::io::{self, Write};
-/// use std::fs::File;
-///
-/// use kameo::Actor;
-/// use kameo::message::{Context, Message};
-///
-/// #[derive(Actor)]
-/// struct MyActor {
-///     file: File,
-/// }
-///
-/// struct Flush;
-/// impl Message<Flush> for MyActor {
-///     type Reply = io::Result<()>;
-///
-///     async fn handle(&mut self, _: Flush, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-///         self.file.flush() // This blocking operation is handled in its own thread
-///     }
-/// }
-///
-/// let actor_ref = kameo::actor::spawn_in_thread(
-///     MyActor { file: File::create("output.txt").unwrap() }
-/// );
-/// actor_ref.tell(Flush).blocking_send()?;
-/// # Ok::<(), kameo::error::SendError<Flush>>(())
-/// ```
-///
-/// This function is useful for actors that require or benefit from running blocking operations while still
-/// enabling asynchronous functionality.
-pub fn spawn_in_thread<A>(actor: A) -> ActorRef<A>
-where
-    A: Actor,
-{
-    spawn_in_thread_with_mailbox(actor, mailbox::bounded(DEFAULT_MAILBOX_CAPACITY))
-}
 
 /// A `PreparedActor` represents an actor that has been initialized and is ready to be either run
 /// in the current task or spawned into a new task.
@@ -276,6 +39,7 @@ where
 /// before it starts running. It allows for flexible execution, either by running the actor
 /// synchronously in the current task or spawning it in a separate task or thread.
 #[allow(missing_debug_implementations)]
+#[must_use = "the prepared actor needs to be ran/spawned"]
 pub struct PreparedActor<A: Actor> {
     actor_ref: ActorRef<A>,
     mailbox_rx: MailboxReceiver<A>,
@@ -283,26 +47,12 @@ pub struct PreparedActor<A: Actor> {
 }
 
 impl<A: Actor> PreparedActor<A> {
-    /// Creates a new prepared actor, allowing access to its [`ActorRef`] before spawning.
+    /// Creates a new prepared actor with a specific mailbox configuration, allowing access to its [`ActorRef`] before spawning.
     ///
-    /// # Example
+    /// This function allows you to explicitly specify a mailbox when preparing an actor.
+    /// Use this when you need custom mailbox behavior or capacity.
     ///
-    /// ```
-    /// # use kameo::Actor;
-    /// # use kameo::actor::PreparedActor;
-    /// use kameo::mailbox;
-    /// #
-    /// # #[derive(Actor)]
-    /// # struct MyActor;
-    /// #
-    /// # tokio_test::block_on(async {
-    /// # let other_actor = kameo::spawn(MyActor);
-    /// let prepared_actor = PreparedActor::new(mailbox::unbounded());
-    /// prepared_actor.actor_ref().link(&other_actor).await;
-    /// let actor_ref = prepared_actor.spawn(MyActor);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// # });
-    /// ```
+    /// This is typically created though [`Actor::prepare`] and [`Actor::prepare_with_mailbox`].
     pub fn new((mailbox_tx, mailbox_rx): (MailboxSender<A>, MailboxReceiver<A>)) -> Self {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         let links = Links::default();
@@ -345,7 +95,6 @@ impl<A: Actor> PreparedActor<A> {
     /// ```no_run
     /// # use kameo::Actor;
     /// # use kameo::actor::PreparedActor;
-    /// use kameo::mailbox;
     /// # use kameo::message::{Context, Message};
     ///
     /// # #[derive(Actor)]
@@ -357,16 +106,16 @@ impl<A: Actor> PreparedActor<A> {
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// let prepared_actor = PreparedActor::new(mailbox::unbounded());
+    /// let prepared_actor = MyActor::prepare();
     /// // Send it a message before it runs
     /// prepared_actor.actor_ref().tell("hello!").await?;
     /// prepared_actor.run(MyActor).await;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```
-    pub async fn run(self, actor: A) -> (A, ActorStopReason) {
+    pub async fn run(self, args: A::Args) -> Result<(A, ActorStopReason), PanicError> {
         run_actor_lifecycle::<A, ActorBehaviour<A>>(
-            actor,
+            args,
             self.actor_ref,
             self.mailbox_rx,
             self.abort_registration,
@@ -376,11 +125,11 @@ impl<A: Actor> PreparedActor<A> {
 
     /// Spawns the actor in a new background tokio task, returning the `JoinHandle`.
     ///
-    /// See [`spawn`] for more information.
-    pub fn spawn(self, actor: A) -> JoinHandle<(A, ActorStopReason)> {
+    /// See [`Actor::spawn`] for more information.
+    pub fn spawn(self, args: A::Args) -> JoinHandle<Result<(A, ActorStopReason), PanicError>> {
         #[cfg(not(all(tokio_unstable, feature = "tracing")))]
         {
-            tokio::spawn(CURRENT_ACTOR_ID.scope(self.actor_ref.id(), self.run(actor)))
+            tokio::spawn(CURRENT_ACTOR_ID.scope(self.actor_ref.id(), self.run(args)))
         }
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -394,8 +143,11 @@ impl<A: Actor> PreparedActor<A> {
 
     /// Spawns the actor in a new background thread, returning the `JoinHandle`.
     ///
-    /// See [`spawn_in_thread`] for more information.
-    pub fn spawn_in_thread(self, actor: A) -> thread::JoinHandle<(A, ActorStopReason)> {
+    /// See [`Actor::spawn_in_thread`] for more information.
+    pub fn spawn_in_thread(
+        self,
+        args: A::Args,
+    ) -> thread::JoinHandle<Result<(A, ActorStopReason), PanicError>> {
         let handle = Handle::current();
         if matches!(handle.runtime_flavor(), RuntimeFlavor::CurrentThread) {
             panic!("threaded actors are not supported in a single threaded tokio runtime");
@@ -405,7 +157,7 @@ impl<A: Actor> PreparedActor<A> {
             .name(A::name().to_string())
             .spawn({
                 let actor_ref = self.actor_ref.clone();
-                move || handle.block_on(CURRENT_ACTOR_ID.scope(actor_ref.id(), self.run(actor)))
+                move || handle.block_on(CURRENT_ACTOR_ID.scope(actor_ref.id(), self.run(args)))
             })
             .unwrap()
     }
@@ -413,11 +165,11 @@ impl<A: Actor> PreparedActor<A> {
 
 #[inline]
 async fn run_actor_lifecycle<A, S>(
-    mut actor: A,
+    args: A::Args,
     actor_ref: ActorRef<A>,
     mut mailbox_rx: MailboxReceiver<A>,
     abort_registration: AbortRegistration,
-) -> (A, ActorStopReason)
+) -> Result<(A, ActorStopReason), PanicError>
 where
     A: Actor,
     S: ActorState<A>,
@@ -428,18 +180,19 @@ where
     #[cfg(feature = "tracing")]
     trace!(%id, %name, "actor started");
 
-    let start_res = AssertUnwindSafe(actor.on_start(actor_ref.clone()))
+    let start_res = AssertUnwindSafe(A::on_start(args, actor_ref.clone()))
         .catch_unwind()
         .await
         .map(|res| res.map_err(|err| PanicError::new(Box::new(err))))
         .map_err(PanicError::new_from_panic_any)
         .and_then(convert::identity);
     match &start_res {
-        Ok(()) => {
+        Ok(actor) => {
             actor_ref
                 .startup_error
                 .set(None)
                 .expect("nothing else should set the startup error");
+            Some(actor)
         }
         Err(err) => {
             invoke_actor_error_hook(err);
@@ -447,8 +200,9 @@ where
                 .startup_error
                 .set(Some(err.clone()))
                 .expect("nothing else should set the startup error");
+            None
         }
-    }
+    };
 
     let mut startup_finished = false;
     if let Err(SendError::MailboxFull(())) =
@@ -463,42 +217,18 @@ where
         (weak_actor_ref, actor_ref.links, actor_ref.startup_semaphore)
     };
 
-    if let Err(err) = start_res {
-        startup_semaphore.add_permits(Semaphore::MAX_PERMITS);
-        let reason = ActorStopReason::Panicked(err);
-        let mut state = S::new_from_actor(actor, actor_ref.clone());
-        let reason = state
-            .on_shutdown(reason.clone())
-            .await
-            .break_value()
-            .unwrap_or(reason);
-        let mut actor = state.shutdown().await;
-        let on_stop_res = actor.on_stop(actor_ref.clone(), reason.clone()).await;
-        match on_stop_res {
-            Ok(()) => {
-                if let Some(actor_ref) = actor_ref.upgrade() {
-                    actor_ref
-                        .shutdown_error
-                        .set(None)
-                        .expect("nothing else should set the shutdown error");
-                }
-            }
-            Err(err) => {
-                let err = PanicError::new(Box::new(err));
-                invoke_actor_error_hook(&err);
-                if let Some(actor_ref) = actor_ref.upgrade() {
-                    actor_ref
-                        .shutdown_error
-                        .set(Some(err))
-                        .expect("nothing else should set the shutdown error");
-                }
-            }
+    let mut state = match start_res {
+        Ok(actor) => S::new_from_actor(actor, actor_ref.clone()),
+        Err(err) => {
+            startup_semaphore.add_permits(Semaphore::MAX_PERMITS);
+            let reason = ActorStopReason::Panicked(err);
+            log_actor_stop_reason(id, name, &reason);
+            let ActorStopReason::Panicked(err) = reason else {
+                unreachable!()
+            };
+            return Err(err);
         }
-        log_actor_stop_reason(id, name, &reason);
-        return (actor, reason);
-    }
-
-    let mut state = S::new_from_actor(actor, actor_ref.clone());
+    };
 
     let reason = Abortable::new(
         abortable_actor_loop(
@@ -587,7 +317,7 @@ where
         }
     }
 
-    (actor, reason)
+    Ok((actor, reason))
 }
 
 async fn abortable_actor_loop<A, S>(

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -136,7 +136,7 @@ impl<A: Actor> PreparedActor<A> {
         {
             tokio::task::Builder::new()
                 .name(A::name())
-                .spawn(CURRENT_ACTOR_ID.scope(self.actor_ref.id(), self.run(actor)))
+                .spawn(CURRENT_ACTOR_ID.scope(self.actor_ref.id(), self.run(args)))
                 .unwrap()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod remote;
 pub mod reply;
 pub mod request;
 
-pub use actor::{spawn, Actor};
+pub use actor::Actor;
 #[cfg(feature = "macros")]
 pub use kameo_macros::{messages, remote_message, Actor, RemoteActor, Reply};
 pub use reply::Reply;
@@ -37,8 +37,7 @@ pub mod prelude {
     #[cfg(feature = "remote")]
     pub use crate::actor::RemoteActorRef;
     pub use crate::actor::{
-        spawn, spawn_in_thread, spawn_link, Actor, ActorID, ActorRef, PreparedActor, Recipient,
-        WeakActorRef, WeakRecipient,
+        Actor, ActorID, ActorRef, PreparedActor, Recipient, WeakActorRef, WeakRecipient,
     };
     #[cfg(feature = "remote")]
     pub use crate::error::RemoteSendError;

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -436,20 +436,30 @@ impl<A: Actor> fmt::Debug for MailboxReceiver<A> {
     }
 }
 
+/// A signal which can be sent to an actors mailbox.
 #[allow(missing_debug_implementations)]
-#[doc(hidden)]
 pub enum Signal<A: Actor> {
+    /// The actor has finished starting up.
     StartupFinished,
+    /// A message.
     Message {
+        /// The boxed message.
         message: BoxMessage<A>,
+        /// The actor ref, to keep the actor from stopping due to RAII semantics.
         actor_ref: ActorRef<A>,
+        /// The reply sender.
         reply: Option<BoxReplySender>,
+        /// If the message sent from within the actor's tokio task/thread
         sent_within_actor: bool,
     },
+    /// A linked actor has died.
     LinkDied {
+        /// The dead actor's ID.
         id: ActorID,
+        /// The reason the actor stopped.
         reason: ActorStopReason,
     },
+    /// Signals the actor to stop.
     Stop,
 }
 

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -164,6 +164,8 @@ where
     /// # Example
     ///
     /// ```
+    /// # use kameo::Actor;
+    /// #
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
     /// #
@@ -175,7 +177,7 @@ where
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// # let actor_ref = kameo::spawn(MyActor);
+    /// # let actor_ref = MyActor::spawn(MyActor);
     /// # let msg = Msg;
     /// let pending = actor_ref.ask(Msg).enqueue().await?;
     /// // Do some other tasks
@@ -375,7 +377,9 @@ where
     /// # Example
     ///
     /// ```
-    /// # #[derive(kameo::Actor)]
+    /// # use kameo::Actor;
+    /// #
+    /// # #[derive(Actor)]
     /// # struct MyActor;
     /// #
     /// # struct Msg;
@@ -386,7 +390,7 @@ where
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// # let actor_ref = kameo::spawn(MyActor);
+    /// # let actor_ref = MyActor::spawn(MyActor);
     /// # let msg = Msg;
     /// let pending = actor_ref.ask(Msg).try_enqueue()?;
     /// // Do some other tasks
@@ -518,6 +522,8 @@ where
     /// # Example
     ///
     /// ```
+    /// # use kameo::Actor;
+    /// #
     /// # #[derive(kameo::Actor)]
     /// # struct MyActor;
     /// #
@@ -529,7 +535,7 @@ where
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// # let actor_ref = kameo::spawn(MyActor);
+    /// # let actor_ref = MyActor::spawn(MyActor);
     /// # let msg = Msg;
     /// # std::thread::spawn(move || {
     /// # let f = move || {
@@ -850,7 +856,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        actor::spawn_with_mailbox,
+        actor::ActorRef,
         error::{Infallible, SendError},
         mailbox,
         message::{Context, Message},
@@ -862,7 +868,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         struct Msg;
@@ -879,7 +893,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(100));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(100));
 
         assert!(actor_ref.ask(Msg).await?); // Should be a regular MessageSend request
         assert!(actor_ref.ask(Msg).send().await?);
@@ -900,7 +914,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         struct Msg;
@@ -917,7 +939,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::unbounded());
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
 
         assert!(actor_ref.ask(Msg).await?); // Should be a regular MessageSend request
         assert!(actor_ref.ask(Msg).send().await?);
@@ -938,7 +960,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -956,7 +986,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(100));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(100));
         actor_ref.stop_gracefully().await?;
         actor_ref.wait_for_shutdown().await;
 
@@ -985,7 +1015,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1003,7 +1041,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::unbounded());
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
         actor_ref.stop_gracefully().await?;
         actor_ref.wait_for_shutdown().await;
 
@@ -1032,7 +1070,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1051,7 +1097,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(1));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
         assert_eq!(actor_ref.tell(Msg).try_send(), Ok(()));
         assert_eq!(
             actor_ref.ask(Msg).try_send().await,
@@ -1067,7 +1113,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1086,7 +1140,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(1));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
         // Mailbox empty, this will succeed
         assert_eq!(
             actor_ref
@@ -1124,7 +1178,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1143,7 +1205,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(100));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(100));
         assert_eq!(
             actor_ref
                 .ask(Sleep(Duration::from_millis(100)))
@@ -1170,7 +1232,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1189,7 +1259,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::unbounded());
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
         assert_eq!(
             actor_ref
                 .ask(Sleep(Duration::from_millis(100)))

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -431,7 +431,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        actor::spawn_with_mailbox,
+        actor::ActorRef,
         error::{Infallible, SendError},
         mailbox,
         message::{Context, Message},
@@ -443,7 +443,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         struct Msg;
@@ -459,7 +467,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(100));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(100));
 
         actor_ref.tell(Msg).await?; // Should be a regular MessageSend request
         actor_ref.tell(Msg).send().await?;
@@ -478,7 +486,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         struct Msg;
@@ -494,7 +510,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::unbounded());
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
 
         actor_ref.tell(Msg).await?; // Should be a regular MessageSend request
         actor_ref.tell(Msg).send().await?;
@@ -509,7 +525,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -526,7 +550,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(100));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(100));
         actor_ref.stop_gracefully().await?;
         actor_ref.wait_for_shutdown().await;
 
@@ -555,7 +579,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -572,7 +604,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::unbounded());
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::unbounded());
         actor_ref.stop_gracefully().await?;
         actor_ref.wait_for_shutdown().await;
 
@@ -601,7 +633,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -619,7 +659,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(1));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
         assert_eq!(actor_ref.tell(Msg).try_send(), Ok(()));
         assert_eq!(
             actor_ref.tell(Msg).try_send(),
@@ -635,7 +675,15 @@ mod tests {
         struct MyActor;
 
         impl Actor for MyActor {
+            type Args = Self;
             type Error = Infallible;
+
+            async fn on_start(
+                state: Self::Args,
+                _actor_ref: ActorRef<Self>,
+            ) -> Result<Self, Self::Error> {
+                Ok(state)
+            }
         }
 
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -653,7 +701,7 @@ mod tests {
             }
         }
 
-        let actor_ref = spawn_with_mailbox(MyActor, mailbox::bounded(1));
+        let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
         // Mailbox empty, will succeed
         assert_eq!(
             actor_ref


### PR DESCRIPTION
Closes #167

## New `Actor::Args` associated type

A new `Args` type is added to the `Actor` trait, allowing the actors state to be initialized in the `on_start` method.

Unfortunately this makes the `on_start` method required, since it cannot have a default implementation. But the `#[derive(Actor)]` macro just sets the `Args = Self`, and returns the state in the implementation.

## `Actor` spawn methods

The spawn functions have been moved to be part of the `Actor` trait directly.

This means instead of `kameo::spawn(MyActor)`, you now use `MyActor::spawn(MyActor)`. This looks a little redundant, however the args passed to `MyActor::spawn(args)` can now be a different type to the actor itself, allowing some powerful patterns.

The spawn methods available are now:

- `Actor::spawn`
- `Actor::spawn_with_mailbox`
- `Actor::spawn_link`
- `Actor::spawn_link_with_mailbox`
- `Actor::spawn_in_thread`
- `Actor::spawn_in_thread_with_mailbox`
- `Actor::prepare`
- `Actor::prepare_with_mailbox`

For the methods not suffixed with `_with_mailbox`, the default mailbox is a bounded with a capacity of 64.