### PR TITLE
feat(actor): add reply recipient that can do ask requests

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -11,8 +11,8 @@ pub use ask::RemoteAskRequest;
 #[cfg(feature = "remote")]
 pub use tell::RemoteTellRequest;
 
-pub use ask::{AskRequest, BlockingPendingReply, PendingReply};
-pub use tell::{RecipientTellRequest, TellRequest};
+pub use ask::{AskRequest, BlockingPendingReply, PendingReply, ReplyRecipientAskRequest};
+pub use tell::{RecipientTellRequest, ReplyRecipientTellRequest, TellRequest};
 
 /// A type for requests without any timeout set.
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -649,27 +649,27 @@ where
 /// A request to send a message to a typed actor with reply.
 #[allow(missing_debug_implementations)]
 #[must_use = "request won't be sent without awaiting, or calling a send method"]
-pub struct ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+pub struct ReplyRecipientAskRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
-    actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+    actor_ref: &'a ReplyRecipient<M, Ok, Err>,
     msg: M,
     mailbox_timeout: Tm,
     #[cfg(all(debug_assertions, feature = "tracing"))]
     called_at: &'static std::panic::Location<'static>,
 }
 
-impl<'a, M, OK, ERR, Tm> ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+impl<'a, M, Ok, Err, Tm> ReplyRecipientAskRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
     pub(crate) fn new(
-        actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+        actor_ref: &'a ReplyRecipient<M, Ok, Err>,
         msg: M,
         #[cfg(all(debug_assertions, feature = "tracing"))] called_at: &'static std::panic::Location<
             'static,
@@ -691,14 +691,14 @@ where
     pub fn mailbox_timeout(
         self,
         duration: Duration,
-    ) -> ReplyRecipientAskRequest<'a, M, OK, ERR, WithRequestTimeout> {
+    ) -> ReplyRecipientAskRequest<'a, M, Ok, Err, WithRequestTimeout> {
         self.mailbox_timeout_opt(Some(duration))
     }
 
     pub(crate) fn mailbox_timeout_opt(
         self,
         duration: Option<Duration>,
-    ) -> ReplyRecipientAskRequest<'a, M, OK, ERR, WithRequestTimeout> {
+    ) -> ReplyRecipientAskRequest<'a, M, Ok, Err, WithRequestTimeout> {
         ReplyRecipientAskRequest {
             actor_ref: self.actor_ref,
             msg: self.msg,
@@ -709,7 +709,7 @@ where
     }
 
     /// Sends the message.
-    pub async fn send(self) -> Result<OK, SendError<M, ERR>>
+    pub async fn send(self) -> Result<Ok, SendError<M, Err>>
     where
         Tm: Into<Option<Duration>>,
     {
@@ -720,31 +720,31 @@ where
     }
 }
 
-impl<M, OK, ERR> ReplyRecipientAskRequest<'_, M, OK, ERR, WithoutRequestTimeout>
+impl<M, Ok, Err> ReplyRecipientAskRequest<'_, M, Ok, Err, WithoutRequestTimeout>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
     /// Tries to send the message without waiting for mailbox capacity.
