### PR TITLE
feat!: add fire-and-forget option for remote tell requests

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -1370,7 +1370,7 @@ where
     /// # tokio_test::block_on(async {
     /// let remote_actor_ref = RemoteActorRef::<MyActor>::lookup("my_actor").await?.unwrap();
     /// # let msg = Msg;
-    /// remote_actor_ref.tell(&msg).await?;
+    /// remote_actor_ref.tell(&msg).send()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// ```

--- a/src/remote/behaviour.rs
+++ b/src/remote/behaviour.rs
@@ -196,7 +196,7 @@ impl Behaviour {
                     payload,
                     mailbox_timeout,
                     immediate,
-                    Some(reply),
+                    reply,
                 );
                 true
             }

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -459,7 +459,7 @@ pub(crate) enum SwarmCommand {
         /// Fail if mailbox is full.
         immediate: bool,
         /// Reply sender.
-        reply: oneshot::Sender<SwarmResponse>,
+        reply: Option<oneshot::Sender<SwarmResponse>>,
     },
     /// An actor link request.
     Link {

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -2,9 +2,6 @@ use std::{future::IntoFuture, time::Duration};
 
 use futures::{future::BoxFuture, FutureExt};
 
-#[cfg(feature = "remote")]
-use crate::{actor, error, remote};
-
 use crate::{
     actor::{ActorRef, Recipient, ReplyRecipient},
     error::SendError,
@@ -363,152 +360,183 @@ where
     }
 }
 
-/// A request to send a message to a remote actor without any reply.
-///
-/// This can be thought of as "fire and forget".
 #[cfg(feature = "remote")]
-#[allow(missing_debug_implementations)]
-#[must_use = "request won't be sent without awaiting, or calling a send method"]
-pub struct RemoteTellRequest<'a, A, M, Tm>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: Send + 'static,
-{
-    actor_ref: &'a actor::RemoteActorRef<A>,
-    msg: &'a M,
-    mailbox_timeout: Tm,
-    #[cfg(all(debug_assertions, feature = "tracing"))]
-    called_at: &'static std::panic::Location<'static>,
-}
+pub use remote::RemoteTellRequest;
 
 #[cfg(feature = "remote")]
