### PR TITLE
Add pre_start actor initialization hook

### DIFF
--- a/actors/src/pool.rs
+++ b/actors/src/pool.rs
@@ -172,12 +172,16 @@ where
         "ActorPool"
     }
 
-    async fn on_start(state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-        for (worker, _) in &state.workers {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
+    }
+
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+        for (worker, _) in &self.workers {
             worker.link(&actor_ref).await;
         }
 
-        Ok(state)
+        Ok(())
     }
 
     async fn on_link_died(
@@ -232,8 +236,8 @@ impl<A: Actor> Actor for Worker<A> {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 }
 

--- a/actors/src/pubsub.rs
+++ b/actors/src/pubsub.rs
@@ -241,8 +241,8 @@ impl<M: 'static> Actor for PubSub<M> {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 }
 

--- a/actors/src/scheduler.rs
+++ b/actors/src/scheduler.rs
@@ -76,8 +76,8 @@ impl Actor for Scheduler {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 
     async fn next(

--- a/docs/core-concepts/actors.mdx
+++ b/docs/core-concepts/actors.mdx
@@ -57,9 +57,13 @@ impl Actor for MyActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
+    }
+
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         println!("Actor started");
-        Ok(MyActor)
+        Ok(())
     }
 
     // Implement other lifecycle hooks as needed...

--- a/docs/core-concepts/supervision.mdx
+++ b/docs/core-concepts/supervision.mdx
@@ -26,7 +26,7 @@ impl Actor for MySupervisor {
         SupervisionStrategy::OneForOne  // default
     }
 
-    async fn on_start(_: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
         Ok(MySupervisor)
     }
 }
