### PR TITLE
fix: preserve pending mailbox messages on actor stop/restart

### DIFF
--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -1,4 +1,6 @@
-use std::{convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread};
+use std::{
+    collections::VecDeque, convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread,
+};
 
 use futures::{
     FutureExt,
@@ -215,16 +217,7 @@ where
 
                 actor_ref.links.set_children_parent_shutdown().await;
                 actor_ref.links.send_children_shutdown().await;
-                {
-                    let wait = actor_ref.links.wait_children_closed();
-                    tokio::pin!(wait);
-                    loop {
-                        tokio::select! {
-                            _ = &mut wait => break,
-                            _ = mailbox_rx.recv() => {}
-                        }
-                    }
-                }
+                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx).await;
                 actor_ref
                     .links
                     .lock()
@@ -274,16 +267,7 @@ where
 
                 actor_ref.links.set_children_parent_shutdown().await;
                 actor_ref.links.send_children_shutdown().await;
-                {
-                    let wait = actor_ref.links.wait_children_closed();
-                    tokio::pin!(wait);
-                    loop {
-                        tokio::select! {
-                            _ = &mut wait => break,
-                            _ = mailbox_rx.recv() => {}
-                        }
-                    }
-                }
+                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx).await;
                 actor_ref
                     .links
                     .lock()
@@ -316,6 +300,30 @@ where
         let actor_span = tracing::info_span!("actor.lifecycle", actor.name = name, actor.id = %id);
         task.instrument(actor_span).await
     }
