### PR TITLE
feat(clippy): ensure compatibility with `clippy::pedantic`

### DIFF
--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use kameo::prelude::*;
 
 #[derive(Actor)]
@@ -13,7 +15,7 @@ impl MyActor {
 
     #[message(derive(Clone))]
     fn inc(&mut self, amount: u32) -> i64 {
-        self.count += amount as i64;
+        self.count += i64::from(amount);
         self.count
     }
 

--- a/macros/src/messages.rs
+++ b/macros/src/messages.rs
@@ -194,6 +194,9 @@ impl Messages {
                             return None;
                         }
 
+                        impl_item_fn.attrs.push(parse_quote! ( #[allow(clippy::unused_self, reason = "self required for message handlers")] ));
+                        impl_item_fn.attrs.push(parse_quote! ( #[allow(clippy::needless_pass_by_value, reason = "references are not allowed in message handlers")] ));
+
                         let mut generics = vec![];
                         let impl_item_generics: Vec<_> = item_impl.generics
                             .lifetimes()


### PR DESCRIPTION
Resolves false positives from `clippy:pedantic` when using `#[messages]` macro.