-    pub async fn try_send(self) -> Result<OK, SendError<M, ERR>> {
+    pub async fn try_send(self) -> Result<Ok, SendError<M, Err>> {
         self.actor_ref.handler.try_ask(self.msg).await
     }
 
     /// Sends the message in a blocking context.
-    pub fn blocking_send(self) -> Result<OK, SendError<M, ERR>> {
+    pub fn blocking_send(self) -> Result<Ok, SendError<M, Err>> {
         self.actor_ref.handler.blocking_ask(self.msg)
     }
 }
 
-impl<'a, M, OK, ERR, Tm> IntoFuture for ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+impl<'a, M, Ok, Err, Tm> IntoFuture for ReplyRecipientAskRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
     Tm: Into<Option<Duration>> + Send + 'static,
 {
-    type Output = Result<OK, SendError<M, ERR>>;
+    type Output = Result<Ok, SendError<M, Err>>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -10,11 +10,11 @@ use tokio::sync::oneshot;
 use crate::{actor, remote};
 
 use crate::{
-    actor::ActorRef,
+    actor::{ActorRef, ReplyRecipient},
     error::{self, SendError},
     mailbox::{MailboxSender, Signal},
     message::Message,
-    reply::ReplySender,
+    reply::{ReplyError, ReplySender},
     Actor, Reply,
 };
 
@@ -643,6 +643,114 @@ where
     /// Receives the reply in a blocking context.
     pub fn recv(self) -> Result<R::Ok, SendError<M, R::Error>> {
         (self.f)()
+    }
+}
+
+/// A request to send a message to a typed actor with reply.
+#[allow(missing_debug_implementations)]
+#[must_use = "request won't be sent without awaiting, or calling a send method"]
+pub struct ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+where
+    M: Send + 'static,
+    OK: Send + 'static,
+    ERR: ReplyError,
+{
+    actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+    msg: M,
+    mailbox_timeout: Tm,
+    #[cfg(all(debug_assertions, feature = "tracing"))]
+    called_at: &'static std::panic::Location<'static>,
+}
+
+impl<'a, M, OK, ERR, Tm> ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+where
+    M: Send + 'static,
+    OK: Send + 'static,
+    ERR: ReplyError,
+{
+    pub(crate) fn new(
+        actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+        msg: M,
+        #[cfg(all(debug_assertions, feature = "tracing"))] called_at: &'static std::panic::Location<
+            'static,
+        >,
+    ) -> Self
+    where
+        Tm: Default,
+    {
+        ReplyRecipientAskRequest {
+            actor_ref,
+            msg,
+            mailbox_timeout: Tm::default(),
+            #[cfg(all(debug_assertions, feature = "tracing"))]
+            called_at,
+        }
+    }
+
+    /// Sets the timeout for waiting for the actors mailbox to have capacity.
+    pub fn mailbox_timeout(
+        self,
+        duration: Duration,
+    ) -> ReplyRecipientAskRequest<'a, M, OK, ERR, WithRequestTimeout> {
+        self.mailbox_timeout_opt(Some(duration))
+    }
+
+    pub(crate) fn mailbox_timeout_opt(
+        self,
+        duration: Option<Duration>,
+    ) -> ReplyRecipientAskRequest<'a, M, OK, ERR, WithRequestTimeout> {
+        ReplyRecipientAskRequest {
+            actor_ref: self.actor_ref,
+            msg: self.msg,
+            mailbox_timeout: WithRequestTimeout(duration),
+            #[cfg(all(debug_assertions, feature = "tracing"))]
+            called_at: self.called_at,
+        }
+    }
+
+    /// Sends the message.
+    pub async fn send(self) -> Result<OK, SendError<M, ERR>>
+    where
+        Tm: Into<Option<Duration>>,
+    {
+        self.actor_ref
+            .handler
+            .ask(self.msg, self.mailbox_timeout.into())
+            .await
+    }
+}
+
+impl<M, OK, ERR> ReplyRecipientAskRequest<'_, M, OK, ERR, WithoutRequestTimeout>
+where
+    M: Send + 'static,
+    OK: Send + 'static,
+    ERR: ReplyError,
+{
+    /// Tries to send the message without waiting for mailbox capacity.
+    pub async fn try_send(self) -> Result<OK, SendError<M, ERR>> {
+        self.actor_ref.handler.try_ask(self.msg).await
+    }
+
+    /// Sends the message in a blocking context.
+    pub fn blocking_send(self) -> Result<OK, SendError<M, ERR>> {
+        self.actor_ref.handler.blocking_ask(self.msg)
+    }
+}
+
+impl<'a, M, OK, ERR, Tm> IntoFuture for ReplyRecipientAskRequest<'a, M, OK, ERR, Tm>
+where
+    M: Send + 'static,
+    OK: Send + 'static,
+    ERR: ReplyError,
+    Tm: Into<Option<Duration>> + Send + 'static,
+{
+    type Output = Result<OK, SendError<M, ERR>>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.actor_ref
+            .handler
+            .ask(self.msg, self.mailbox_timeout.into())
     }
 }
 

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -258,27 +258,27 @@ where
 /// A request to send a message to a typed actor without any reply.
 #[allow(missing_debug_implementations)]
 #[must_use = "request won't be sent without awaiting, or calling a send method"]
