### PR TITLE
refactor: rename `ActorID` to `ActorId`

### DIFF
--- a/actors/src/broker.rs
+++ b/actors/src/broker.rs
@@ -95,7 +95,7 @@ impl<M: Send + 'static> Broker<M> {
         }
     }
 
-    fn unsubscribe(&mut self, pattern: &Pattern, actor_id: ActorID) {
+    fn unsubscribe(&mut self, pattern: &Pattern, actor_id: ActorId) {
         if let Some(recipients) = self.subscriptions.get_mut(pattern) {
             recipients.retain(|recipient| recipient.id() != actor_id);
             if recipients.is_empty() {
@@ -138,7 +138,7 @@ pub struct Unsubscribe {
     /// If None, unsubscribe from all topic patterns.
     pub topic: Option<Pattern>,
     /// The ID of the actor to unsubscribe.
-    pub actor_id: ActorID,
+    pub actor_id: ActorId,
 }
 
 impl<M: Send + 'static> Message<Unsubscribe> for Broker<M> {

--- a/actors/src/message_bus.rs
+++ b/actors/src/message_bus.rs
@@ -89,7 +89,7 @@ impl MessageBus {
         }
     }
 
-    fn unsubscribe<M: 'static>(&mut self, actor_id: &ActorID) {
+    fn unsubscribe<M: 'static>(&mut self, actor_id: &ActorId) {
         let type_id = TypeId::of::<M>();
         if let Some(recipients) = self.subscriptions.get_mut(&type_id) {
             recipients.retain(|reg| &reg.actor_id != actor_id);
@@ -128,7 +128,7 @@ impl<M: Send + 'static> Message<Register<M>> for MessageBus {
 /// specified type from the message bus.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Unregister<M> {
-    actor_id: ActorID,
+    actor_id: ActorId,
     phantom: PhantomData<M>,
 }
 
@@ -142,7 +142,7 @@ impl<M> Unregister<M> {
     /// # Returns
     ///
     /// A new `Unregister` message that can be sent to the message bus
-    pub fn new(actor_id: ActorID) -> Self {
+    pub fn new(actor_id: ActorId) -> Self {
         Unregister {
             actor_id,
             phantom: PhantomData,
@@ -248,7 +248,7 @@ impl<M: Clone + Send + 'static> Message<Publish<M>> for MessageBus {
 
 #[derive(Debug)]
 struct Registration {
-    actor_id: ActorID,
+    actor_id: ActorId,
     recipient: Box<dyn Any + Send + Sync>,
 }
 

--- a/actors/src/message_queue.rs
+++ b/actors/src/message_queue.rs
@@ -194,7 +194,7 @@ struct Queue {
 #[derive(Debug)]
 struct Registration {
     /// ID of consuming actor
-    actor_id: ActorID,
+    actor_id: ActorId,
     /// Typed recipient for messages
     recipient: Box<dyn Any + Send + Sync>,
     /// Key-value tags associated with this consumer that can be used for filtered message delivery

--- a/actors/src/pool.rs
+++ b/actors/src/pool.rs
@@ -184,7 +184,7 @@ where
     async fn on_link_died(
         &mut self,
         actor_ref: WeakActorRef<Self>,
-        id: ActorID,
+        id: ActorId,
         _reason: ActorStopReason,
     ) -> Result<ControlFlow<ActorStopReason>, Self::Error> {
         let Some(actor_ref) = actor_ref.upgrade() else {

--- a/actors/src/pubsub.rs
+++ b/actors/src/pubsub.rs
@@ -61,7 +61,7 @@ type FilterFn<M> = Box<dyn FnMut(&M) -> bool + Send>;
 /// to manage it directly or interact with it via messages.
 #[allow(missing_debug_implementations)]
 pub struct PubSub<M> {
-    subscribers: HashMap<ActorID, (Subscriber<M>, FilterFn<M>)>,
+    subscribers: HashMap<ActorId, (Subscriber<M>, FilterFn<M>)>,
 }
 
 impl<M> PubSub<M> {

--- a/examples/manual_swarm.rs
+++ b/examples/manual_swarm.rs
@@ -169,7 +169,7 @@ impl SwarmBehaviour for CustomBehaviour {
     fn ask(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -194,7 +194,7 @@ impl SwarmBehaviour for CustomBehaviour {
     fn tell(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -216,9 +216,9 @@ impl SwarmBehaviour for CustomBehaviour {
 
     fn link(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         sibbling_remote_id: Cow<'static, str>,
     ) -> OutboundRequestId {
         self.actor_request_response.send_request(
@@ -234,9 +234,9 @@ impl SwarmBehaviour for CustomBehaviour {
 
     fn unlink(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
     ) -> OutboundRequestId {
         self.actor_request_response.send_request(
             actor_id.peer_id().unwrap(),
@@ -250,8 +250,8 @@ impl SwarmBehaviour for CustomBehaviour {
 
     fn signal_link_died(
         &mut self,
-        dead_actor_id: ActorID,
-        notified_actor_id: ActorID,
+        dead_actor_id: ActorId,
+        notified_actor_id: ActorId,
         notified_actor_remote_id: Cow<'static, str>,
         stop_reason: kameo::error::ActorStopReason,
     ) -> OutboundRequestId {

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -6,14 +6,14 @@ use kameo_actors::pool::{ActorPool, Broadcast, Dispatch};
 #[derive(Actor, Default)]
 struct MyActor;
 
-struct PrintActorID;
+struct PrintActorId;
 
-impl Message<PrintActorID> for MyActor {
+impl Message<PrintActorId> for MyActor {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: PrintActorID,
+        _: PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("Hello from {}", ctx.actor_ref().id());
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Print IDs 0, 2, 4, 6, 8
     for _ in 0..5 {
-        pool.tell(Dispatch(PrintActorID)).await?;
+        pool.tell(Dispatch(PrintActorId)).await?;
     }
 
     // Force all workers to stop, causing them to be restarted
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // New IDs 11, 13, 15, 17, 19 will be printed
     for _ in 0..5 {
-        pool.tell(Dispatch(PrintActorID)).await?;
+        pool.tell(Dispatch(PrintActorId)).await?;
     }
 
     tokio::time::sleep(Duration::from_millis(200)).await;

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -2,17 +2,17 @@ use kameo::prelude::*;
 use kameo_actors::pubsub::{PubSub, Publish, Subscribe};
 
 #[derive(Clone)]
-struct PrintActorID;
+struct PrintActorId;
 
 #[derive(Actor, Default)]
 struct ActorA;
 
-impl Message<PrintActorID> for ActorA {
+impl Message<PrintActorId> for ActorA {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: PrintActorID,
+        _: PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorA: {}", ctx.actor_ref().id());
@@ -22,12 +22,12 @@ impl Message<PrintActorID> for ActorA {
 #[derive(Actor, Default)]
 struct ActorB;
 
-impl Message<PrintActorID> for ActorB {
+impl Message<PrintActorId> for ActorB {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: PrintActorID,
+        _: PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorB: {}", ctx.actor_ref().id());
@@ -36,14 +36,14 @@ impl Message<PrintActorID> for ActorB {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pubsub = PubSub::spawn(PubSub::<PrintActorID>::new());
+    let pubsub = PubSub::spawn(PubSub::<PrintActorId>::new());
 
     let actor_a = ActorA::spawn(ActorA);
     let actor_b = ActorB::spawn(ActorB);
 
     pubsub.ask(Subscribe(actor_a)).await?;
     pubsub.ask(Subscribe(actor_b)).await?;
-    pubsub.ask(Publish(PrintActorID)).await?;
+    pubsub.ask(Publish(PrintActorId)).await?;
 
     Ok(())
 }

--- a/examples/pubsub_filter.rs
+++ b/examples/pubsub_filter.rs
@@ -2,17 +2,17 @@ use kameo::prelude::*;
 use kameo_actors::pubsub::{PubSub, Publish, Subscribe, SubscribeFilter};
 
 #[derive(Clone)]
-struct PrintActorID(String);
+struct PrintActorId(String);
 
 #[derive(Actor, Default)]
 struct ActorA;
 
-impl Message<PrintActorID> for ActorA {
+impl Message<PrintActorId> for ActorA {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        PrintActorID(msg): PrintActorID,
+        PrintActorId(msg): PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorA: {} - {msg}", ctx.actor_ref().id());
@@ -22,12 +22,12 @@ impl Message<PrintActorID> for ActorA {
 #[derive(Actor, Default)]
 struct ActorB;
 
-impl Message<PrintActorID> for ActorB {
+impl Message<PrintActorId> for ActorB {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        PrintActorID(msg): PrintActorID,
+        PrintActorId(msg): PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorB: {} - {msg}", ctx.actor_ref().id());
@@ -37,12 +37,12 @@ impl Message<PrintActorID> for ActorB {
 #[derive(Actor, Default)]
 struct ActorC;
 
-impl Message<PrintActorID> for ActorC {
+impl Message<PrintActorId> for ActorC {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        PrintActorID(msg): PrintActorID,
+        PrintActorId(msg): PrintActorId,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         println!("ActorC: {} - {msg}", ctx.actor_ref().id());
@@ -51,31 +51,31 @@ impl Message<PrintActorID> for ActorC {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pubsub = PubSub::spawn(PubSub::<PrintActorID>::new());
+    let pubsub = PubSub::spawn(PubSub::<PrintActorId>::new());
 
     let actor_a = ActorA::spawn(ActorA);
     let actor_b = ActorB::spawn(ActorB);
     let actor_c = ActorC::spawn(ActorC);
 
     pubsub
-        .ask(SubscribeFilter(actor_a, |m: &PrintActorID| {
+        .ask(SubscribeFilter(actor_a, |m: &PrintActorId| {
             m.0.starts_with("TopicA:")
         }))
         .await?;
     pubsub
-        .ask(SubscribeFilter(actor_b, |m: &PrintActorID| {
+        .ask(SubscribeFilter(actor_b, |m: &PrintActorId| {
             m.0.starts_with("TopicB:")
         }))
         .await?;
     pubsub.ask(Subscribe(actor_c)).await?;
 
     pubsub
-        .ask(Publish(PrintActorID(
+        .ask(Publish(PrintActorId(
             "TopicA: Some important note".to_string(),
         )))
         .await?;
     pubsub
-        .ask(Publish(PrintActorID(
+        .ask(Publish(PrintActorId(
             "TopicB: Some very important note".to_string(),
         )))
         .await?;

--- a/macros/src/derive_remote_actor.rs
+++ b/macros/src/derive_remote_actor.rs
@@ -46,8 +46,8 @@ impl ToTokens for DeriveRemoteActor {
                     ::kameo::remote::_internal::RemoteActorFns {
                         link: (
                             |
-                              actor_id: ::kameo::actor::ActorID,
-                              sibbling_id: ::kameo::actor::ActorID,
+                              actor_id: ::kameo::actor::ActorId,
+                              sibbling_id: ::kameo::actor::ActorId,
                               sibbling_remote_id: ::std::borrow::Cow<'static, str>,
                             | {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::link::<
@@ -60,8 +60,8 @@ impl ToTokens for DeriveRemoteActor {
                             }) as ::kameo::remote::_internal::RemoteLinkFn,
                         unlink: (
                             |
-                              actor_id: ::kameo::actor::ActorID,
-                              sibbling_id: ::kameo::actor::ActorID,
+                              actor_id: ::kameo::actor::ActorId,
+                              sibbling_id: ::kameo::actor::ActorId,
                             | {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::unlink::<
                                     #ident #ty_generics,
@@ -72,8 +72,8 @@ impl ToTokens for DeriveRemoteActor {
                             }) as ::kameo::remote::_internal::RemoteUnlinkFn,
                         signal_link_died: (
                             |
-                              dead_actor_id: ::kameo::actor::ActorID,
-                              notified_actor_id: ::kameo::actor::ActorID,
+                              dead_actor_id: ::kameo::actor::ActorId,
+                              notified_actor_id: ::kameo::actor::ActorId,
                               stop_reason: kameo::error::ActorStopReason,
                             | {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::signal_link_died::<

--- a/macros/src/remote_message.rs
+++ b/macros/src/remote_message.rs
@@ -67,7 +67,7 @@ impl RemoteMessage {
                         message_remote_id: <#actor_ty #ty_generics as ::kameo::remote::RemoteMessage<#message_generics>>::REMOTE_ID,
                     },
                     ::kameo::remote::_internal::RemoteMessageFns {
-                        ask: (|actor_id: ::kameo::actor::ActorID,
+                        ask: (|actor_id: ::kameo::actor::ActorId,
                               msg: ::std::vec::Vec<u8>,
                               mailbox_timeout: ::std::option::Option<::std::time::Duration>,
                               reply_timeout: ::std::option::Option<::std::time::Duration>| {
@@ -81,7 +81,7 @@ impl RemoteMessage {
                                     reply_timeout,
                                 ))
                             }) as ::kameo::remote::_internal::RemoteAskFn,
-                        try_ask: (|actor_id: ::kameo::actor::ActorID,
+                        try_ask: (|actor_id: ::kameo::actor::ActorId,
                               msg: ::std::vec::Vec<u8>,
                               reply_timeout: ::std::option::Option<::std::time::Duration>| {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::try_ask::<
@@ -93,7 +93,7 @@ impl RemoteMessage {
                                     reply_timeout,
                                 ))
                             }) as ::kameo::remote::_internal::RemoteTryAskFn,
-                        tell: (|actor_id: ::kameo::actor::ActorID,
+                        tell: (|actor_id: ::kameo::actor::ActorId,
                               msg: ::std::vec::Vec<u8>,
                               mailbox_timeout: ::std::option::Option<::std::time::Duration>| {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::tell::<
@@ -105,7 +105,7 @@ impl RemoteMessage {
                                     mailbox_timeout,
                                 ))
                             }) as ::kameo::remote::_internal::RemoteTellFn,
-                        try_tell: (|actor_id: ::kameo::actor::ActorID,
+                        try_tell: (|actor_id: ::kameo::actor::ActorId,
                               msg: ::std::vec::Vec<u8>| {
                                 ::std::boxed::Box::pin(::kameo::remote::_internal::try_tell::<
                                     #actor_ty,

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -242,7 +242,7 @@ pub trait Actor: Sized + Send + 'static {
     fn on_link_died(
         &mut self,
         actor_ref: WeakActorRef<Self>,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> impl Future<Output = Result<ControlFlow<ActorStopReason>, Self::Error>> + Send {
         async move {

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -10,7 +10,7 @@ use crate::{
     reply::BoxReplySender,
 };
 
-use super::ActorID;
+use super::ActorId;
 
 pub(crate) trait ActorState<A: Actor>: Sized {
     fn new_from_actor(actor: A, actor_ref: WeakActorRef<A>) -> Self;
@@ -34,7 +34,7 @@ pub(crate) trait ActorState<A: Actor>: Sized {
 
     fn handle_link_died(
         &mut self,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> impl Future<Output = ControlFlow<ActorStopReason>> + Send;
 
@@ -127,7 +127,7 @@ where
     #[inline]
     async fn handle_link_died(
         &mut self,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> ControlFlow<ActorStopReason> {
         let res = AssertUnwindSafe(self.state.on_link_died(

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -30,7 +30,7 @@ use crate::{
     mailbox::{MailboxReceiver, MailboxSender, Signal},
 };
 
-use super::ActorID;
+use super::ActorId;
 
 /// A `PreparedActor` represents an actor that has been initialized and is ready to be either run
 /// in the current task or spawned into a new task.
@@ -393,7 +393,7 @@ where
 
 #[inline]
 #[cfg(feature = "tracing")]
-fn log_actor_stop_reason(id: ActorID, name: &str, reason: &ActorStopReason) {
+fn log_actor_stop_reason(id: ActorId, name: &str, reason: &ActorStopReason) {
     match reason {
         reason @ ActorStopReason::Normal
         | reason @ ActorStopReason::Killed
@@ -411,4 +411,4 @@ fn log_actor_stop_reason(id: ActorID, name: &str, reason: &ActorStopReason) {
 }
 
 #[cfg(not(feature = "tracing"))]
-fn log_actor_stop_reason(_id: ActorID, _name: &str, _reason: &ActorStopReason) {}
+fn log_actor_stop_reason(_id: ActorId, _name: &str, _reason: &ActorStopReason) {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ use tokio::{
     time::error::Elapsed,
 };
 
-use crate::{actor::ActorID, mailbox::Signal, reply::ReplyError, Actor};
+use crate::{actor::ActorId, mailbox::Signal, reply::ReplyError, Actor};
 
 type ErrorHookFn = fn(&PanicError);
 
@@ -687,7 +687,7 @@ pub enum ActorStopReason {
     /// Link died.
     LinkDied {
         /// Actor ID.
-        id: ActorID,
+        id: ActorId,
         /// Actor died reason.
         reason: Box<ActorStopReason>,
     },
@@ -843,35 +843,6 @@ impl<'de> Deserialize<'de> for PanicError {
         Ok(PanicError::new(Box::new(s)))
     }
 }
-
-/// Errors that can occur when deserializing an `ActorID` from bytes.
-#[derive(Debug)]
-pub enum ActorIDFromBytesError {
-    /// The byte slice doesn't contain enough data for the `sequence_id`.
-    MissingSequenceID,
-    /// An error occurred while parsing the `PeerId`.
-    #[cfg(feature = "remote")]
-    ParsePeerID(libp2p_identity::ParseError),
-}
-
-#[cfg(feature = "remote")]
-impl From<libp2p_identity::ParseError> for ActorIDFromBytesError {
-    fn from(err: libp2p_identity::ParseError) -> Self {
-        ActorIDFromBytesError::ParsePeerID(err)
-    }
-}
-
-impl fmt::Display for ActorIDFromBytesError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ActorIDFromBytesError::MissingSequenceID => write!(f, "missing instance ID"),
-            #[cfg(feature = "remote")]
-            ActorIDFromBytesError::ParsePeerID(err) => err.fmt(f),
-        }
-    }
-}
-
-impl error::Error for ActorIDFromBytesError {}
 
 /// An infallible error type, similar to [std::convert::Infallible].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,12 @@ pub mod prelude {
     #[cfg(feature = "macros")]
     pub use kameo_macros::{messages, remote_message, Actor, RemoteActor, Reply};
 
+    #[allow(deprecated)]
+    pub use crate::actor::ActorID;
     #[cfg(feature = "remote")]
     pub use crate::actor::RemoteActorRef;
     pub use crate::actor::{
-        Actor, ActorID, ActorRef, PreparedActor, Recipient, ReplyRecipient, WeakActorRef,
+        Actor, ActorId, ActorRef, PreparedActor, Recipient, ReplyRecipient, WeakActorRef,
         WeakRecipient, WeakReplyRecipient,
     };
     #[cfg(feature = "remote")]

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -12,7 +12,7 @@ use futures::{future::BoxFuture, FutureExt};
 use tokio::sync::mpsc::{self, error::TryRecvError};
 
 use crate::{
-    actor::{ActorID, ActorRef},
+    actor::{ActorId, ActorRef},
     error::{ActorStopReason, SendError},
     message::BoxMessage,
     reply::BoxReplySender,
@@ -455,7 +455,7 @@ pub enum Signal<A: Actor> {
     /// A linked actor has died.
     LinkDied {
         /// The dead actor's ID.
-        id: ActorID,
+        id: ActorId,
         /// The reason the actor stopped.
         reason: ActorStopReason,
     },
@@ -480,7 +480,7 @@ pub trait SignalMailbox: DynClone + Send + Sync {
     fn signal_startup_finished(&self) -> Result<(), SendError>;
     fn signal_link_died(
         &self,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> BoxFuture<'_, Result<(), SendError>>;
     fn signal_stop(&self) -> BoxFuture<'_, Result<(), SendError>>;
@@ -507,7 +507,7 @@ where
 
     fn signal_link_died(
         &self,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> BoxFuture<'_, Result<(), SendError>> {
         match self {
@@ -555,7 +555,7 @@ where
 
     fn signal_link_died(
         &self,
-        id: ActorID,
+        id: ActorId,
         reason: ActorStopReason,
     ) -> BoxFuture<'_, Result<(), SendError>> {
         async move {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -62,7 +62,7 @@ use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 
 use crate::{
-    actor::{ActorID, Links},
+    actor::{ActorId, Links},
     error::{ActorStopReason, Infallible, RemoteSendError},
     mailbox::SignalMailbox,
 };
@@ -73,7 +73,7 @@ mod swarm;
 
 pub use swarm::*;
 
-pub(crate) static REMOTE_REGISTRY: Lazy<Mutex<HashMap<ActorID, RemoteRegistryActorRef>>> =
+pub(crate) static REMOTE_REGISTRY: Lazy<Mutex<HashMap<ActorId, RemoteRegistryActorRef>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 pub(crate) struct RemoteRegistryActorRef {
@@ -148,7 +148,7 @@ pub trait RemoteMessage<M> {
 }
 
 pub(crate) async fn ask(
-    actor_id: ActorID,
+    actor_id: ActorId,
     actor_remote_id: Cow<'static, str>,
     message_remote_id: Cow<'static, str>,
     payload: Vec<u8>,
@@ -173,7 +173,7 @@ pub(crate) async fn ask(
 }
 
 pub(crate) async fn tell(
-    actor_id: ActorID,
+    actor_id: ActorId,
     actor_remote_id: Cow<'static, str>,
     message_remote_id: Cow<'static, str>,
     payload: Vec<u8>,
@@ -197,9 +197,9 @@ pub(crate) async fn tell(
 }
 
 pub(crate) async fn link(
-    actor_id: ActorID,
+    actor_id: ActorId,
     actor_remote_id: Cow<'static, str>,
-    sibbling_id: ActorID,
+    sibbling_id: ActorId,
     sibbling_remote_id: Cow<'static, str>,
 ) -> Result<(), RemoteSendError<Infallible>> {
     let Some(fns) = REMOTE_ACTORS_MAP.get(&*actor_remote_id) else {
@@ -210,9 +210,9 @@ pub(crate) async fn link(
 }
 
 pub(crate) async fn unlink(
-    actor_id: ActorID,
+    actor_id: ActorId,
     actor_remote_id: Cow<'static, str>,
-    sibbling_id: ActorID,
+    sibbling_id: ActorId,
 ) -> Result<(), RemoteSendError<Infallible>> {
     let Some(fns) = REMOTE_ACTORS_MAP.get(&*actor_remote_id) else {
         return Err(RemoteSendError::UnknownActor { actor_remote_id });
@@ -222,8 +222,8 @@ pub(crate) async fn unlink(
 }
 
 pub(crate) async fn signal_link_died(
-    dead_actor_id: ActorID,
-    notified_actor_id: ActorID,
+    dead_actor_id: ActorId,
+    notified_actor_id: ActorId,
     notified_actor_remote_id: Cow<'static, str>,
     stop_reason: ActorStopReason,
 ) -> Result<(), RemoteSendError<Infallible>> {

--- a/src/remote/_internal.rs
+++ b/src/remote/_internal.rs
@@ -6,7 +6,7 @@ pub use linkme;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::actor::{ActorID, ActorRef, Link};
+use crate::actor::{ActorId, ActorRef, Link};
 use crate::error::{ActorStopReason, Infallible, RemoteSendError};
 use crate::message::Message;
 use crate::{Actor, Reply};
@@ -35,41 +35,41 @@ pub struct RemoteMessageFns {
 }
 
 pub type RemoteAskFn = fn(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
     reply_timeout: Option<Duration>,
 ) -> BoxFuture<'static, Result<Vec<u8>, RemoteSendError<Vec<u8>>>>;
 
 pub type RemoteTryAskFn = fn(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     reply_timeout: Option<Duration>,
 ) -> BoxFuture<'static, Result<Vec<u8>, RemoteSendError<Vec<u8>>>>;
 
 pub type RemoteTellFn = fn(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
 ) -> BoxFuture<'static, Result<(), RemoteSendError>>;
 
 pub type RemoteTryTellFn =
-    fn(actor_id: ActorID, msg: Vec<u8>) -> BoxFuture<'static, Result<(), RemoteSendError>>;
+    fn(actor_id: ActorId, msg: Vec<u8>) -> BoxFuture<'static, Result<(), RemoteSendError>>;
 
 pub type RemoteLinkFn = fn(
-    actor_id: ActorID,
-    sibbling_id: ActorID,
+    actor_id: ActorId,
+    sibbling_id: ActorId,
     sibbling_remote_id: Cow<'static, str>,
 ) -> BoxFuture<'static, Result<(), RemoteSendError<Infallible>>>;
 
 pub type RemoteUnlinkFn = fn(
-    actor_id: ActorID,
-    sibbling_id: ActorID,
+    actor_id: ActorId,
+    sibbling_id: ActorId,
 ) -> BoxFuture<'static, Result<(), RemoteSendError<Infallible>>>;
 
 pub type RemoteSignalLinkDiedFn = fn(
-    dead_actor_id: ActorID,
-    notified_actor_id: ActorID,
+    dead_actor_id: ActorId,
+    notified_actor_id: ActorId,
     stop_reason: ActorStopReason,
 )
     -> BoxFuture<'static, Result<(), RemoteSendError<Infallible>>>;
@@ -81,7 +81,7 @@ pub struct RemoteMessageRegistrationID<'a> {
 }
 
 pub async fn ask<A, M>(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
     reply_timeout: Option<Duration>,
@@ -124,7 +124,7 @@ where
 }
 
 pub async fn try_ask<A, M>(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     reply_timeout: Option<Duration>,
 ) -> Result<Vec<u8>, RemoteSendError<Vec<u8>>>
@@ -165,7 +165,7 @@ where
 }
 
 pub async fn tell<A, M>(
-    actor_id: ActorID,
+    actor_id: ActorId,
     msg: Vec<u8>,
     mailbox_timeout: Option<Duration>,
 ) -> Result<(), RemoteSendError>
@@ -197,7 +197,7 @@ where
     }
 }
 
-pub async fn try_tell<A, M>(actor_id: ActorID, msg: Vec<u8>) -> Result<(), RemoteSendError>
+pub async fn try_tell<A, M>(actor_id: ActorId, msg: Vec<u8>) -> Result<(), RemoteSendError>
 where
     A: Actor + Message<M>,
     M: DeserializeOwned + Send + 'static,
@@ -223,8 +223,8 @@ where
 }
 
 pub async fn link<A>(
-    actor_id: ActorID,
-    sibbling_id: ActorID,
+    actor_id: ActorId,
+    sibbling_id: ActorId,
     sibbling_remote_id: Cow<'static, str>,
 ) -> Result<(), RemoteSendError<Infallible>>
 where
@@ -251,8 +251,8 @@ where
 }
 
 pub async fn unlink<A>(
-    actor_id: ActorID,
-    sibbling_id: ActorID,
+    actor_id: ActorId,
+    sibbling_id: ActorId,
 ) -> Result<(), RemoteSendError<Infallible>>
 where
     A: Actor,
@@ -274,8 +274,8 @@ where
 }
 
 pub async fn signal_link_died<A>(
-    dead_actor_id: ActorID,
-    notified_actor_id: ActorID,
+    dead_actor_id: ActorId,
+    notified_actor_id: ActorId,
     stop_reason: ActorStopReason,
 ) -> Result<(), RemoteSendError<Infallible>>
 where

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
-    actor::{ActorID, ActorRef, RemoteActorRef},
+    actor::{ActorId, ActorRef, RemoteActorRef},
     error::{ActorStopReason, BootstrapError, Infallible, RegistryError, RemoteSendError},
     remote, Actor,
 };
@@ -450,8 +450,8 @@ impl ActorSwarm {
 
     pub(crate) fn link<A: Actor + RemoteActor, B: Actor + RemoteActor>(
         &self,
-        actor_id: ActorID,
-        sibbling_id: ActorID,
+        actor_id: ActorId,
+        sibbling_id: ActorId,
     ) -> impl Future<Output = Result<(), RemoteSendError<Infallible>>> {
         let reply_rx = self.swarm_tx.send_with_reply(|reply| SwarmCommand::Link {
             actor_id,
@@ -472,8 +472,8 @@ impl ActorSwarm {
 
     pub(crate) fn unlink<B: Actor + RemoteActor>(
         &self,
-        actor_id: ActorID,
-        sibbling_id: ActorID,
+        actor_id: ActorId,
+        sibbling_id: ActorId,
     ) -> impl Future<Output = Result<(), RemoteSendError<Infallible>>> {
         let reply_rx = self.swarm_tx.send_with_reply(|reply| SwarmCommand::Unlink {
             actor_id,
@@ -493,8 +493,8 @@ impl ActorSwarm {
 
     pub(crate) fn signal_link_died(
         &self,
-        dead_actor_id: ActorID,
-        notified_actor_id: ActorID,
+        dead_actor_id: ActorId,
+        notified_actor_id: ActorId,
         notified_actor_remote_id: Cow<'static, str>,
         stop_reason: ActorStopReason,
     ) -> impl Future<Output = Result<(), RemoteSendError<Infallible>>> {
@@ -1315,7 +1315,7 @@ pub enum SwarmCommand {
         /// Peer ID.
         peer_id: PeerId,
         /// Actor ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor remote ID.
         actor_remote_id: Cow<'static, str>,
         /// Message remote ID.
@@ -1336,7 +1336,7 @@ pub enum SwarmCommand {
         /// Peer ID.
         peer_id: PeerId,
         /// Actor ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor remote ID.
         actor_remote_id: Cow<'static, str>,
         /// Message remote ID.
@@ -1367,11 +1367,11 @@ pub enum SwarmCommand {
     /// An actor link request.
     Link {
         /// Actor A ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor A remote ID.
         actor_remote_id: Cow<'static, str>,
         /// Actor B ID.
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         /// Actor B remote ID.
         sibbling_remote_id: Cow<'static, str>,
         /// Reply sender.
@@ -1387,9 +1387,9 @@ pub enum SwarmCommand {
     /// An actor unlink request.
     Unlink {
         /// Actor A ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor B ID.
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         /// Actor B remote ID.
         sibbling_remote_id: Cow<'static, str>,
         /// Reply sender.
@@ -1405,9 +1405,9 @@ pub enum SwarmCommand {
     /// Notifies a linked actor has died.
     SignalLinkDied {
         /// The actor which died.
-        dead_actor_id: ActorID,
+        dead_actor_id: ActorId,
         /// The actor to notify.
-        notified_actor_id: ActorID,
+        notified_actor_id: ActorId,
         /// Actor remote iD
         notified_actor_remote_id: Cow<'static, str>,
         /// The reason the actor died.
@@ -1427,12 +1427,12 @@ pub enum SwarmCommand {
 /// An actor registration record.
 #[derive(Debug)]
 pub struct ActorRegistration<'a> {
-    actor_id: ActorID,
+    actor_id: ActorId,
     remote_id: Cow<'a, str>,
 }
 
 impl<'a> ActorRegistration<'a> {
-    fn new(actor_id: ActorID, remote_id: Cow<'a, str>) -> Self {
+    fn new(actor_id: ActorId, remote_id: Cow<'a, str>) -> Self {
         ActorRegistration {
             actor_id,
             remote_id,
@@ -1451,7 +1451,7 @@ impl<'a> ActorRegistration<'a> {
 
     fn from_bytes(bytes: &'a [u8]) -> Self {
         let peer_id_bytes_len = u8::from_le_bytes(bytes[..1].try_into().unwrap()) as usize;
-        let actor_id = ActorID::from_bytes(&bytes[1..1 + 8 + peer_id_bytes_len]).unwrap();
+        let actor_id = ActorId::from_bytes(&bytes[1..1 + 8 + peer_id_bytes_len]).unwrap();
         let remote_id = std::str::from_utf8(&bytes[1 + 8 + peer_id_bytes_len..]).unwrap();
         ActorRegistration::new(actor_id, Cow::Borrowed(remote_id))
     }
@@ -1469,7 +1469,7 @@ pub enum SwarmRequest {
     /// This variant includes information about the actor, the message, payload, and timeout settings.
     Ask {
         /// Identifier of the actor initiating the request.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Remote identifier of the actor as a static string.
         actor_remote_id: Cow<'static, str>,
         /// Remote identifier of the message as a static string.
@@ -1488,7 +1488,7 @@ pub enum SwarmRequest {
     /// This variant includes information about the actor, the message, payload, and timeout settings.
     Tell {
         /// Identifier of the actor initiating the message.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Remote identifier of the actor as a static string.
         actor_remote_id: Cow<'static, str>,
         /// Remote identifier of the message as a static string.
@@ -1503,29 +1503,29 @@ pub enum SwarmRequest {
     /// A request to link two actors together.
     Link {
         /// Actor ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor remote ID.
         actor_remote_id: Cow<'static, str>,
         /// Sibbling ID.
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         /// Sibbling remote ID.
         sibbling_remote_id: Cow<'static, str>,
     },
     /// A request to unlink two actors.
     Unlink {
         /// Actor ID.
-        actor_id: ActorID,
+        actor_id: ActorId,
         /// Actor remote ID.
         actor_remote_id: Cow<'static, str>,
         /// Sibbling ID.
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
     },
     /// A signal notifying a linked actor has died.
     SignalLinkDied {
         /// The actor which died.
-        dead_actor_id: ActorID,
+        dead_actor_id: ActorId,
         /// The actor to notify.
-        notified_actor_id: ActorID,
+        notified_actor_id: ActorId,
         /// The actor to notify.
         notified_actor_remote_id: Cow<'static, str>,
         /// The reason the actor died.
@@ -1570,7 +1570,7 @@ pub trait SwarmBehaviour: NetworkBehaviour {
     fn ask(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -1586,7 +1586,7 @@ pub trait SwarmBehaviour: NetworkBehaviour {
     fn tell(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -1597,25 +1597,25 @@ pub trait SwarmBehaviour: NetworkBehaviour {
     /// Sends a link request.
     fn link(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         sibbling_remote_id: Cow<'static, str>,
     ) -> OutboundRequestId;
 
     /// Sends a unlink request.
     fn unlink(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
     ) -> OutboundRequestId;
 
     /// Sends a signal notifying that a linked actor has died.
     fn signal_link_died(
         &mut self,
-        dead_actor_id: ActorID,
-        notified_actor_id: ActorID,
+        dead_actor_id: ActorId,
+        notified_actor_id: ActorId,
         notified_actor_remote_id: Cow<'static, str>,
         stop_reason: ActorStopReason,
     ) -> OutboundRequestId;
@@ -1786,7 +1786,7 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
     fn ask(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -1811,7 +1811,7 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
     fn tell(
         &mut self,
         peer: &PeerId,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
         message_remote_id: Cow<'static, str>,
         payload: Vec<u8>,
@@ -1833,9 +1833,9 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
 
     fn link(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
         sibbling_remote_id: Cow<'static, str>,
     ) -> OutboundRequestId {
         self.request_response.send_request(
@@ -1851,9 +1851,9 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
 
     fn unlink(
         &mut self,
-        actor_id: ActorID,
+        actor_id: ActorId,
         actor_remote_id: Cow<'static, str>,
-        sibbling_id: ActorID,
+        sibbling_id: ActorId,
     ) -> OutboundRequestId {
         self.request_response.send_request(
             actor_id.peer_id().unwrap(),
@@ -1867,8 +1867,8 @@ impl SwarmBehaviour for ActorSwarmBehaviour {
 
     fn signal_link_died(
         &mut self,
-        dead_actor_id: ActorID,
-        notified_actor_id: ActorID,
+        dead_actor_id: ActorId,
+        notified_actor_id: ActorId,
         notified_actor_remote_id: Cow<'static, str>,
         stop_reason: ActorStopReason,
     ) -> OutboundRequestId {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -54,7 +54,7 @@ use tokio::sync::oneshot;
 
 use crate::{
     actor::{
-        ActorID, ActorRef, PreparedActor, Recipient, ReplyRecipient, WeakActorRef, WeakRecipient,
+        ActorId, ActorRef, PreparedActor, Recipient, ReplyRecipient, WeakActorRef, WeakRecipient,
         WeakReplyRecipient,
     },
     error::{ActorStopReason, BoxSendError, Infallible, PanicError, SendError},
@@ -383,7 +383,7 @@ macro_rules! impl_infallible_reply {
 }
 
 impl_infallible_reply!([
-    ActorID,
+    ActorId,
     {A: Actor} ActorRef<A>,
     {A: Actor} PreparedActor<A>,
     {M: Send} Recipient<M>,


### PR DESCRIPTION
To better align with rust naming conventions, this PR renames `ActorID` to `ActorId`.

For backwards compatibility, `ActorID` is still available as a type alias, but is deprecated.