### PR TITLE
fix!: Support error chains on `SendError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -340,7 +340,17 @@ impl<M, E> From<Elapsed> for SendError<M, E> {
     }
 }
 
-impl<M, E> error::Error for SendError<M, E> where E: fmt::Debug + fmt::Display {}
+impl<M, E> error::Error for SendError<M, E>
+where
+    E: error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Self::HandlerError(ref error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Reason for an actor being stopped.
 #[derive(Clone, Serialize, Deserialize)]


### PR DESCRIPTION
The previous trait bounds on the `std::error::Error` implementation of the `SendError<T, E>` (`E: std::fmt::Debug + std::fmt::Display`) were too loose, preventing downstream code to obtain the full error chain for concrete `E` types that implement `std::error::Error`. The new trait bounds and `std::error::Error` implementation on the `SendError<T, E>` type allow `std::error::Error::source` ovverriding and error source extraction in case of a `SourceError::HandlerError`.

BREAKING CHANGE: `SendError<M, E>` no longer implements `std::error::Error` for types `E` that implement `std::fmt::Debug + std::fmt::Display` but not `std::error::Error`. Downstream code that relies on `SendError<M, E>: std::error::Error` with such an E will no longer compile.