-pub struct ReplyRecipientTellRequest<'a, M, OK, ERR, Tm>
+pub struct ReplyRecipientTellRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
-    actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+    actor_ref: &'a ReplyRecipient<M, Ok, Err>,
     msg: M,
     mailbox_timeout: Tm,
     #[cfg(all(debug_assertions, feature = "tracing"))]
     called_at: &'static std::panic::Location<'static>,
 }
 
-impl<'a, M, OK, ERR, Tm> ReplyRecipientTellRequest<'a, M, OK, ERR, Tm>
+impl<'a, M, Ok, Err, Tm> ReplyRecipientTellRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
     pub(crate) fn new(
-        actor_ref: &'a ReplyRecipient<M, OK, ERR>,
+        actor_ref: &'a ReplyRecipient<M, Ok, Err>,
         msg: M,
         #[cfg(all(debug_assertions, feature = "tracing"))] called_at: &'static std::panic::Location<
             'static,
@@ -300,14 +300,14 @@ where
     pub fn mailbox_timeout(
         self,
         duration: Duration,
-    ) -> ReplyRecipientTellRequest<'a, M, OK, ERR, WithRequestTimeout> {
+    ) -> ReplyRecipientTellRequest<'a, M, Ok, Err, WithRequestTimeout> {
         self.mailbox_timeout_opt(Some(duration))
     }
 
     pub(crate) fn mailbox_timeout_opt(
         self,
         duration: Option<Duration>,
-    ) -> ReplyRecipientTellRequest<'a, M, OK, ERR, WithRequestTimeout> {
+    ) -> ReplyRecipientTellRequest<'a, M, Ok, Err, WithRequestTimeout> {
         ReplyRecipientTellRequest {
             actor_ref: self.actor_ref,
             msg: self.msg,
@@ -329,11 +329,11 @@ where
     }
 }
 
-impl<M, OK, ERR> ReplyRecipientTellRequest<'_, M, OK, ERR, WithoutRequestTimeout>
+impl<M, Ok, Err> ReplyRecipientTellRequest<'_, M, Ok, Err, WithoutRequestTimeout>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
 {
     /// Tries to send the message without waiting for mailbox capacity.
     pub fn try_send(self) -> Result<(), SendError<M>> {
@@ -346,11 +346,11 @@ where
     }
 }
 
-impl<'a, M, OK, ERR, Tm> IntoFuture for ReplyRecipientTellRequest<'a, M, OK, ERR, Tm>
+impl<'a, M, Ok, Err, Tm> IntoFuture for ReplyRecipientTellRequest<'a, M, Ok, Err, Tm>
 where
     M: Send + 'static,
-    OK: Send + 'static,
-    ERR: ReplyError,
+    Ok: Send + 'static,
+    Err: ReplyError,
     Tm: Into<Option<Duration>> + Send + 'static,
 {
     type Output = Result<(), SendError<M>>;


### PR DESCRIPTION
Implements `ReplyRecipient<M, OK, ERR>` in addition to `Recipient<M>` which can do ask requests. It is created in the same way as `Recipient` from `ActorRef` using `reply_recipient<M>()` method. `OK` and `ERR` generics are determined from corresponding `Message<M>::Reply`

### Why additionally?

Because it seems that some cases does not need ask requests (like message bus and broker) and reply types would interfere. So I decide that better to split it. `ReplyRecipient` can be "erased" to `Recipient` using `ReplyRecipient::erase_reply()` method. 