### PR TITLE
feat(macros): hash remote_message impls to auto generate ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ include = ["/src"]
 default = ["macros", "tracing"]
 macros = ["dep:kameo_macros"]
 remote = [
+  "dep:const-fnv1a-hash",
+  "dep:const-str",
   "dep:either",
   "dep:libp2p",
   "dep:libp2p-identity",
@@ -44,6 +46,8 @@ tracing = ["dep:tracing", "tokio/tracing"]
 [dependencies]
 kameo_macros = { version = "0.17.0", path = "./macros", optional = true }
 
+const-fnv1a-hash = { version = "1.1.0", optional = true }
+const-str = { version = "0.6.4", features = ["proc"], optional = true }
 downcast-rs = "2.0.1"
 dyn-clone = "1.0"
 either = { version = "1.15.0", optional = true }

--- a/docs/distributed-actors/messaging-remote-actors.mdx
+++ b/docs/distributed-actors/messaging-remote-actors.mdx
@@ -59,7 +59,7 @@ pub struct MyActor;
 2. **Message Serialization with `#[remote_message]`**: In Kameo, messages sent between nodes must be serializable. To enable this, message types need to implement `Serialize` and `Deserialize` traits, and the message implementation must be annotated with the `#[remote_message]` macro, which assigns a unique identifier to the actor and message type handler.
 
 ```rust
-#[remote_message("3b9128f1-0593-44a0-b83a-f4188baa05bf")]
+#[remote_message]
 impl Message<Inc> for MyActor {
     type Reply = i64;
 

--- a/examples/custom_swarm.rs
+++ b/examples/custom_swarm.rs
@@ -22,7 +22,7 @@ pub struct Inc {
     from: PeerId,
 }
 
-#[remote_message("3b9128f1-0593-44a0-b83a-f4188baa05bf")]
+#[remote_message]
 impl Message<Inc> for MyActor {
     type Reply = i64;
 

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -18,7 +18,7 @@ pub struct Inc {
     from: PeerId,
 }
 
-#[remote_message("3b9128f1-0593-44a0-b83a-f4188baa05bf")]
+#[remote_message]
 impl Message<Inc> for MyActor {
     type Reply = i64;
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,4 +17,3 @@ heck = "0.5"
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
 syn = { version = "2.0.52", features = ["extra-traits", "full"] }
-uuid = { version = "1.10", features = ["v4"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -155,7 +155,7 @@ pub fn derive_remote_actor(input: TokenStream) -> TokenStream {
 /// struct MyActor { }
 /// struct MyMessage { }
 ///
-/// #[remote_message("c6fa9f76-8818-4000-96f4-50c2ebd52408")]
+/// #[remote_message]
 /// impl Message<MyMessage> for MyActor {
 ///     // implementation here
 /// }

--- a/src/remote/_internal.rs
+++ b/src/remote/_internal.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::time::Duration;
 
+pub use const_fnv1a_hash;
+pub use const_str;
 use futures::future::BoxFuture;
 pub use linkme;
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
With this PR, the `#[remote_message]` macro now no longer explitily needs a UUID set, and hashes the impl block to generate a short unique identifier. The hashed ID consists of `CRATE_NAME :: MAJOR_VERSION :: MODULE_PATH :: MESSAGE_TY :: ACTOR_TY :: ACTOR_GENERICS`.