### PR TITLE
ci: improve test and lint coverage for all workspace crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,35 @@ env:
 
 jobs:
   build:
-    name: Build - ${{ matrix.toolchain }}
+    name: Build - ${{ matrix.toolchain }} - ${{ matrix.package }} - ${{ matrix.features }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain: [stable, beta]
-        features: ["--no-default-features", "--no-default-features --features macros", "--no-default-features --features tracing", "--no-default-features --features remote", "-p kameo_actors"]
+        include:
+          # kameo crate with different feature combinations
+          - package: "kameo"
+            features: "--no-default-features"
+          - package: "kameo"
+            features: "--no-default-features --features macros"
+          - package: "kameo"
+            features: "--no-default-features --features tracing"
+          - package: "kameo"
+            features: "--no-default-features --features remote"
+          - package: "kameo"
+            features: "--no-default-features --features macros,tracing"
+          - package: "kameo"
+            features: "--no-default-features --features macros,remote"
+          - package: "kameo"
+            features: "--no-default-features --features tracing,remote"
+          - package: "kameo"
+            features: "--all-features"
+          # kameo_actors crate (no additional features)
+          - package: "kameo_actors"
+            features: ""
+          # kameo_macros crate (no additional features)
+          - package: "kameo_macros"
+            features: ""
     steps:
       - uses: actions/checkout@v4
       
@@ -37,19 +60,42 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
       
       - name: Standard build
-        run: cargo build ${{ matrix.features }}
+        run: cargo build -p ${{ matrix.package }} ${{ matrix.features }}
         
       - name: Tokio unstable build
-        if: "!contains(matrix.features, 'kameo_actors')"
-        run: RUSTFLAGS="--cfg tokio_unstable" cargo build ${{ matrix.features }}
+        if: matrix.package == 'kameo'
+        run: RUSTFLAGS="--cfg tokio_unstable" cargo build -p ${{ matrix.package }} ${{ matrix.features }}
 
   test:
-    name: Test - ${{ matrix.toolchain }}
+    name: Test - ${{ matrix.toolchain }} - ${{ matrix.package }} - ${{ matrix.features }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain: [stable, beta]
-        features: ["--no-default-features", "--no-default-features --features macros", "--no-default-features --features tracing", "--no-default-features --features remote"]
+        include:
+          # kameo crate with different feature combinations
+          - package: "kameo"
+            features: "--no-default-features"
+          - package: "kameo"
+            features: "--no-default-features --features macros"
+          - package: "kameo"
+            features: "--no-default-features --features tracing"
+          - package: "kameo"
+            features: "--no-default-features --features remote"
+          - package: "kameo"
+            features: "--no-default-features --features macros,tracing"
+          - package: "kameo"
+            features: "--no-default-features --features macros,remote"
+          - package: "kameo"
+            features: "--no-default-features --features tracing,remote"
+          - package: "kameo"
+            features: "--all-features"
+          # kameo_actors crate (no additional features)
+          - package: "kameo_actors"
+            features: ""
+          # kameo_macros crate (no additional features)
+          - package: "kameo_macros"
+            features: ""
     steps:
       - uses: actions/checkout@v4
       
@@ -70,22 +116,44 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
       
       - name: Run tests
-        run: cargo test ${{ matrix.features }}
+        run: cargo test -p ${{ matrix.package }} ${{ matrix.features }}
 
   lint:
-    name: Clippy - ${{ matrix.toolchain }}
+    name: Clippy - ${{ matrix.package }} - ${{ matrix.features }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable]
-        features: ["--no-default-features", "--no-default-features --features macros", "--no-default-features --features tracing", "--no-default-features --features remote"]
+        include:
+          # kameo crate with different feature combinations
+          - package: "kameo"
+            features: "--no-default-features"
+          - package: "kameo"
+            features: "--no-default-features --features macros"
+          - package: "kameo"
+            features: "--no-default-features --features tracing"
+          - package: "kameo"
+            features: "--no-default-features --features remote"
+          - package: "kameo"
+            features: "--no-default-features --features macros,tracing"
+          - package: "kameo"
+            features: "--no-default-features --features macros,remote"
+          - package: "kameo"
+            features: "--no-default-features --features tracing,remote"
+          - package: "kameo"
+            features: "--all-features"
+          # kameo_actors crate (no additional features)
+          - package: "kameo_actors"
+            features: ""
+          # kameo_macros crate (no additional features)
+          - package: "kameo_macros"
+            features: ""
     steps:
       - uses: actions/checkout@v4
       
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
           components: clippy
       
@@ -96,8 +164,41 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-stable-
       
       - name: Run clippy
-        run: cargo clippy ${{ matrix.features }}
+        run: cargo clippy -p ${{ matrix.package }} ${{ matrix.features }}
+
+  # Additional job to run workspace-wide checks
+  workspace:
+    name: Workspace checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy, rustfmt
+      
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-stable-
+      
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      
+      - name: Run clippy on workspace
+        run: cargo clippy --workspace --all-features
+      
+      - name: Run tests on workspace
+        run: cargo test --workspace --all-features


### PR DESCRIPTION
- Add explicit coverage for kameo_actors and kameo_macros crates
- Restructure CI matrix to use include for better control
- Add comprehensive feature combination testing for kameo
- Add workspace-wide formatting and clippy checks
- Fix missing clippy runs for kameo_actors crate

Resolves the issue where kameo_actors was not being linted, ensuring all three workspace crates (kameo, kameo_actors, kameo_macros) are properly built, tested, and linted.