@@ -56,7 +56,11 @@ impl Actor for Supervisor {
     type Args = ();
     type Error = Infallible;
 
-    async fn on_start(_: Self::Args, supervisor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+        Ok(Supervisor)
+    }
+
+    async fn on_start(&mut self, supervisor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         // Spawn with cloneable args
         let worker = Worker::supervise(&supervisor_ref, Worker { count: 0 })
             .restart_policy(RestartPolicy::Permanent)
@@ -70,7 +74,7 @@ impl Actor for Supervisor {
             .spawn()
             .await;
 
-        Ok(Supervisor)
+        Ok(())
     }
 }
 
@@ -82,8 +86,8 @@ struct Worker {
 impl Actor for Worker {
     type Args = Self;
     type Error = Infallible;
-    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 }
 
@@ -95,8 +99,8 @@ impl Task {
 impl Actor for Task {
     type Args = Self;
     type Error = Infallible;
-    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 }
 ```
@@ -165,8 +169,8 @@ impl Actor for WorkerA {
     type Args = Self;
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
-    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(state)
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
     }
 
     async fn on_link_died(

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -63,7 +63,7 @@ Actors stop running if one of the following conditions is met:
 
 - All references to the actor (`ActorRef<MyActor>`) are dropped.
 - It is explicitly stopped with `.stop_gracefully()` or `.kill()`.
-- `Actor::on_start` returns an error.
+- `Actor::pre_start`, `Actor::on_start`, or another lifecycle hook returns an error.
 - `Actor::on_panic` returns `Ok(ControlFlow::Break(reason))`, or returns an error.
 - `Actor::on_link_died` returns `Ok(ControlFlow::Break(reason))`, or returns an error.
 - `Actor::next` returns `None`.

--- a/examples/forward_with_fallback.rs
+++ b/examples/forward_with_fallback.rs
@@ -26,7 +26,7 @@ impl Actor for PrimaryComputeActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
         Ok(args)
     }
 }
@@ -60,7 +60,7 @@ impl Actor for GatewayActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
         Ok(args)
     }
 }

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -14,14 +14,18 @@ impl Actor for MyActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
+    }
+
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         let stream = Box::pin(stream::repeat(1).take(5).throttle(Duration::from_secs(1)));
         actor_ref.attach_stream(stream, "1st stream", "1st stream");
 
         let stream = stream::repeat(1).take(5);
         actor_ref.attach_stream(stream, "2nd stream", "2nd stream");
 
-        Ok(state)
+        Ok(())
     }
 }
 

--- a/examples/supervision.rs
+++ b/examples/supervision.rs
@@ -14,7 +14,11 @@ impl Actor for MySupervisor {
         SupervisionStrategy::OneForAll
     }
 
-    async fn on_start(_: Self::Args, supervisor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+        Ok(MySupervisor)
+    }
+
+    async fn on_start(&mut self, supervisor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         let brother = BrotherActor::supervise(&supervisor_ref, BrotherActor)
             .spawn()
             .await;
@@ -38,7 +42,7 @@ impl Actor for MySupervisor {
 
         Box::leak(Box::new(brother));
 
-        Ok(MySupervisor)
+        Ok(())
     }
 }
 
@@ -51,9 +55,13 @@ impl Actor for MyActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
+    }
+
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         info!("my actor started");
-        Ok(state)
+        Ok(())
     }
 }
 
@@ -94,9 +102,13 @@ impl Actor for BrotherActor {
     type Args = Self;
     type Error = Infallible;
 
-    async fn on_start(state: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+        Ok(args)
+    }
+
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         info!("brother actor started");
-        Ok(state)
+        Ok(())
     }
 
     async fn on_link_died(

--- a/macros/src/derive_actor.rs
+++ b/macros/src/derive_actor.rs
@@ -35,11 +35,8 @@ impl ToTokens for DeriveActor {
                     #name
                 }
 
-                async fn on_start(
-                    state: Self::Args,
-                    _actor_ref: ::kameo::actor::ActorRef<Self>,
-                ) -> ::std::result::Result<Self, Self::Error> {
-                    ::std::result::Result::Ok(state)
+                async fn pre_start(args: Self::Args) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::result::Result::Ok(args)
                 }
             }
         });

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,7 @@
 //! Core functionality for defining and managing actors in Kameo.
 //!
 //! Actors are independent units of computation that run asynchronously, sending and receiving messages.
-//! Each actor operates within its own task, and its lifecycle is managed by hooks such as `on_start`, `on_panic`, and `on_stop`.
+//! Each actor operates within its own task, and its lifecycle is managed by hooks such as `pre_start`, `on_start`, `on_panic`, and `on_stop`.
 //!
 //! The actor trait is designed to support fault tolerance, recovery from panics, and clean termination.
 //! Lifecycle hooks allow customization of actor behavior when starting, encountering errors, or shutting down.
@@ -11,12 +11,13 @@
 //!
 //! # Features
 //! - **Asynchronous Message Handling**: Each actor processes messages asynchronously within its own task.
-//! - **Lifecycle Hooks**: Customizable hooks ([`on_start`], [`on_stop`], [`on_panic`]) for managing the actor's lifecycle.
+//! - **Lifecycle Hooks**: Customizable hooks ([`pre_start`], [`on_start`], [`on_stop`], [`on_panic`]) for managing the actor's lifecycle.
 //! - **Backpressure**: Mailboxes can be bounded or unbounded, controlling the flow of messages.
 //! - **Supervision**: Actors can be linked, enabling robust supervision and error recovery systems.
 //!
 //! This module allows building resilient, fault-tolerant, distributed systems with flexible control over the actor lifecycle.
 //!
+//! [`pre_start`]: Actor::pre_start
 //! [`on_start`]: Actor::on_start
 //! [`on_stop`]: Actor::on_stop
 //! [`on_panic`]: Actor::on_panic
@@ -47,7 +48,7 @@ pub(crate) const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// Core behavior of an actor, including its lifecycle events and how it processes messages.
 ///
 /// Every actor must implement this trait, which provides hooks
-/// for the actor's initialization ([`on_start`]), handling errors ([`on_panic`]), and cleanup ([`on_stop`]).
+/// for the actor's initialization ([`pre_start`] and [`on_start`]), handling errors ([`on_panic`]), and cleanup ([`on_stop`]).
 ///
 /// The actor runs within its own task and processes messages asynchronously from a mailbox.
 /// Each actor can be linked to others, allowing for robust supervision and failure recovery mechanisms.
@@ -77,12 +78,13 @@ pub(crate) const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 ///     type Args = Self;
 ///     type Error = Infallible;
 ///
-///     async fn on_start(
-///         state: Self::Args,
-///         actor_ref: ActorRef<Self>
-///     ) -> Result<Self, Self::Error> {
+///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+///         Ok(args)
+///     }
+///
+///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
 ///         println!("actor started");
-///         Ok(state)
+///         Ok(())
 ///     }
 ///
 ///     async fn on_stop(
@@ -97,7 +99,8 @@ pub(crate) const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// ```
 ///
 /// # Lifecycle Hooks
-/// - [`on_start`]: Called when the actor starts. This is where initialization happens.
+/// - [`pre_start`]: Called before the actor starts. This is where actor construction happens.
+/// - [`on_start`]: Called after the actor is constructed, before it processes messages.
 /// - [`on_panic`]: Called when the actor encounters a panic or an error while processing a "tell" message.
 /// - [`on_stop`]: Called before the actor is stopped. This allows for cleanup tasks.
 /// - [`on_link_died`]: Hook that is invoked when a linked actor dies.
@@ -110,6 +113,7 @@ pub(crate) const DEFAULT_MAILBOX_CAPACITY: usize = 64;
 /// Mailboxes enable efficient asynchronous message passing with support for both backpressure and
 /// unbounded queueing depending on system requirements.
 ///
+/// [`pre_start`]: Actor::pre_start
 /// [`on_start`]: Actor::on_start
 /// [`on_panic`]: Actor::on_panic
 /// [`on_stop`]: Actor::on_stop
@@ -169,10 +173,7 @@ pub trait Actor: Sized + Send + 'static {
     ///         SupervisionStrategy::OneForAll
     ///     }
     ///
-    ///     async fn on_start(
-    ///         _: Self::Args,
-    ///         _: ActorRef<Self>
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
     ///         Ok(Supervisor)
     ///     }
     /// }
@@ -186,7 +187,32 @@ pub trait Actor: Sized + Send + 'static {
         SupervisionStrategy::default()
     }
 
-    /// Called when the actor starts, before it processes any messages.
+    /// Called before the actor starts, to construct the actor from its spawn arguments.
+    ///
+    /// This hook is executed by the actor framework, so panics and errors during actor
+    /// construction are captured and surfaced through the normal actor failure path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use kameo::actor::Actor;
+    /// # use kameo::error::Infallible;
+    /// #
+    /// struct MyActor;
+    ///
+    /// impl Actor for MyActor {
+    ///     type Args = Self;
+    ///     type Error = Infallible;
+    ///
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
+    ///     }
+    /// }
+    /// ```
+    #[allow(unused_variables)]
+    fn pre_start(args: Self::Args) -> impl Future<Output = Result<Self, Self::Error>> + Send;
+
+    /// Called when the constructed actor starts, before it processes any messages.
     ///
     /// Messages sent internally by the actor during `on_start` are prioritized and processed
     /// before any externally sent messages, even if external messages are received first.
@@ -205,19 +231,23 @@ pub trait Actor: Sized + Send + 'static {
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
+    ///     }
+    ///
+    ///     async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+    ///         Ok(())
     ///     }
     /// }
     /// ```
     #[allow(unused_variables)]
+    #[inline]
     fn on_start(
-        args: Self::Args,
+        &mut self,
         actor_ref: ActorRef<Self>,
-    ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
+    }
 
     /// Called when the actor receives a message to be processed.
     ///
@@ -806,7 +836,7 @@ pub trait Spawn: Actor + private::Sealed {
     /// configured policies.
     ///
     /// When the child actor needs to be restarted, the provided `args` will be cloned
-    /// and passed to the actor's [`on_start`](Actor::on_start) method. This requires
+    /// and passed to the actor's [`pre_start`](Actor::pre_start) method. This requires
     /// that `Args` implements [`Clone`] + [`Sync`].
     ///
     /// **Note**: If your args type is not [`Sync`], use [`supervise_with`](Self::supervise_with)
@@ -838,7 +868,11 @@ pub trait Spawn: Actor + private::Sealed {
     ///         SupervisionStrategy::OneForOne
     ///     }
     ///
-    ///     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(Supervisor)
+    ///     }
+    ///
+    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     ///         // Spawn a supervised child
     ///         let child = Worker::supervise(&actor_ref, Worker { count: 0 })
     ///             .restart_policy(RestartPolicy::Transient)
@@ -846,7 +880,7 @@ pub trait Spawn: Actor + private::Sealed {
     ///             .spawn()
     ///             .await;
     ///
-    ///         Ok(Supervisor)
+    ///         Ok(())
     ///     }
     /// }
     ///
@@ -859,8 +893,8 @@ pub trait Spawn: Actor + private::Sealed {
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     /// ```
@@ -912,7 +946,11 @@ pub trait Spawn: Actor + private::Sealed {
     ///     type Args = ();
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(Supervisor)
+    ///     }
+    ///
+    ///     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     ///         // Use a factory function to generate fresh state on each restart
     ///         let child = Worker::supervise_with(&actor_ref, || Worker {
     ///             // This function is called on each restart
@@ -922,7 +960,7 @@ pub trait Spawn: Actor + private::Sealed {
     ///         .spawn()
     ///         .await;
     ///
-    ///         Ok(Supervisor)
+    ///         Ok(())
     ///     }
     /// }
     ///
@@ -934,8 +972,8 @@ pub trait Spawn: Actor + private::Sealed {
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     /// ```

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -209,7 +209,6 @@ pub trait Actor: Sized + Send + 'static {
     ///     }
     /// }
     /// ```
-    #[allow(unused_variables)]
     fn pre_start(args: Self::Args) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Called when the constructed actor starts, before it processes any messages.

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -269,7 +269,7 @@ where
     ///
     /// Unlike [`wait_for_startup_result`](ActorRef::wait_for_startup_result), this method does
     /// not block — it returns immediately with `None` if the actor has not yet completed its
-    /// [`on_start`](Actor::on_start) hook.
+    /// startup hooks.
     ///
     /// # Example
     ///
@@ -284,10 +284,7 @@ where
     ///     type Args = Self;
     ///     type Error = ParseIntError;
     ///
-    ///     async fn on_start(
-    ///         _state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_args: Self::Args) -> Result<Self, Self::Error> {
     ///         "invalid int".parse().map(|_: i32| MyActor) // Will always error
     ///     }
     /// }
@@ -320,7 +317,7 @@ where
     ///
     /// Unlike [`wait_for_startup_with_result`](ActorRef::wait_for_startup_with_result), this
     /// method does not block — it returns immediately with `None` if the actor has not yet
-    /// completed its [`on_start`](Actor::on_start) hook.
+    /// completed its startup hooks.
     ///
     /// The closure receives a reference to the error rather than a clone, which is useful when
     /// `A::Error` does not implement [`Clone`].
@@ -339,10 +336,7 @@ where
     ///     type Args = Self;
     ///     type Error = NonCloneError;
     ///
-    ///     async fn on_start(
-    ///         _state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_args: Self::Args) -> Result<Self, Self::Error> {
     ///         Err(NonCloneError) // Will always error
     ///     }
     /// }
@@ -398,11 +392,8 @@ where
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     ///
@@ -456,11 +447,8 @@ where
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     ///
@@ -495,7 +483,7 @@ where
 
     /// Waits for the actor to finish startup and become ready to process messages.
     ///
-    /// This method ensures the actors on_start lifecycle hook has been fully processed.
+    /// This method ensures the actor's startup lifecycle hooks have been fully processed.
     /// If `wait_for_startup` is called after the actor has already started up, this will return immediately.
     ///
     /// # Example
@@ -513,12 +501,13 @@ where
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
+    ///     }
+    ///
+    ///     async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     ///         sleep(Duration::from_secs(2)).await; // Some io operation
-    ///         Ok(state)
+    ///         Ok(())
     ///     }
     /// }
     ///
@@ -536,7 +525,7 @@ where
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
     ///
-    /// This method ensures the actors on_start lifecycle hook has been fully processed.
+    /// This method ensures the actor's startup lifecycle hooks have been fully processed.
     /// If `wait_for_startup_result` is called after the actor has already started up, this will return immediately.
     ///
     /// # Example
@@ -552,10 +541,7 @@ where
     ///     type Args = Self;
     ///     type Error = ParseIntError;
     ///
-    ///     async fn on_start(
-    ///         _state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_args: Self::Args) -> Result<Self, Self::Error> {
     ///         "invalid int".parse().map(|_: i32| MyActor) // Will always error
     ///     }
     /// }
@@ -581,7 +567,7 @@ where
 
     /// Waits for the actor to finish startup, returning the startup result with a clousre containing the error.
     ///
-    /// This method ensures the actors on_start lifecycle hook has been fully processed.
+    /// This method ensures the actor's startup lifecycle hooks have been fully processed.
     /// If `wait_for_startup_with_result` is called after the actor has already started up, this will return immediately.
     ///
     /// # Example
@@ -598,10 +584,7 @@ where
     ///     type Args = Self;
     ///     type Error = NonCloneError;
     ///
-    ///     async fn on_start(
-    ///         _state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
+    ///     async fn pre_start(_args: Self::Args) -> Result<Self, Self::Error> {
     ///         Err(NonCloneError) // Will always error
     ///     }
     /// }
@@ -671,11 +654,8 @@ where
     ///     type Args = Self;
     ///     type Error = ParseIntError;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     ///
     ///     async fn on_stop(&mut self, actor_ref: WeakActorRef<Self>, reason: ActorStopReason) -> Result<(), Self::Error> {
@@ -689,11 +669,8 @@ where
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     ///
@@ -749,11 +726,8 @@ where
     ///     type Args = Self;
     ///     type Error = NonCloneError;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     ///
     ///     async fn on_stop(&mut self, actor_ref: WeakActorRef<Self>, reason: ActorStopReason) -> Result<(), Self::Error> {
@@ -767,11 +741,8 @@ where
     ///     type Args = Self;
     ///     type Error = Infallible;
     ///
-    ///     async fn on_start(
-    ///         state: Self::Args,
-    ///         _actor_ref: ActorRef<Self>,
-    ///     ) -> Result<Self, Self::Error> {
-    ///         Ok(state)
+    ///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+    ///         Ok(args)
     ///     }
     /// }
     ///

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -445,3 +445,39 @@ fn log_actor_stop_reason(id: ActorId, name: &str, reason: &ActorStopReason) {
 
 #[cfg(not(feature = "tracing"))]
 fn log_actor_stop_reason(_id: ActorId, _name: &str, _reason: &ActorStopReason) {}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        actor::{Actor, Spawn},
+        error::{HookError, Infallible, PanicReason},
+    };
+
+    #[tokio::test]
+    async fn pre_start_panic_is_captured_as_startup_failure() {
+        struct PanicsInPreStart;
+
+        impl Actor for PanicsInPreStart {
+            type Args = ();
+            type Error = Infallible;
+
+            async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+                panic!("pre_start exploded");
+            }
+        }
+
+        let actor_ref = PanicsInPreStart::spawn(());
+        let err = actor_ref
+            .wait_for_startup_result()
+            .await
+            .expect_err("pre_start panic should fail actor startup");
+
+        let HookError::Panicked(err) = err;
+
+        assert_eq!(err.reason(), PanicReason::PreStart);
+        assert_eq!(
+            err.with_str(str::to_owned),
+            Some("pre_start exploded".to_owned())
+        );
+    }
+}

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -182,12 +182,22 @@ where
         #[cfg(feature = "tracing")]
         trace!(%id, %name, "actor started");
 
-        let start_res = AssertUnwindSafe(A::on_start(args, actor_ref.clone()))
+        let start_res = match AssertUnwindSafe(A::pre_start(args))
             .catch_unwind()
             .await
-            .map(|res| res.map_err(|err| PanicError::new(Box::new(err), PanicReason::OnStart)))
-            .map_err(|err| PanicError::new_from_panic_any(err, PanicReason::OnStart))
-            .and_then(convert::identity);
+            .map(|res| res.map_err(|err| PanicError::new(Box::new(err), PanicReason::PreStart)))
+            .map_err(|err| PanicError::new_from_panic_any(err, PanicReason::PreStart))
+            .and_then(convert::identity)
+        {
+            Ok(mut actor) => AssertUnwindSafe(actor.on_start(actor_ref.clone()))
+                .catch_unwind()
+                .await
+                .map(|res| res.map_err(|err| PanicError::new(Box::new(err), PanicReason::OnStart)))
+                .map_err(|err| PanicError::new_from_panic_any(err, PanicReason::OnStart))
+                .and_then(convert::identity)
+                .map(|()| actor),
+            Err(err) => Err(err),
+        };
         let startup_finished = matches!(
             actor_ref.weak_signal_mailbox().signal_startup_finished(),
             Err(SendError::MailboxFull(()))

--- a/src/error.rs
+++ b/src/error.rs
@@ -674,6 +674,8 @@ pub enum PanicReason {
     ///
     /// [`on_message`]: Actor::on_message
     OnMessage,
+    /// The [`pre_start`](Actor::pre_start) lifecycle hook returned an error.
+    PreStart,
     /// The [`on_start`](Actor::on_start) lifecycle hook returned an error.
     OnStart,
     /// The [`on_panic`](Actor::on_panic) lifecycle hook returned an error.
@@ -689,7 +691,7 @@ pub enum PanicReason {
 impl PanicReason {
     /// Returns `true` if the panic occurred in a lifecycle hook.
     ///
-    /// Lifecycle hooks include `on_start`, `on_panic`, `on_link_died`, and `on_stop`.
+    /// Lifecycle hooks include `pre_start`, `on_start`, `on_panic`, `on_link_died`, and `on_stop`.
     /// This can be useful for distinguishing between initialization/cleanup errors
     /// and runtime message handling errors.
     ///
@@ -704,7 +706,8 @@ impl PanicReason {
     pub fn is_lifecycle_hook(&self) -> bool {
         matches!(
             self,
-            PanicReason::OnStart
+            PanicReason::PreStart
+                | PanicReason::OnStart
                 | PanicReason::OnPanic
                 | PanicReason::OnLinkDied
                 | PanicReason::OnStop
@@ -735,6 +738,7 @@ impl fmt::Display for PanicReason {
         match self {
             PanicReason::HandlerPanic => write!(f, "message handler panicked"),
             PanicReason::OnMessage => write!(f, "on_message returned error"),
+            PanicReason::PreStart => write!(f, "pre_start returned error"),
             PanicReason::OnStart => write!(f, "on_start returned error"),
             PanicReason::OnPanic => write!(f, "on_panic returned error"),
             PanicReason::OnLinkDied => write!(f, "on_link_died returned error"),

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -798,10 +798,7 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                args: Self::Args,
-                _actor_ref: crate::actor::ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
                 Ok(args)
             }
         }
@@ -836,10 +833,7 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                args: Self::Args,
-                _actor_ref: crate::actor::ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
                 Ok(args)
             }
         }
@@ -906,10 +900,7 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                args: Self::Args,
-                _actor_ref: crate::actor::ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
                 Ok(args)
             }
         }

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -1012,7 +1012,7 @@ mod tests {
 
     use crate::{
         Actor,
-        actor::{ActorRef, Spawn},
+        actor::Spawn,
         error::{Infallible, SendError},
         mailbox,
         message::{Context, Message},
@@ -1026,11 +1026,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1072,11 +1069,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1118,11 +1112,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1173,11 +1164,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1228,11 +1216,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1253,9 +1238,10 @@ mod tests {
         }
 
         let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
-        // Mailbox is empty, this will make there be one item in the mailbox
+        actor_ref.wait_for_startup().await;
+        // Fill both the actor's in-flight message and the bounded mailbox slot.
         #[cfg(not(feature = "hotpath"))]
-        let fill_count = 1;
+        let fill_count = 2;
         #[cfg(feature = "hotpath")]
         let fill_count = 4; // Sadly, hotpath adds some proxy layers, causing the fill count to be 4 instead of 1
         for _ in 0..fill_count {
@@ -1286,11 +1272,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1358,11 +1341,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -1412,11 +1392,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -616,7 +616,7 @@ mod tests {
 
     use crate::{
         Actor,
-        actor::{ActorRef, Spawn},
+        actor::Spawn,
         error::{Infallible, SendError},
         mailbox,
         message::{Context, Message},
@@ -630,11 +630,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -673,11 +670,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -712,11 +706,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -766,11 +757,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -820,11 +808,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -875,11 +860,8 @@ mod tests {
             type Args = Self;
             type Error = Infallible;
 
-            async fn on_start(
-                state: Self::Args,
-                _actor_ref: ActorRef<Self>,
-            ) -> Result<Self, Self::Error> {
-                Ok(state)
+            async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+                Ok(args)
             }
         }
 
@@ -899,9 +881,10 @@ mod tests {
         }
 
         let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
-        // Mailbox is empty, this will make there be one item in the mailbox
+        actor_ref.wait_for_startup().await;
+        // Fill both the actor's in-flight message and the bounded mailbox slot.
         #[cfg(not(feature = "hotpath"))]
-        let fill_count = 1;
+        let fill_count = 2;
         #[cfg(feature = "hotpath")]
         let fill_count = 4;
         for _ in 0..fill_count {

--- a/src/supervision.rs
+++ b/src/supervision.rs
@@ -33,7 +33,11 @@
 //!         SupervisionStrategy::OneForOne
 //!     }
 //!
-//!     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+//!     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
+//!         Ok(Supervisor)
+//!     }
+//!
+//!     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
 //!         // Spawn a supervised child that restarts on abnormal exits
 //!         let child = Worker::supervise(&actor_ref, Worker)
 //!             .restart_policy(RestartPolicy::Transient)
@@ -41,7 +45,7 @@
 //!             .spawn()
 //!             .await;
 //!
-//!         Ok(Supervisor)
+//!         Ok(())
 //!     }
 //! }
 //!
@@ -50,8 +54,8 @@
 //! impl Actor for Worker {
 //!     type Args = Self;
 //!     type Error = Infallible;
-//!     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-//!         Ok(state)
+//!     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+//!         Ok(args)
 //!     }
 //! }
 //! ```
@@ -115,7 +119,7 @@ use crate::{
 /// # impl Actor for Supervisor {
 /// #     type Args = ();
 /// #     type Error = Infallible;
-/// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+/// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
 /// #         Ok(Supervisor)
 /// #     }
 /// # }
@@ -124,8 +128,8 @@ use crate::{
 /// # impl Actor for Worker {
 /// #     type Args = Self;
 /// #     type Error = Infallible;
-/// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-/// #         Ok(state)
+/// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+/// #         Ok(args)
 /// #     }
 /// # }
 /// # async {
@@ -223,7 +227,7 @@ pub enum RestartPolicy {
 ///         SupervisionStrategy::OneForAll
 ///     }
 ///
-///     async fn on_start(_: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+///     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> {
 ///         Ok(Supervisor)
 ///     }
 /// }
@@ -319,14 +323,15 @@ pub enum SupervisionStrategy {
 /// # impl Actor for Supervisor {
 /// #     type Args = ();
 /// #     type Error = Infallible;
-/// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+/// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+/// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
 /// #[derive(Clone)]
 /// struct Worker;
 /// impl Actor for Worker {
 ///     type Args = Self;
 ///     type Error = Infallible;
-///     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-///         Ok(state)
+///     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+///         Ok(args)
 ///     }
 /// }
 /// # let supervisor_ref: ActorRef<Supervisor> = unimplemented!();
@@ -397,18 +402,19 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for Worker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// let child = Worker::supervise(supervisor_ref, Worker)
     ///     .restart_policy(RestartPolicy::Transient) // Only restart on abnormal exits
     ///     .spawn()
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     pub fn restart_policy(mut self, policy: RestartPolicy) -> Self {
         self.restart_policy = policy;
@@ -440,11 +446,12 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for Worker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// // Allow at most 3 restarts in 10 seconds
@@ -452,7 +459,7 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     ///     .restart_limit(3, Duration::from_secs(10))
     ///     .spawn()
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     pub fn restart_limit(mut self, restarts: u32, within: Duration) -> Self {
         self.max_restarts = restarts;
@@ -477,17 +484,18 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for Worker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// let child = Worker::supervise(supervisor_ref, Worker)
     ///     .spawn()
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     ///
     /// [`ActorRef`]: crate::actor::ActorRef
@@ -519,18 +527,19 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for Worker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// // Spawn with a custom bounded mailbox
     /// let child = Worker::supervise(supervisor_ref, Worker)
     ///     .spawn_with_mailbox(mailbox::bounded(100))
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     ///
     /// [`ActorRef`]: crate::actor::ActorRef
@@ -560,18 +569,19 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for BlockingWorker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// // Spawn in a dedicated thread for blocking operations
     /// let child = BlockingWorker::supervise(supervisor_ref, BlockingWorker)
     ///     .spawn_in_thread()
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     ///
     /// [`ActorRef`]: crate::actor::ActorRef
@@ -603,18 +613,19 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
     /// # impl Actor for BlockingWorker {
     /// #     type Args = Self;
     /// #     type Error = Infallible;
-    /// #     async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> { Ok(state) }
+    /// #     async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> { Ok(args) }
     /// # }
     /// # struct Supervisor;
     /// # impl Actor for Supervisor { type Args = (); type Error = Infallible;
-    /// #     async fn on_start(_: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     async fn pre_start(_: Self::Args) -> Result<Self, Self::Error> { Ok(Supervisor) }
+    /// #     async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
     /// # let supervisor_ref = &actor_ref;
     ///
     /// // Spawn in thread with custom mailbox
     /// let child = BlockingWorker::supervise(supervisor_ref, BlockingWorker)
     ///     .spawn_in_thread_with_mailbox(mailbox::bounded(200))
     ///     .await;
-    /// # Ok(Supervisor) }}
+    /// # Ok(()) }}
     /// ```
     ///
     /// [`ActorRef`]: crate::actor::ActorRef
@@ -765,12 +776,13 @@ mod tests {
         type Args = Self;
         type Error = Infallible;
 
-        async fn on_start(
-            state: Self::Args,
-            _actor_ref: ActorRef<Self>,
-        ) -> Result<Self, Self::Error> {
-            state.start_count.fetch_add(1, Ordering::SeqCst);
-            Ok(state)
+        async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+            Ok(args)
+        }
+
+        async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+            self.start_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -846,11 +858,8 @@ mod tests {
             SupervisionStrategy::OneForOne
         }
 
-        async fn on_start(
-            state: Self::Args,
-            _actor_ref: ActorRef<Self>,
-        ) -> Result<Self, Self::Error> {
-            Ok(state)
+        async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+            Ok(args)
         }
     }
 
@@ -865,11 +874,8 @@ mod tests {
             SupervisionStrategy::OneForAll
         }
 
-        async fn on_start(
-            state: Self::Args,
-            _actor_ref: ActorRef<Self>,
-        ) -> Result<Self, Self::Error> {
-            Ok(state)
+        async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+            Ok(args)
         }
     }
 
@@ -884,11 +890,8 @@ mod tests {
             SupervisionStrategy::RestForOne
         }
 
-        async fn on_start(
-            state: Self::Args,
-            _actor_ref: ActorRef<Self>,
-        ) -> Result<Self, Self::Error> {
-            Ok(state)
+        async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+            Ok(args)
         }
     }
 
@@ -912,12 +915,13 @@ mod tests {
         type Args = Self;
         type Error = Infallible;
 
-        async fn on_start(
-            state: Self::Args,
-            _actor_ref: ActorRef<Self>,
-        ) -> Result<Self, Self::Error> {
-            state.start_count.fetch_add(1, Ordering::SeqCst);
-            Ok(state)
+        async fn pre_start(args: Self::Args) -> Result<Self, Self::Error> {
+            Ok(args)
+        }
+
+        async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+            self.start_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
 
         async fn on_link_died(


### PR DESCRIPTION
Note: this PR's main goal is to start a conversation. Is there any appetite for this?

## Summary
One of the nice things of kameo (compared to Ractor) is that the state of the actor is internal to the actor itself. We don't have to store and create a separate `Actor::State` struct and act on that. Now [there is good reason for this in ractor](https://news.ycombinator.com/item?id=41729106). If the state initialization fails or panics, the framework can catch this and bubble it up to any parents. 

Ideally we could take this same concept and apply it to Kameo. Rather than have users implement `on_start`, which assumes the Actor is already created successfully, this PR adds a new function `pre_start` (copying Ractor), that takes an Actor's `Self::Args` but *does not* take an `ActorRef<Self>`. 

This allows the framework to initialize the state for an actor, and then the `on_start` method can just take the `ActorRef<Self>` to allow users to create other actors and link them to the parent.


## Motivation
This combines the best of both worlds from each framework: 
1. We get to keep kameo's per-message implementation of `Handle`.
2. We get ractor's start-up safety.

## Backwards Compatibility
This is clearly not backwards compatible and would require a major version change. 

## AI Use
This code for this PR is largely generated by GPT 5.5 via Codex, but I've reviewed it all. This summary is entirely written by me.

