### PR TITLE
feat!: add a `lookup_all` method to the actor registry using providers

### DIFF
--- a/examples/manual_swarm.rs
+++ b/examples/manual_swarm.rs
@@ -346,4 +346,28 @@ impl SwarmBehaviour for CustomBehaviour {
     fn kademlia_remove_record_local(&mut self, key: &kad::RecordKey) {
         self.kademlia.store_mut().remove(key);
     }
+
+    fn kademlia_get_providers(&mut self, key: kad::RecordKey) -> kad::QueryId {
+        self.kademlia.get_providers(key)
+    }
+
+    fn kademlia_get_providers_local(&mut self, key: &kad::RecordKey) -> usize {
+        // Get providers from local store
+        self.kademlia
+            .store_mut()
+            .provided()
+            .filter(|k| &k.key == key)
+            .count()
+    }
+
+    fn kademlia_start_providing(
+        &mut self,
+        key: kad::RecordKey,
+    ) -> Result<kad::QueryId, kad::store::Error> {
+        self.kademlia.start_providing(key)
+    }
+
+    fn kademlia_stop_providing(&mut self, key: &kad::RecordKey) {
+        self.kademlia.stop_providing(key);
+    }
 }

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use futures::StreamExt;
+use futures::TryStreamExt;
 use kameo::prelude::*;
 use libp2p::swarm::dial_opts::DialOpts;
 use serde::{Deserialize, Serialize};
