### PR TITLE
fix: Make ActorState to call Actor::on_message instead of Message::ha…

### DIFF
--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -112,7 +112,7 @@ where
             return ControlFlow::Continue(());
         }
 
-        let res = AssertUnwindSafe(message.handle_dyn(&mut self.state, actor_ref, reply))
+        let res = AssertUnwindSafe(self.state.on_message(message, actor_ref, reply))
             .catch_unwind()
             .await;
         match res {


### PR DESCRIPTION
A possible fix to #185. 

As far as I can tell, the `Actor:on_message` is intended be called by `ActorState::handle_message". 
With this modification, `on_message` works as expected.