-impl<'a, A, M, Tm> RemoteTellRequest<'a, A, M, Tm>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: Send + 'static,
-    Tm: Default,
-{
-    pub(crate) fn new(
-        actor_ref: &'a actor::RemoteActorRef<A>,
+mod remote {
+    use std::{borrow::Cow, time::Duration};
+
+    use serde::Serialize;
+    use tokio::sync::oneshot;
+
+    use crate::{
+        actor::RemoteActorRef,
+        error::RemoteSendError,
+        message::Message,
+        remote::{messaging, RemoteActor, RemoteMessage, SwarmCommand},
+        request::{WithRequestTimeout, WithoutRequestTimeout},
+        Actor,
+    };
+
+    /// A request to send a message to a remote actor without any reply.
+    ///
+    /// This can be thought of as "fire and forget".
+    #[allow(missing_debug_implementations)]
+    #[must_use = "request won't be sent without awaiting, or calling a send method"]
+    pub struct RemoteTellRequest<'a, A, M, Tm>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Send + 'static,
+    {
+        actor_ref: &'a RemoteActorRef<A>,
         msg: &'a M,
-        #[cfg(all(debug_assertions, feature = "tracing"))] called_at: &'static std::panic::Location<
-            'static,
-        >,
-    ) -> Self {
-        RemoteTellRequest {
-            actor_ref,
-            msg,
-            mailbox_timeout: Tm::default(),
+        mailbox_timeout: Tm,
+        #[cfg(all(debug_assertions, feature = "tracing"))]
+        called_at: &'static std::panic::Location<'static>,
+    }
+
+    impl<'a, A, M, Tm> RemoteTellRequest<'a, A, M, Tm>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Send + 'static,
+        Tm: Default,
+    {
+        pub(crate) fn new(
+            actor_ref: &'a RemoteActorRef<A>,
+            msg: &'a M,
             #[cfg(all(debug_assertions, feature = "tracing"))]
-            called_at,
+            called_at: &'static std::panic::Location<'static>,
+        ) -> Self {
+            RemoteTellRequest {
+                actor_ref,
+                msg,
+                mailbox_timeout: Tm::default(),
+                #[cfg(all(debug_assertions, feature = "tracing"))]
+                called_at,
+            }
         }
     }
-}
 
-#[cfg(feature = "remote")]
-impl<'a, A, M, Tm> RemoteTellRequest<'a, A, M, Tm>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize + Send + 'static,
-{
-    /// Sets the timeout for waiting for the actors mailbox to have capacity.
-    pub fn mailbox_timeout(
-        self,
-        duration: Duration,
-    ) -> RemoteTellRequest<'a, A, M, WithRequestTimeout> {
-        self.mailbox_timeout_opt(Some(duration))
-    }
+    impl<'a, A, M, Tm> RemoteTellRequest<'a, A, M, Tm>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Serialize + Send + 'static,
+    {
+        /// Sets the timeout for waiting for the actors mailbox to have capacity.
+        pub fn mailbox_timeout(
+            self,
+            duration: Duration,
+        ) -> RemoteTellRequest<'a, A, M, WithRequestTimeout> {
+            self.mailbox_timeout_opt(Some(duration))
+        }
 
-    pub(crate) fn mailbox_timeout_opt(
-        self,
-        duration: Option<Duration>,
-    ) -> RemoteTellRequest<'a, A, M, WithRequestTimeout> {
-        RemoteTellRequest {
-            actor_ref: self.actor_ref,
-            msg: self.msg,
-            mailbox_timeout: WithRequestTimeout(duration),
-            #[cfg(all(debug_assertions, feature = "tracing"))]
-            called_at: self.called_at,
+        pub(crate) fn mailbox_timeout_opt(
+            self,
+            duration: Option<Duration>,
+        ) -> RemoteTellRequest<'a, A, M, WithRequestTimeout> {
+            RemoteTellRequest {
+                actor_ref: self.actor_ref,
+                msg: self.msg,
+                mailbox_timeout: WithRequestTimeout(duration),
+                #[cfg(all(debug_assertions, feature = "tracing"))]
+                called_at: self.called_at,
+            }
         }
     }
-}
 
-#[cfg(feature = "remote")]
-impl<A, M, Tm> RemoteTellRequest<'_, A, M, Tm>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize + Send + 'static,
-    Tm: Into<Option<Duration>>,
-{
-    /// Sends the message.
-    pub async fn send(self) -> Result<(), error::RemoteSendError> {
-        remote_tell(self.actor_ref, self.msg, self.mailbox_timeout.into(), false).await
-    }
-}
-
-#[cfg(feature = "remote")]
-impl<A, M> RemoteTellRequest<'_, A, M, WithoutRequestTimeout>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize + Send + 'static,
-{
-    /// Tries to send the message without waiting for mailbox capacity.
-    pub async fn try_send(self) -> Result<(), error::RemoteSendError> {
-        remote_tell(self.actor_ref, self.msg, self.mailbox_timeout.into(), true).await
-    }
-}
-
-#[cfg(feature = "remote")]
-impl<'a, A, M, Tm> IntoFuture for RemoteTellRequest<'a, A, M, Tm>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize + Send + Sync + 'static,
-    Tm: Into<Option<Duration>> + Send + 'static,
-{
-    type Output = Result<(), error::RemoteSendError>;
-    type IntoFuture = BoxFuture<'a, Self::Output>;
-
-    fn into_future(self) -> Self::IntoFuture {
-        self.send().boxed()
-    }
-}
-
-#[cfg(feature = "remote")]
-async fn remote_tell<A, M>(
-    actor_ref: &actor::RemoteActorRef<A>,
-    msg: &M,
-    mailbox_timeout: Option<Duration>,
-    immediate: bool,
-) -> Result<(), error::RemoteSendError>
-where
-    A: Actor + Message<M> + remote::RemoteActor + remote::RemoteMessage<M>,
-    M: serde::Serialize + Send + 'static,
-{
-    use remote::*;
-    use std::borrow::Cow;
-
-    let actor_id = actor_ref.id();
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    actor_ref.send_to_swarm(SwarmCommand::Tell {
-        actor_id,
-        actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
-        message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
-        payload: rmp_serde::to_vec_named(msg)
-            .map_err(|err| error::RemoteSendError::SerializeMessage(err.to_string()))?,
-        mailbox_timeout,
-        immediate,
-        reply: reply_tx,
-    });
-
-    match reply_rx.await.unwrap() {
-        messaging::SwarmResponse::Tell(res) => match res {
-            Ok(()) => Ok(()),
-            Err(err) => Err(err),
-        },
-        messaging::SwarmResponse::OutboundFailure(err) => {
-            Err(err.map_err(|_| unreachable!("outbound failure doesn't contain handler errors")))
+    impl<A, M, Tm> RemoteTellRequest<'_, A, M, Tm>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Serialize + Send + 'static,
+        Tm: Into<Option<Duration>>,
+    {
+        /// Sends the message fire-and-forget style (fast, no delivery confirmation).
+        pub fn send(self) -> Result<(), RemoteSendError> {
+            remote_tell(self.actor_ref, self.msg, self.mailbox_timeout.into(), false)
         }
-        _ => panic!("unexpected response"),
+
+        /// Sends the message and waits for delivery acknowledgment (reliable, slower).
+        pub async fn send_ack(self) -> Result<(), RemoteSendError> {
+            remote_tell_ack(self.actor_ref, self.msg, self.mailbox_timeout.into(), false).await
+        }
+    }
+
+    impl<A, M> RemoteTellRequest<'_, A, M, WithoutRequestTimeout>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: serde::Serialize + Send + 'static,
+    {
+        /// Tries to send the message fire-and-forget style, failing immediately if mailbox is full.
+        pub async fn try_send(self) -> Result<(), RemoteSendError> {
+            remote_tell(self.actor_ref, self.msg, self.mailbox_timeout.into(), true)
+        }
+
+        /// Tries to send the message with acknowledgment, failing immediately if mailbox is full.
+        pub async fn try_send_ack(self) -> Result<(), RemoteSendError> {
+            remote_tell_ack(self.actor_ref, self.msg, self.mailbox_timeout.into(), true).await
+        }
+    }
+
+    fn remote_tell<A, M>(
+        actor_ref: &RemoteActorRef<A>,
+        msg: &M,
+        mailbox_timeout: Option<Duration>,
+        immediate: bool,
+    ) -> Result<(), RemoteSendError>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Serialize + Send + 'static,
+    {
+        let actor_id = actor_ref.id();
+        actor_ref.send_to_swarm(SwarmCommand::Tell {
+            actor_id,
+            actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
+            message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
+            payload: rmp_serde::to_vec_named(msg)
+                .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
+            mailbox_timeout,
+            immediate,
+            reply: None,
+        });
+
+        Ok(())
+    }
+
+    async fn remote_tell_ack<A, M>(
+        actor_ref: &RemoteActorRef<A>,
+        msg: &M,
+        mailbox_timeout: Option<Duration>,
+        immediate: bool,
+    ) -> Result<(), RemoteSendError>
+    where
+        A: Actor + Message<M> + RemoteActor + RemoteMessage<M>,
+        M: Serialize + Send + 'static,
+    {
+        let actor_id = actor_ref.id();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        actor_ref.send_to_swarm(SwarmCommand::Tell {
+            actor_id,
+            actor_remote_id: Cow::Borrowed(<A as RemoteActor>::REMOTE_ID),
+            message_remote_id: Cow::Borrowed(<A as RemoteMessage<M>>::REMOTE_ID),
+            payload: rmp_serde::to_vec_named(msg)
+                .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?,
+            mailbox_timeout,
+            immediate,
+            reply: Some(reply_tx),
+        });
+
+        match reply_rx.await.unwrap() {
+            messaging::SwarmResponse::Tell(res) => match res {
+                Ok(()) => Ok(()),
+                Err(err) => Err(err),
+            },
+            messaging::SwarmResponse::OutboundFailure(err) => {
+                Err(err
+                    .map_err(|_| unreachable!("outbound failure doesn't contain handler errors")))
+            }
+            _ => panic!("unexpected response"),
+        }
     }
 }
 


### PR DESCRIPTION
- Make send() and try_send() fire-and-forget by default for better performance
- Add send_ack() and try_send_ack() methods for delivery acknowledgment
- Remove IntoFuture impl to force explicit choice between speed and reliability

BREAKING CHANGE: Remote tell requests no longer wait for acknowledgment by default.
Use send_ack() instead of send().await for the previous behavior.

Fixes performance issue where remote tell took ~1.6ms due to waiting for acknowledgment, making it unusable for high-frequency messaging.

Fixes https://github.com/tqwewe/kameo/issues/203