### PR TITLE
Remove dependency on once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ libp2p = { version = "0.56.0", features = [
 ], optional = true }
 libp2p-identity = { version = "0.2.9", optional = true }
 linkme = { version = "0.3.28", optional = true }
-once_cell = "1.19"
 rmp-serde = { version = "1.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,14 +5,14 @@ use std::{
     borrow::{Borrow, Cow},
     collections::{hash_map::Keys, HashMap},
     hash::Hash,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{LazyLock, Mutex},
 };
 
 use crate::{actor::ActorRef, error::RegistryError, Actor};
 
 /// Global actor registry for local actors.
-pub static ACTOR_REGISTRY: LazyLock<Arc<Mutex<ActorRegistry>>> =
-    LazyLock::new(|| Arc::new(Mutex::new(ActorRegistry::new())));
+pub static ACTOR_REGISTRY: LazyLock<Mutex<ActorRegistry>> =
+    LazyLock::new(|| Mutex::new(ActorRegistry::new()));
 
 type AnyActorRef = Box<dyn Any + Send>;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,16 +5,14 @@ use std::{
     borrow::{Borrow, Cow},
     collections::{hash_map::Keys, HashMap},
     hash::Hash,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
-
-use once_cell::sync::Lazy;
 
 use crate::{actor::ActorRef, error::RegistryError, Actor};
 
 /// Global actor registry for local actors.
-pub static ACTOR_REGISTRY: Lazy<Arc<Mutex<ActorRegistry>>> =
-    Lazy::new(|| Arc::new(Mutex::new(ActorRegistry::new())));
+pub static ACTOR_REGISTRY: LazyLock<Arc<Mutex<ActorRegistry>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(ActorRegistry::new())));
 
 type AnyActorRef = Box<dyn Any + Send>;
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -53,7 +53,7 @@
 //! // transports, discovery, and protocol composition
 //! ```
 
-use std::{any, collections::HashMap, error, str};
+use std::{any, collections::HashMap, error, str, sync::LazyLock};
 
 use futures::StreamExt;
 use libp2p::{
@@ -61,7 +61,6 @@ use libp2p::{
     swarm::{NetworkBehaviour, SwarmEvent},
     tcp, yamux, PeerId, SwarmBuilder,
 };
-use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -80,8 +79,8 @@ mod swarm;
 pub use behaviour::*;
 pub use swarm::*;
 
-pub(crate) static REMOTE_REGISTRY: Lazy<Mutex<HashMap<ActorId, RemoteRegistryActorRef>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+pub(crate) static REMOTE_REGISTRY: LazyLock<Mutex<HashMap<ActorId, RemoteRegistryActorRef>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub(crate) struct RemoteRegistryActorRef {
     pub(crate) actor_ref: Box<dyn any::Any + Send + Sync>,

--- a/src/remote/swarm.rs
+++ b/src/remote/swarm.rs
@@ -1,9 +1,8 @@
 use core::task;
-use std::{borrow::Cow, marker::PhantomData, pin, str, task::Poll, time::Duration};
+use std::{borrow::Cow, marker::PhantomData, pin, str, sync::OnceLock, task::Poll, time::Duration};
 
 use futures::{ready, Future, FutureExt, Stream, StreamExt};
 use libp2p::PeerId;
-use once_cell::sync::OnceCell;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
@@ -21,7 +20,7 @@ use super::{
     RemoteActor, RemoteRegistryActorRef, REMOTE_REGISTRY,
 };
 
-static ACTOR_SWARM: OnceCell<ActorSwarm> = OnceCell::new();
+static ACTOR_SWARM: OnceLock<ActorSwarm> = OnceLock::new();
 
 /// `ActorSwarm` is the core component for remote actors within Kameo.
 ///
@@ -59,8 +58,8 @@ impl ActorSwarm {
     pub(crate) fn set(
         swarm_tx: mpsc::UnboundedSender<SwarmCommand>,
         local_peer_id: PeerId,
-    ) -> Result<&'static Self, (&'static Self, Self)> {
-        ACTOR_SWARM.try_insert(ActorSwarm {
+    ) -> Result<(), Self> {
+        ACTOR_SWARM.set(ActorSwarm {
             swarm_tx: SwarmSender(swarm_tx),
             local_peer_id,
         })


### PR DESCRIPTION
Use std::sync::OnceLock

### Some additional questions:

* Is the `Arc` really required for the static local registry? Does compile and test without it. But I assume this would be a breaking change to remove it.

* How about switching to a concurrent container to avoid Mutex overhead? Ractor uses a [DashMap](https://github.com/slawlor/ractor/blob/main/ractor/src/registry/pid_registry.rs#L46) but [scc](https://crates.io/crates/scc) may also be a good candidate. Maybe a read-optimized container like `HashIndex` or `TreeIndex`.