+}
+
+/// Waits for all child actors to close while keeping the mailbox drained, so a child
+/// notifying us cannot deadlock on a full mailbox. Pending messages pulled during the wait
+/// are re-queued afterwards so they survive a supervisor restart rather than being dropped.
+async fn drain_until_children_closed<A>(links: &Links, mailbox_rx: &mut MailboxReceiver<A>)
+where
+    A: Actor,
+{
+    let mut preserved = VecDeque::new();
+    let wait = links.wait_children_closed();
+    tokio::pin!(wait);
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut wait => break,
+            signal = mailbox_rx.recv() => {
+                if let Some(signal @ Signal::Message { .. }) = signal {
+                    preserved.push_back(signal);
+                }
+            }
+        }
+    }
+    mailbox_rx.push_front(preserved);
 }
 
 async fn abortable_actor_loop<A>(

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -4,7 +4,7 @@
 
 use std::{
     any::Any,
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     fmt,
     task::{Context, Poll},
     time::Duration,
@@ -44,6 +44,7 @@ pub fn bounded<A: Actor>(buffer: usize) -> (MailboxSender<A>, MailboxReceiver<A>
         },
         MailboxReceiver {
             inner: MailboxReceiverInner::Bounded(rx),
+            front: VecDeque::new(),
             #[cfg(feature = "metrics")]
             messages_received: metrics::counter!("kameo_messages_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
@@ -75,6 +76,7 @@ pub fn unbounded<A: Actor>() -> (MailboxSender<A>, MailboxReceiver<A>) {
         },
         MailboxReceiver {
             inner: MailboxReceiverInner::Unbounded(rx),
+            front: VecDeque::new(),
             #[cfg(feature = "metrics")]
             messages_received: metrics::counter!("kameo_messages_received", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
@@ -519,6 +521,7 @@ impl<A: Actor> fmt::Debug for WeakMailboxSender<A> {
 /// Instances are created by the [`bounded`] and [`unbounded`] functions.
 pub struct MailboxReceiver<A: Actor> {
     inner: MailboxReceiverInner<A>,
+    front: VecDeque<Signal<A>>,
     #[cfg(feature = "metrics")]
     messages_received: metrics::Counter,
     #[cfg(feature = "metrics")]
@@ -535,6 +538,20 @@ enum MailboxReceiverInner<A: Actor> {
 }
 
 impl<A: Actor> MailboxReceiver<A> {
+    /// Re-inserts signals ahead of the channel, preserving their order, so they are
+    /// yielded before anything still queued. Used to keep pending messages across a restart.
+    pub(crate) fn push_front(&mut self, mut signals: VecDeque<Signal<A>>) {
+        signals.append(&mut self.front);
+        self.front = signals;
+    }
+
+    /// Moves up to `limit` already-buffered front signals into `buffer`, returning the count.
+    fn drain_front_into(&mut self, buffer: &mut Vec<Signal<A>>, limit: usize) -> usize {
+        let count = self.front.len().min(limit);
+        buffer.extend(self.front.drain(..count));
+        count
+    }
+
     /// Receives the next value for this receiver.
     ///
     /// See tokio's [`mpsc::Receiver::recv`] and [`mpsc::UnboundedReceiver::recv`] docs for more info.
@@ -542,6 +559,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::recv`]: tokio::sync::mpsc::Receiver::recv
     /// [`mpsc::UnboundedReceiver::recv`]: tokio::sync::mpsc::UnboundedReceiver::recv
     pub async fn recv(&mut self) -> Option<Signal<A>> {
+        if let Some(signal) = self.front.pop_front() {
+            return Some(signal);
+        }
+
         let signal = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.recv().await,
             MailboxReceiverInner::Unbounded(rx) => rx.recv().await,
@@ -567,6 +588,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::recv_many`]: tokio::sync::mpsc::Receiver::recv_many
     /// [`mpsc::UnboundedReceiver::recv_many`]: tokio::sync::mpsc::UnboundedReceiver::recv_many
     pub async fn recv_many(&mut self, buffer: &mut Vec<Signal<A>>, limit: usize) -> usize {
+        if !self.front.is_empty() {
+            return self.drain_front_into(buffer, limit);
+        }
+
         let count = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.recv_many(buffer, limit).await,
             MailboxReceiverInner::Unbounded(rx) => rx.recv_many(buffer, limit).await,
@@ -596,6 +621,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::try_recv`]: tokio::sync::mpsc::Receiver::try_recv
     /// [`mpsc::UnboundedReceiver::try_recv`]: tokio::sync::mpsc::UnboundedReceiver::try_recv
     pub fn try_recv(&mut self) -> Result<Signal<A>, TryRecvError> {
+        if let Some(signal) = self.front.pop_front() {
+            return Ok(signal);
+        }
+
         let res = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.try_recv(),
             MailboxReceiverInner::Unbounded(rx) => rx.try_recv(),
@@ -621,6 +650,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::blocking_recv`]: tokio::sync::mpsc::Receiver::blocking_recv
     /// [`mpsc::UnboundedReceiver::blocking_recv`]: tokio::sync::mpsc::UnboundedReceiver::blocking_recv
     pub fn blocking_recv(&mut self) -> Option<Signal<A>> {
+        if let Some(signal) = self.front.pop_front() {
+            return Some(signal);
+        }
+
         let signal = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.blocking_recv(),
             MailboxReceiverInner::Unbounded(rx) => rx.blocking_recv(),
@@ -646,6 +679,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::blocking_recv_many`]: tokio::sync::mpsc::Receiver::blocking_recv_many
     /// [`mpsc::UnboundedReceiver::blocking_recv_many`]: tokio::sync::mpsc::UnboundedReceiver::blocking_recv_many
     pub fn blocking_recv_many(&mut self, buffer: &mut Vec<Signal<A>>, limit: usize) -> usize {
+        if !self.front.is_empty() {
+            return self.drain_front_into(buffer, limit);
+        }
+
         let count = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.blocking_recv_many(buffer, limit),
             MailboxReceiverInner::Unbounded(rx) => rx.blocking_recv_many(buffer, limit),
@@ -701,6 +738,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::is_empty`]: tokio::sync::mpsc::Receiver::is_empty
     /// [`mpsc::UnboundedReceiver::is_empty`]: tokio::sync::mpsc::UnboundedReceiver::is_empty
     pub fn is_empty(&self) -> bool {
+        if !self.front.is_empty() {
+            return false;
+        }
+
         match &self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.is_empty(),
             MailboxReceiverInner::Unbounded(rx) => rx.is_empty(),
@@ -714,10 +755,11 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::len`]: tokio::sync::mpsc::Receiver::len
     /// [`mpsc::UnboundedReceiver::len`]: tokio::sync::mpsc::UnboundedReceiver::len
     pub fn len(&self) -> usize {
-        match &self.inner {
+        let inner = match &self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.len(),
             MailboxReceiverInner::Unbounded(rx) => rx.len(),
-        }
+        };
+        self.front.len() + inner
     }
 
     /// Polls to receive the next message on this channel.
@@ -727,6 +769,10 @@ impl<A: Actor> MailboxReceiver<A> {
     /// [`mpsc::Receiver::poll_recv`]: tokio::sync::mpsc::Receiver::poll_recv
     /// [`mpsc::UnboundedReceiver::poll_recv`]: tokio::sync::mpsc::UnboundedReceiver::poll_recv
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<Signal<A>>> {
+        if let Some(signal) = self.front.pop_front() {
+            return Poll::Ready(Some(signal));
+        }
+
         let poll = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.poll_recv(cx),
             MailboxReceiverInner::Unbounded(rx) => rx.poll_recv(cx),
@@ -759,6 +805,10 @@ impl<A: Actor> MailboxReceiver<A> {
         buffer: &mut Vec<Signal<A>>,
         limit: usize,
     ) -> Poll<usize> {
+        if !self.front.is_empty() {
+            return Poll::Ready(self.drain_front_into(buffer, limit));
+        }
+
         let poll = match &mut self.inner {
             MailboxReceiverInner::Bounded(rx) => rx.poll_recv_many(cx, buffer, limit),
             MailboxReceiverInner::Unbounded(rx) => rx.poll_recv_many(cx, buffer, limit),

--- a/tests/supervision_mailbox.rs
+++ b/tests/supervision_mailbox.rs
@@ -1,0 +1,192 @@
+//! Regression tests for https://github.com/tqwewe/kameo/issues/335
+//!
+//! When a supervised actor stops or panics, the messages still pending in its mailbox must
+//! survive the restart and be processed afterwards, in order. Previously they could be
+//! randomly dropped because the shutdown path drained and discarded the mailbox while
+//! waiting for children to close.
+//!
+//! Each test loops the scenario many times because the bug was non-deterministic: a single
+//! run could pass by luck. With enough iterations the probability of all passing on the
+//! buggy code is effectively zero.
+
+use std::time::Duration;
+
+use kameo::error::Infallible;
+use kameo::prelude::*;
+use kameo::supervision::RestartPolicy;
+use tokio::sync::mpsc;
+
+const ITERATIONS: usize = 50;
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Receive the next item, failing the test (rather than hanging forever) if nothing arrives.
+async fn recv_or_fail<T>(rx: &mut mpsc::UnboundedReceiver<T>, what: &str) -> T {
+    match tokio::time::timeout(RECV_TIMEOUT, rx.recv()).await {
+        Ok(Some(v)) => v,
+        Ok(None) => panic!("channel closed before receiving {what} — message was dropped"),
+        Err(_) => panic!("timed out waiting for {what} — message was dropped from the mailbox"),
+    }
+}
+
+// ==================== Supervisor ====================
+
+struct Supervisor;
+
+impl Actor for Supervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+// ==================== Worker ====================
+
+#[derive(Clone)]
+struct Worker {
+    on_start_tx: mpsc::UnboundedSender<()>,
+    on_msg_tx: mpsc::UnboundedSender<Msg>,
+}
+
+impl Actor for Worker {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        this.on_start_tx.send(()).unwrap();
+        Ok(this)
+    }
+}
+
+/// Makes the worker panic, but only after a short delay so that messages sent afterwards
+/// are guaranteed to be sitting in the mailbox when the panic occurs.
+struct Panic;
+
+impl Message<Panic> for Worker {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: Panic, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        panic!("intentional panic for testing");
+    }
+}
+
+/// Stops the worker normally, again after a short delay.
+struct StopAfterDelay;
+
+impl Message<StopAfterDelay> for Worker {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: StopAfterDelay,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        ctx.stop();
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct Msg(usize);
+
+impl Message<Msg> for Worker {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Msg, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.on_msg_tx.send(msg).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn messages_survive_supervised_panic_restart() {
+    for i in 0..ITERATIONS {
+        let supervisor = Supervisor::spawn(Supervisor);
+
+        let (on_start_tx, mut on_start_rx) = mpsc::unbounded_channel();
+        let (on_msg_tx, mut on_msg_rx) = mpsc::unbounded_channel();
+        let worker = Worker::supervise(
+            &supervisor,
+            Worker {
+                on_start_tx,
+                on_msg_tx,
+            },
+        )
+        .restart_policy(RestartPolicy::Permanent)
+        .restart_limit(5, Duration::from_secs(10))
+        .spawn()
+        .await;
+
+        // Wait for the initial startup.
+        recv_or_fail(&mut on_start_rx, "initial startup").await;
+
+        // Trigger the panic, then enqueue two messages behind it.
+        worker.tell(Panic).await.unwrap();
+        worker.tell(Msg(0)).await.unwrap();
+        worker.tell(Msg(1)).await.unwrap();
+
+        // Wait for the actor to restart after the panic.
+        recv_or_fail(&mut on_start_rx, "restart startup").await;
+
+        // The remaining messages must be processed, in order.
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(0)").await,
+            Msg(0),
+            "iteration {i}: first pending message lost or reordered after restart"
+        );
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(1)").await,
+            Msg(1),
+            "iteration {i}: second pending message lost or reordered after restart"
+        );
+
+        supervisor.kill();
+        supervisor.wait_for_shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn messages_survive_supervised_normal_stop_restart() {
+    for i in 0..ITERATIONS {
+        let supervisor = Supervisor::spawn(Supervisor);
+
+        let (on_start_tx, mut on_start_rx) = mpsc::unbounded_channel();
+        let (on_msg_tx, mut on_msg_rx) = mpsc::unbounded_channel();
+        let worker = Worker::supervise(
+            &supervisor,
+            Worker {
+                on_start_tx,
+                on_msg_tx,
+            },
+        )
+        .restart_policy(RestartPolicy::Permanent)
+        .restart_limit(5, Duration::from_secs(10))
+        .spawn()
+        .await;
+
+        recv_or_fail(&mut on_start_rx, "initial startup").await;
+
+        // Stop normally, then enqueue two messages behind the stop.
+        worker.tell(StopAfterDelay).await.unwrap();
+        worker.tell(Msg(0)).await.unwrap();
+        worker.tell(Msg(1)).await.unwrap();
+
+        // Permanent policy restarts even on a normal exit.
+        recv_or_fail(&mut on_start_rx, "restart startup").await;
+
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(0)").await,
+            Msg(0),
+            "iteration {i}: first pending message lost or reordered after restart"
+        );
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(1)").await,
+            Msg(1),
+            "iteration {i}: second pending message lost or reordered after restart"
+        );
+
+        supervisor.kill();
+        supervisor.wait_for_shutdown().await;
+    }
+}


### PR DESCRIPTION
fixes #335

When a supervised actor stopped or panicked, pending messages in its mailbox could be dropped instead of surviving the restart. The shutdown path drains the mailbox while waiting for children to close, but it discarded everything it pulled, including messages meant to be handed to the supervisor for restart.

This keeps the drain (needed to avoid the child-shutdown deadlock) but buffers the pulled messages and re-queues them on the receiver, so they survive the restart in order. Adds regression tests covering panic and normal-stop restarts.