### PR TITLE
chore(id): encapsulate remote feature behind feature flag

### DIFF
--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -114,18 +114,19 @@ impl ActorId {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(8 + 42);
         bytes.extend(&self.sequence_id.to_le_bytes());
-
+        
         #[cfg(feature = "remote")]
-        let peer_id_bytes = self
-            .peer_id
-            .peer_id()
-            .map(|peer_id| peer_id.to_bytes())
-            .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
-        #[cfg(feature = "remote")]
-        if let Some(peer_id_bytes) = peer_id_bytes {
-            bytes.extend(peer_id_bytes);
+        {
+            let peer_id_bytes = self
+                .peer_id()
+                .map(|peer_id| peer_id.to_bytes())
+                .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
+            
+            if let Some(peer_id_bytes) = peer_id_bytes {
+                bytes.extend(peer_id_bytes);
+            }
         }
-
+        
         bytes
     }
 

--- a/src/actor/id.rs
+++ b/src/actor/id.rs
@@ -114,19 +114,19 @@ impl ActorId {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(8 + 42);
         bytes.extend(&self.sequence_id.to_le_bytes());
-        
+
         #[cfg(feature = "remote")]
         {
             let peer_id_bytes = self
                 .peer_id()
                 .map(|peer_id| peer_id.to_bytes())
                 .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
-            
+
             if let Some(peer_id_bytes) = peer_id_bytes {
                 bytes.extend(peer_id_bytes);
             }
         }
-        
+
         bytes
     }
 


### PR DESCRIPTION
Kind of small, though you can encapsulate these type of cases within code block. :)

Old Version
```rust
let peer_id_bytes = self
            .peer_id
            .peer_id()
            .map(|peer_id| peer_id.to_bytes())
            .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
#[cfg(feature = "remote")]
if let Some(peer_id_bytes) = peer_id_bytes {
            bytes.extend(peer_id_bytes);
}
```

New Version 
```rust
#[cfg(feature = "remote")]
{
    let peer_id_bytes = self
                .peer_id()
                .map(|peer_id| peer_id.to_bytes())
                .or_else(|| ActorSwarm::get().map(|swarm| swarm.local_peer_id().to_bytes()));
            
    if let Some(peer_id_bytes) = peer_id_bytes {
                bytes.extend(peer_id_bytes);
    }
}
```