### PR TITLE
fix: metrics counter names

### DIFF
--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -31,20 +31,20 @@ pub fn bounded<A: Actor>(buffer: usize) -> (MailboxSender<A>, MailboxReceiver<A>
         MailboxSender {
             inner: MailboxSenderInner::Bounded(tx),
             #[cfg(feature = "metrics")]
-            messages_sent: metrics::counter!("kameo.messages.sent", "actor_name" => A::name()),
+            messages_sent: metrics::counter!("kameo_messages_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            lifecycle_signals_sent: metrics::counter!("kameo.lifecycle.sent", "actor_name" => A::name()),
+            lifecycle_signals_sent: metrics::counter!("kameo_lifecycle_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            link_died_signals_sent: metrics::counter!("kameo.link_died.sent", "actor_name" => A::name()),
+            link_died_signals_sent: metrics::counter!("kameo_link_died_sent", "actor_name" => A::name()),
         },
         MailboxReceiver {
             inner: MailboxReceiverInner::Bounded(rx),
             #[cfg(feature = "metrics")]
-            messages_received: metrics::counter!("kameo.messages.received", "actor_name" => A::name()),
+            messages_received: metrics::counter!("kameo_messages_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            lifecycle_signals_received: metrics::counter!("kameo.lifecycle.received", "actor_name" => A::name()),
+            lifecycle_signals_received: metrics::counter!("kameo_lifecycle_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            link_died_signals_received: metrics::counter!("kameo.link_died.received", "actor_name" => A::name()),
+            link_died_signals_received: metrics::counter!("kameo_link_died_received", "actor_name" => A::name()),
         },
     )
 }
@@ -60,20 +60,20 @@ pub fn unbounded<A: Actor>() -> (MailboxSender<A>, MailboxReceiver<A>) {
         MailboxSender {
             inner: MailboxSenderInner::Unbounded(tx),
             #[cfg(feature = "metrics")]
-            messages_sent: metrics::counter!("kameo.messages.sent", "actor_name" => A::name()),
+            messages_sent: metrics::counter!("kameo_messages_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            lifecycle_signals_sent: metrics::counter!("kameo.lifecycle.sent", "actor_name" => A::name()),
+            lifecycle_signals_sent: metrics::counter!("kameo_lifecycle_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            link_died_signals_sent: metrics::counter!("kameo.link_died.sent", "actor_name" => A::name()),
+            link_died_signals_sent: metrics::counter!("kameo_link_died_sent", "actor_name" => A::name()),
         },
         MailboxReceiver {
             inner: MailboxReceiverInner::Unbounded(rx),
             #[cfg(feature = "metrics")]
-            messages_received: metrics::counter!("kameo.messages.received", "actor_name" => A::name()),
+            messages_received: metrics::counter!("kameo_messages_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            lifecycle_signals_received: metrics::counter!("kameo.lifecycle.received", "actor_name" => A::name()),
+            lifecycle_signals_received: metrics::counter!("kameo_lifecycle_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
-            link_died_signals_received: metrics::counter!("kameo.link_died.received", "actor_name" => A::name()),
+            link_died_signals_received: metrics::counter!("kameo_link_died_received", "actor_name" => A::name()),
         },
     )
 }


### PR DESCRIPTION
Fixes https://github.com/tqwewe/kameo/issues/258

Replaces `.`'s in metric names with `_`.