@@ -87,8 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if !is_host {
             let mut remote_actor_refs = RemoteActorRef::<MyActor>::lookup_all("my_actor");
             let mut found = 0;
-            while let Some(res) = remote_actor_refs.next().await {
-                let remote_actor_ref = res?;
+            while let Some(remote_actor_ref) = remote_actor_refs.try_next().await? {
                 let count = remote_actor_ref.ask(&Inc { amount: 10 }).await?;
                 println!("Incremented! Count is {count}");
                 found += 1;

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use futures::StreamExt;
 use kameo::prelude::*;
 use libp2p::swarm::dial_opts::DialOpts;
 use serde::{Deserialize, Serialize};
@@ -84,15 +85,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         if !is_host {
-            let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?;
-            match remote_actor_ref {
-                Some(remote_actor_ref) => {
-                    let count = remote_actor_ref.ask(&Inc { amount: 10 }).await?;
-                    println!("Incremented! Count is {count}");
-                }
-                None => {
-                    println!("actor not found");
-                }
+            let mut remote_actor_refs = RemoteActorRef::<MyActor>::lookup_all("my_actor");
+            let mut found = 0;
+            while let Some(res) = remote_actor_refs.next().await {
+                let remote_actor_ref = res?;
+                let count = remote_actor_ref.ask(&Inc { amount: 10 }).await?;
+                println!("Incremented! Count is {count}");
+                found += 1;
+            }
+            if found == 0 {
+                println!("actor not found");
             }
         }
 

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -1266,6 +1266,19 @@ where
             .await
     }
 
+    /// Looks up all actors registered by name across the distributed network.
+    ///
+    /// Returns a stream of remote actor refs found under the registered name.
+    pub fn lookup_all(name: &str) -> remote::LookupStream<A>
+    where
+        A: remote::RemoteActor + 'static,
+    {
+        match remote::ActorSwarm::get() {
+            Some(swarm) => swarm.lookup_all(name.to_string()),
+            None => remote::LookupStream::new_err(),
+        }
+    }
+
     /// Sends a message to the remote actor and waits for a reply.
     ///
     /// The `ask` pattern is used when a response is expected from the remote actor. This method

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -104,11 +104,15 @@ where
         &self,
         name: impl Into<std::borrow::Cow<'static, str>>,
     ) -> Result<(), error::RegistryError> {
-        crate::registry::ACTOR_REGISTRY
+        let was_inserted = crate::registry::ACTOR_REGISTRY
             .lock()
             .unwrap()
             .insert(name, self.clone());
-        Ok(())
+        if !was_inserted {
+            Err(error::RegistryError::NameAlreadyRegistered)
+        } else {
+            Ok(())
+        }
     }
 
     /// Registers the actor under a given name within the actor swarm.

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -1257,9 +1257,16 @@ where
         self.id
     }
 
-    /// Looks up an actor registered by name across the distributed network.
+    /// Looks up a single actor registered by name across the distributed network.
     ///
-    /// Returns `Some` if the actor is found, or `None` if no actor with the given name is registered.
+    /// If multiple actors are registered under the same name, returns one of them.
+    /// The specific actor returned is not deterministic and may vary between calls.
+    ///
+    /// Returns `None` if no actor with the given name is found.
+    ///
+    /// Use [`lookup_all`] when multiple actors might exist and you need deterministic behavior.
+    ///
+    /// [`lookup_all`]: Self::lookup_all
     pub async fn lookup(name: &str) -> Result<Option<Self>, error::RegistryError>
     where
         A: remote::RemoteActor + 'static,
@@ -1272,7 +1279,11 @@ where
 
     /// Looks up all actors registered by name across the distributed network.
     ///
-    /// Returns a stream of remote actor refs found under the registered name.
+    /// Returns a stream of all remote actor refs found under the given name.
+    /// The stream completes when all known actors have been discovered.
+    ///
+    /// Use this when multiple actors may be registered under the same name
+    /// and you need to handle all of them or make deterministic choices.
     pub fn lookup_all(name: &str) -> remote::LookupStream<A>
     where
         A: remote::RemoteActor + 'static,

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -295,6 +295,8 @@ where
     log_actor_stop_reason(id, name, &reason);
 
     while let Some(()) = link_notification_futures.next().await {}
+    #[cfg(not(feature = "remote"))]
+    crate::registry::ACTOR_REGISTRY.lock().unwrap().remove(name);
     #[cfg(feature = "remote")]
     remote::REMOTE_REGISTRY.lock().await.remove(&id);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -395,6 +395,8 @@ pub enum RegistryError {
     SwarmNotBootstrapped,
     /// The remote actor was found given the ID, but was not the correct type.
     BadActorType,
+    /// An actor has already been registered under the name.
+    NameAlreadyRegistered,
     /// Quorum failed.
     #[cfg(feature = "remote")]
     QuorumFailed {
@@ -417,6 +419,7 @@ impl fmt::Display for RegistryError {
         match self {
             #[cfg(feature = "remote")]
             RegistryError::SwarmNotBootstrapped => write!(f, "actor swarm not bootstrapped"),
+            RegistryError::NameAlreadyRegistered => write!(f, "name already registered"),
             RegistryError::BadActorType => write!(f, "bad actor type"),
             #[cfg(feature = "remote")]
             RegistryError::QuorumFailed { quorum } => {
@@ -433,6 +436,15 @@ impl fmt::Display for RegistryError {
 }
 
 impl error::Error for RegistryError {}
+
+#[cfg(feature = "remote")]
+impl From<libp2p::kad::AddProviderError> for RegistryError {
+    fn from(err: libp2p::kad::AddProviderError) -> Self {
+        match err {
+            libp2p::kad::AddProviderError::Timeout { .. } => RegistryError::Timeout,
+        }
+    }
+}
 
 #[cfg(feature = "remote")]
 impl From<libp2p::kad::GetProvidersError> for RegistryError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -404,6 +404,12 @@ pub enum RegistryError {
     /// Timeout.
     #[cfg(feature = "remote")]
     Timeout,
+    /// Get providers error.
+    #[cfg(feature = "remote")]
+    GetProviders(libp2p::kad::GetProvidersError),
+    /// Get record error.
+    #[cfg(feature = "remote")]
+    GetRecord(libp2p::kad::GetRecordError),
 }
 
 impl fmt::Display for RegistryError {
@@ -418,11 +424,29 @@ impl fmt::Display for RegistryError {
             }
             #[cfg(feature = "remote")]
             RegistryError::Timeout => write!(f, "the request timed out"),
+            #[cfg(feature = "remote")]
+            RegistryError::GetProviders(err) => err.fmt(f),
+            #[cfg(feature = "remote")]
+            RegistryError::GetRecord(err) => err.fmt(f),
         }
     }
 }
 
 impl error::Error for RegistryError {}
+
+#[cfg(feature = "remote")]
+impl From<libp2p::kad::GetProvidersError> for RegistryError {
+    fn from(err: libp2p::kad::GetProvidersError) -> Self {
+        RegistryError::GetProviders(err)
+    }
+}
+
+#[cfg(feature = "remote")]
+impl From<libp2p::kad::GetRecordError> for RegistryError {
+    fn from(err: libp2p::kad::GetRecordError) -> Self {
+        RegistryError::GetRecord(err)
+    }
+}
 
 /// Error that can occur when sending a message to an actor.
 #[cfg(feature = "remote")]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -100,9 +100,13 @@ impl ActorRegistry {
         name: impl Into<Cow<'static, str>>,
         actor_ref: ActorRef<A>,
     ) -> bool {
-        self.actor_refs
-            .insert(name.into(), Box::new(actor_ref))
-            .is_some()
+        let name = name.into();
+        if self.actor_refs.contains_key(&name) {
+            return false;
+        }
+
+        self.actor_refs.insert(name.into(), Box::new(actor_ref));
+        true
     }
 
     /// Removes a previously registered actor ref under a given name.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,7 +105,7 @@ impl ActorRegistry {
             return false;
         }
 
-        self.actor_refs.insert(name.into(), Box::new(actor_ref));
+        self.actor_refs.insert(name, Box::new(actor_ref));
         true
     }
 

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -531,11 +531,20 @@ impl ActorSwarm {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
+/// # use kameo::{Actor, RemoteActor, actor::RemoteActorRef};
+/// # use futures::TryStreamExt;
+/// #
+/// # #[derive(Actor, RemoteActor)]
+/// # struct MyActor;
+/// #
+/// # tokio_test::block_on(async {
 /// let mut stream = RemoteActorRef::<MyActor>::lookup_all("my-service");
 /// while let Some(actor_ref) = stream.try_next().await? {
 ///     // Handle each discovered actor
 /// }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # });
 /// ```
 ///
 /// [`RemoteActorRef<A>`]: crate::actor::RemoteActorRef

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -323,13 +323,13 @@ impl ActorSwarm {
         &self,
         name: String,
     ) -> Result<Option<RemoteActorRef<A>>, RegistryError> {
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "tracing"))]
         let name_clone = name.clone();
         let mut stream = self.lookup_all(name);
 
         let first = stream.next().await.transpose()?;
 
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "tracing"))]
         if first.is_some() {
             tokio::spawn(async move {
                 // Check if there's a second actor

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -518,7 +518,27 @@ impl ActorSwarm {
     }
 }
 
-/// A stream of remote actor id responses from a lookup.
+/// A stream of remote actor references discovered during distributed lookup.
+///
+/// This stream yields [`RemoteActorRef<A>`] instances as they are discovered across
+/// the network. The stream completes when all known actors matching the lookup
+/// name have been found.
+///
+/// # Errors
+///
+/// Individual stream items may be errors if specific actors cannot be reached
+/// or validated during lookup.
+///
+/// # Example
+///
+/// ```rust
+/// let mut stream = RemoteActorRef::<MyActor>::lookup_all("my-service");
+/// while let Some(actor_ref) = stream.try_next().await? {
+///     // Handle each discovered actor
+/// }
+/// ```
+///
+/// [`RemoteActorRef<A>`]: crate::actor::RemoteActorRef
 #[derive(Debug)]
 pub struct LookupStream<A> {
     inner: LookupStreamInner,

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -1,7 +1,9 @@
 use core::task;
-use std::{borrow::Cow, collections::HashMap, io, pin, time::Duration};
+use std::{
+    borrow::Cow, collections::HashMap, io, marker::PhantomData, pin, task::Poll, time::Duration,
+};
 
-use futures::{ready, stream::FuturesUnordered, Future, FutureExt, StreamExt};
+use futures::{ready, stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
 use libp2p::{
     core::{transport::ListenerId, ConnectedPoint},
     identity::Keypair,
@@ -317,40 +319,24 @@ impl ActorSwarm {
     }
 
     /// Looks up an actor in the swarm.
-    pub(crate) fn lookup<A: Actor + RemoteActor>(
+    pub(crate) async fn lookup<A: Actor + RemoteActor>(
         &self,
         name: String,
-    ) -> impl Future<Output = Result<Option<RemoteActorRef<A>>, RegistryError>> {
-        let reply_rx = self.swarm_tx.send_with_reply(|reply| SwarmCommand::Lookup {
-            key: name.into_bytes().into(),
-            reply,
-        });
+    ) -> Result<Option<RemoteActorRef<A>>, RegistryError> {
+        self.lookup_all(name).next().await.transpose()
+    }
+
+    /// Looks up all actors with a given name in the swarm.
+    pub fn lookup_all<A: Actor + RemoteActor>(&self, name: String) -> LookupStream<A> {
+        let (reply_tx, reply_rx) = mpsc::unbounded_channel();
+        let cmd = SwarmCommand::Lookup {
+            name,
+            reply: reply_tx,
+        };
+        self.swarm_tx.send(cmd);
 
         let swarm_tx = self.swarm_tx.clone();
-        async move {
-            match reply_rx.await {
-                Ok(kad::PeerRecord { record, .. }) => {
-                    if record.value.is_empty() {
-                        return Ok(None);
-                    }
-
-                    let ActorRegistration {
-                        actor_id,
-                        remote_id,
-                    } = ActorRegistration::from_bytes(&record.value);
-                    if A::REMOTE_ID != remote_id {
-                        return Err(RegistryError::BadActorType);
-                    }
-
-                    Ok(Some(RemoteActorRef::new(actor_id, swarm_tx.clone())))
-                }
-                Err(kad::GetRecordError::NotFound { .. }) => Ok(None),
-                Err(kad::GetRecordError::QuorumFailed { quorum, .. }) => {
-                    Err(RegistryError::QuorumFailed { quorum })
-                }
-                Err(kad::GetRecordError::Timeout { .. }) => Err(RegistryError::Timeout),
-            }
-        }
+        LookupStream::new(swarm_tx, reply_rx)
     }
 
     /// Registers an actor within the swarm.
@@ -361,15 +347,39 @@ impl ActorSwarm {
     ) -> impl Future<Output = Result<(), RegistryError>> {
         let actor_registration =
             ActorRegistration::new(actor_ref.id(), Cow::Borrowed(A::REMOTE_ID));
-        let reply_rx = self
+
+        // Start providing the actor name
+        let provide_reply_rx =
+            self.swarm_tx
+                .send_with_reply(|reply| SwarmCommand::StartProviding {
+                    key: name.clone().into_bytes().into(),
+                    reply,
+                });
+
+        // Store metadata with composite key
+        let metadata_key = format!("{}:meta:{}", name, self.local_peer_id);
+        let metadata_reply_rx = self
             .swarm_tx
             .send_with_reply(|reply| SwarmCommand::Register {
-                record: kad::Record::new(name.into_bytes(), actor_registration.into_bytes()),
+                record: kad::Record::new(
+                    metadata_key.into_bytes(),
+                    actor_registration.into_bytes(),
+                ),
                 reply,
             });
 
         async move {
-            match reply_rx.await {
+            // Wait for both operations
+            match provide_reply_rx.await {
+                Ok(kad::AddProviderOk { .. }) => {
+                    // Continue with metadata storage
+                }
+                Err(kad::AddProviderError::Timeout { .. }) => {
+                    return Err(RegistryError::Timeout);
+                }
+            }
+
+            match metadata_reply_rx.await {
                 Ok(kad::PutRecordOk { .. }) => {
                     let signal_mailbox = actor_ref.weak_signal_mailbox();
                     let links = actor_ref.links.clone();
@@ -396,15 +406,28 @@ impl ActorSwarm {
     /// The future returned by unregister does not have to be awaited.
     /// Awaiting it is only necessary to handle the result.
     pub fn unregister(&self, name: String) -> impl Future<Output = Result<(), RegistryError>> {
-        let reply_rx = self
+        // Stop providing the actor name
+        let stop_reply_rx = self
+            .swarm_tx
+            .send_with_reply(|reply| SwarmCommand::StopProviding {
+                key: name.clone().into_bytes().into(),
+                reply,
+            });
+
+        // Remove metadata
+        let metadata_key = format!("{}:meta:{}", name, self.local_peer_id);
+        let metadata_reply_rx = self
             .swarm_tx
             .send_with_reply(|reply| SwarmCommand::Unregister {
-                key: name.into_bytes().into(),
+                key: metadata_key.into_bytes().into(),
                 reply,
             });
 
         async move {
-            match reply_rx.await {
+            // Wait for both operations
+            stop_reply_rx.await;
+
+            match metadata_reply_rx.await {
                 Ok(kad::PutRecordOk { .. }) => Ok(()),
                 Err(kad::PutRecordError::QuorumFailed { quorum, .. }) => {
                     Err(RegistryError::QuorumFailed { quorum })
@@ -484,6 +507,80 @@ impl ActorSwarm {
     }
 }
 
+/// A stream of remote actor id responses from a lookup.
+#[derive(Debug)]
+pub struct LookupStream<A> {
+    inner: LookupStreamInner,
+    _phantom: PhantomData<fn() -> A>,
+}
+
+impl<A> LookupStream<A> {
+    fn new(
+        swarm_tx: SwarmSender,
+        reply_rx: mpsc::UnboundedReceiver<Result<ActorRegistration<'static>, RegistryError>>,
+    ) -> Self {
+        LookupStream {
+            inner: LookupStreamInner::Stream { swarm_tx, reply_rx },
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn new_err() -> Self {
+        LookupStream {
+            inner: LookupStreamInner::SwarmNotBootstrapped { done: false },
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum LookupStreamInner {
+    SwarmNotBootstrapped {
+        done: bool,
+    },
+    Stream {
+        swarm_tx: SwarmSender,
+        reply_rx: mpsc::UnboundedReceiver<Result<ActorRegistration<'static>, RegistryError>>,
+    },
+}
+
+impl<A: Actor + RemoteActor> Stream for LookupStream<A> {
+    type Item = Result<RemoteActorRef<A>, RegistryError>;
+
+    fn poll_next(
+        self: pin::Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match &mut this.inner {
+            LookupStreamInner::SwarmNotBootstrapped { done } => {
+                if *done {
+                    Poll::Ready(None)
+                } else {
+                    *done = true;
+                    Poll::Ready(Some(Err(RegistryError::SwarmNotBootstrapped)))
+                }
+            }
+            LookupStreamInner::Stream { swarm_tx, reply_rx } => {
+                match ready!(reply_rx.poll_recv(cx)) {
+                    Some(Ok(registration)) => {
+                        if A::REMOTE_ID != registration.remote_id {
+                            Poll::Ready(Some(Err(RegistryError::BadActorType)))
+                        } else {
+                            Poll::Ready(Some(Ok(RemoteActorRef::new(
+                                registration.actor_id,
+                                swarm_tx.clone(),
+                            ))))
+                        }
+                    }
+                    Some(Err(err)) => Poll::Ready(Some(Err(err))),
+                    None => Poll::Ready(None),
+                }
+            }
+        }
+    }
+}
+
 /// A concrete implementation of the `SwarmBehaviour` trait.
 ///
 /// `ActorSwarmHandler` manages swarm-related operations, including handling
@@ -497,9 +594,20 @@ impl ActorSwarm {
 pub struct ActorSwarmHandler {
     cmd_tx: SwarmSender,
     cmd_rx: mpsc::UnboundedReceiver<SwarmCommand>,
-    get_queries:
-        HashMap<kad::QueryId, oneshot::Sender<Result<kad::PeerRecord, kad::GetRecordError>>>,
+    get_queries: HashMap<
+        kad::QueryId,
+        mpsc::UnboundedSender<Result<ActorRegistration<'static>, RegistryError>>,
+    >,
     put_queries: HashMap<kad::QueryId, oneshot::Sender<kad::PutRecordResult>>,
+    provider_queries: HashMap<
+        kad::QueryId,
+        (
+            String,
+            mpsc::UnboundedSender<Result<ActorRegistration<'static>, RegistryError>>,
+        ),
+    >,
+    start_providing_queries:
+        HashMap<kad::QueryId, oneshot::Sender<Result<kad::AddProviderOk, kad::AddProviderError>>>,
     requests: HashMap<OutboundRequestId, oneshot::Sender<SwarmResponse>>,
 }
 
@@ -510,6 +618,8 @@ impl ActorSwarmHandler {
             cmd_rx: rx,
             get_queries: HashMap::new(),
             put_queries: HashMap::new(),
+            provider_queries: HashMap::new(),
+            start_providing_queries: HashMap::new(),
             requests: HashMap::new(),
         }
     }
@@ -567,16 +677,32 @@ impl ActorSwarmHandler {
             SwarmCommand::DisconnectPeerId { peer_id } => {
                 let _ = swarm.disconnect_peer_id(peer_id);
             }
-            SwarmCommand::Lookup { key, reply } => {
-                let query_id = swarm.behaviour_mut().kademlia_get_record(key);
-                self.get_queries.insert(query_id, reply);
+            SwarmCommand::Lookup { name, reply } => {
+                let query_id = swarm
+                    .behaviour_mut()
+                    .kademlia_get_providers(kad::RecordKey::new(&name));
+                self.provider_queries.insert(query_id, (name, reply));
             }
             SwarmCommand::LookupLocal { key, reply } => {
-                let registration = swarm
-                    .behaviour_mut()
-                    .kademlia_get_record_local(&key)
-                    .map(|record| ActorRegistration::from_bytes(&record.value).into_owned());
-                let _ = reply.send(registration);
+                // Check if we're providing this key locally
+                let providers = swarm.behaviour_mut().kademlia_get_providers_local(&key);
+                let local_peer_id = *swarm.local_peer_id();
+
+                if providers > 0 {
+                    // Get metadata for local provider
+                    let metadata_key = format!(
+                        "{}:meta:{}",
+                        String::from_utf8_lossy(key.as_ref()),
+                        local_peer_id
+                    );
+                    let registration = swarm
+                        .behaviour_mut()
+                        .kademlia_get_record_local(&kad::RecordKey::new(&metadata_key))
+                        .map(|record| ActorRegistration::from_bytes(&record.value).into_owned());
+                    let _ = reply.send(registration);
+                } else {
+                    let _ = reply.send(None);
+                }
             }
             SwarmCommand::Register { record, reply } => {
                 if swarm.network_info().num_peers() == 0 {
@@ -607,6 +733,14 @@ impl ActorSwarmHandler {
                     swarm.behaviour_mut().kademlia_remove_record(&key);
                     self.put_queries.insert(query_id, reply);
                 }
+            }
+            SwarmCommand::StartProviding { key, reply } => {
+                let query_id = swarm.behaviour_mut().kademlia_start_providing(key).unwrap();
+                self.start_providing_queries.insert(query_id, reply);
+            }
+            SwarmCommand::StopProviding { key, reply } => {
+                swarm.behaviour_mut().kademlia_stop_providing(&key);
+                let _ = reply.send(());
             }
             SwarmCommand::Ask {
                 peer_id,
@@ -827,22 +961,26 @@ impl ActorSwarmHandler {
                 ActorSwarmBehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed {
                     id,
                     result,
+                    step,
                     ..
                 }) => match result {
                     kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(
-                        record @ kad::PeerRecord {
-                            record: kad::Record { .. },
+                        kad::PeerRecord {
+                            record: kad::Record { value, .. },
                             ..
                         },
                     ))) => {
                         if let Some(tx) = self.get_queries.remove(&id) {
-                            let _ = tx.send(Ok(record));
+                            if !value.is_empty() {
+                                let registration = ActorRegistration::from_bytes(&value);
+                                let _ = tx.send(Ok(registration.into_owned()));
+                            }
                         }
                     }
                     kad::QueryResult::GetRecord(Ok(_)) => {}
                     kad::QueryResult::GetRecord(Err(err)) => {
                         if let Some(tx) = self.get_queries.remove(&id) {
-                            let _ = tx.send(Err(err));
+                            let _ = tx.send(Err(err.into()));
                         }
                     }
                     kad::QueryResult::PutRecord(res @ Ok(kad::PutRecordOk { .. })) => {
@@ -852,6 +990,46 @@ impl ActorSwarmHandler {
                     }
                     kad::QueryResult::PutRecord(res @ Err(_)) => {
                         if let Some(tx) = self.put_queries.remove(&id) {
+                            let _ = tx.send(res);
+                        }
+                    }
+                    kad::QueryResult::GetProviders(Ok(kad::GetProvidersOk::FoundProviders {
+                        providers,
+                        ..
+                    })) => {
+                        if let Some((name, tx)) = self.provider_queries.get_mut(&id) {
+                            if !tx.is_closed() {
+                                for provider in providers {
+                                    let key = format!("{name}:meta:{provider}");
+                                    let query_id = swarm
+                                        .behaviour_mut()
+                                        .kademlia_get_record(key.into_bytes().into());
+                                    self.get_queries.insert(query_id, tx.clone());
+                                }
+
+                                if step.last {
+                                    self.provider_queries.remove(&id);
+                                }
+                            }
+                        }
+                    }
+                    kad::QueryResult::GetProviders(Ok(
+                        kad::GetProvidersOk::FinishedWithNoAdditionalRecord { .. },
+                    )) => {
+                        self.provider_queries.remove(&id);
+                    }
+                    kad::QueryResult::GetProviders(Err(err)) => {
+                        if let Some((_, tx)) = self.provider_queries.remove(&id) {
+                            let _ = tx.send(Err(err.into()));
+                        }
+                    }
+                    kad::QueryResult::StartProviding(res @ Ok(kad::AddProviderOk { .. })) => {
+                        if let Some(tx) = self.start_providing_queries.remove(&id) {
+                            let _ = tx.send(res);
+                        }
+                    }
+                    kad::QueryResult::StartProviding(res @ Err(_)) => {
+                        if let Some(tx) = self.start_providing_queries.remove(&id) {
                             let _ = tx.send(res);
                         }
                     }
@@ -1046,12 +1224,12 @@ pub enum SwarmCommand {
         /// Peer ID.
         peer_id: PeerId,
     },
-    /// Lookup an actor by name in the kademlia network.
+    /// Lookup providers for an actor by name in the kademlia network.
     Lookup {
-        /// Kademlia record key.
-        key: kad::RecordKey,
+        /// Registered name.
+        name: String,
         /// Reply sender.
-        reply: oneshot::Sender<Result<kad::PeerRecord, kad::GetRecordError>>,
+        reply: mpsc::UnboundedSender<Result<ActorRegistration<'static>, RegistryError>>,
     },
     /// Lookup an actor by name on the local node only.
     LookupLocal {
@@ -1073,6 +1251,20 @@ pub enum SwarmCommand {
         key: kad::RecordKey,
         /// Reply sender.
         reply: oneshot::Sender<kad::PutRecordResult>,
+    },
+    /// Start providing a key.
+    StartProviding {
+        /// Kademlia record key.
+        key: kad::RecordKey,
+        /// Reply sender.
+        reply: oneshot::Sender<Result<kad::AddProviderOk, kad::AddProviderError>>,
+    },
+    /// Stop providing a key.
+    StopProviding {
+        /// Kademlia record key.
+        key: kad::RecordKey,
+        /// Reply sender.
+        reply: oneshot::Sender<()>,
     },
     /// An actor ask request.
     Ask {
@@ -1468,6 +1660,21 @@ pub trait SwarmBehaviour: NetworkBehaviour {
 
     /// Removes a record locally.
     fn kademlia_remove_record_local(&mut self, key: &kad::RecordKey);
+
+    /// Gets providers for a key from the Kademlia network.
+    fn kademlia_get_providers(&mut self, key: kad::RecordKey) -> kad::QueryId;
+
+    /// Gets providers for a key from local storage only.
+    fn kademlia_get_providers_local(&mut self, key: &kad::RecordKey) -> usize;
+
+    /// Starts providing a key in the Kademlia network.
+    fn kademlia_start_providing(
+        &mut self,
+        key: kad::RecordKey,
+    ) -> Result<kad::QueryId, kad::store::Error>;
+
+    /// Stops providing a key in the Kademlia network.
+    fn kademlia_stop_providing(&mut self, key: &kad::RecordKey);
 }
 
 #[allow(missing_docs)]
@@ -1711,6 +1918,30 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
 
     fn kademlia_remove_record_local(&mut self, key: &kad::RecordKey) {
         self.kademlia.store_mut().remove(key);
+    }
+
+    fn kademlia_get_providers(&mut self, key: kad::RecordKey) -> kad::QueryId {
+        self.kademlia.get_providers(key)
+    }
+
+    fn kademlia_get_providers_local(&mut self, key: &kad::RecordKey) -> usize {
+        // Get providers from local store
+        self.kademlia
+            .store_mut()
+            .provided()
+            .filter(|k| &k.key == key)
+            .count()
+    }
+
+    fn kademlia_start_providing(
+        &mut self,
+        key: kad::RecordKey,
+    ) -> Result<kad::QueryId, kad::store::Error> {
+        self.kademlia.start_providing(key)
+    }
+
+    fn kademlia_stop_providing(&mut self, key: &kad::RecordKey) {
+        self.kademlia.stop_providing(key);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tqwewe/kameo/issues/131

Uses kademlia providers to support multiple peers registering different actors under the same name.

Previously, registering an actor under an already occupied name would corrupt the DHT, and have somewhat undefined behaviour. This PR improves upon this edge case by using kademlia providers.

TODO:

- [x] Add check when registering to ensure the name is not taken on the local peer.
- [x] Improve docs on regular `fn lookup` method to clarify what happens when multiple are found.