### PR TITLE
refactor(supervision): drop all messages during drain instead of buffering tells and processing asks

### DIFF
--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -355,7 +355,10 @@ where
                 // tell: preserve for the restart
                 Some(signal @ Signal::Message { reply: None, .. }) => preserved.push_back(signal),
                 // ask: drop the reply sender so the caller gets `ActorStopped`
-                Some(Signal::Message { reply: Some(_), .. }) => {}
+                Some(Signal::Message { reply: Some(_), .. }) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!("dropping pending ask during restart drain, caller will receive ActorStopped");
+                }
                 // lifecycle / link-died signals during our own teardown: discard
                 Some(_) => {}
                 None => break,

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -1,4 +1,6 @@
-use std::{convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread};
+use std::{
+    collections::VecDeque, convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread,
+};
 
 use futures::{
     FutureExt,
@@ -334,13 +336,15 @@ where
 }
 
 /// Keeps the mailbox drained while waiting for supervised children to close their channels,
-/// preventing a child's notification from deadlocking on a full mailbox. All messages consumed
-/// during this window are discarded: reply senders are dropped, so pending asks receive
-/// `ActorStopped`.
+/// preventing a child's notification from deadlocking on a full mailbox. Tells consumed during
+/// this window are preserved and re-queued so they survive a supervisor restart; asks have their
+/// reply sender dropped (caller receives `ActorStopped`), which unblocks any child awaiting a
+/// reply so it can finish shutting down.
 async fn drain_until_children_closed<A>(links: &Links, mailbox_rx: &mut MailboxReceiver<A>)
 where
     A: Actor,
 {
+    let mut preserved = VecDeque::new();
     let wait = links.wait_children_closed();
     tokio::pin!(wait);
     loop {
@@ -348,11 +352,17 @@ where
             biased;
             _ = &mut wait => break,
             signal = mailbox_rx.recv() => match signal {
+                // tell: preserve for the restart
+                Some(signal @ Signal::Message { reply: None, .. }) => preserved.push_back(signal),
+                // ask: drop the reply sender so the caller gets `ActorStopped`
+                Some(Signal::Message { reply: Some(_), .. }) => {}
+                // lifecycle / link-died signals during our own teardown: discard
                 Some(_) => {}
                 None => break,
             }
         }
     }
+    mailbox_rx.push_front(preserved);
 }
 
 async fn abortable_actor_loop<A>(

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -1,6 +1,4 @@
-use std::{
-    collections::VecDeque, convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread,
-};
+use std::{convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread};
 
 use futures::{
     FutureExt,
@@ -239,7 +237,6 @@ where
                 monitor.set_stopping();
 
                 let mut actor = state.shutdown().await;
-
                 actor_ref.links.set_children_parent_shutdown().await;
                 actor_ref.links.send_children_shutdown().await;
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx).await;
@@ -336,28 +333,26 @@ where
     }
 }
 
-/// Waits for all child actors to close while keeping the mailbox drained, so a child
-/// notifying us cannot deadlock on a full mailbox. Pending messages pulled during the wait
-/// are re-queued afterwards so they survive a supervisor restart rather than being dropped.
+/// Keeps the mailbox drained while waiting for supervised children to close their channels,
+/// preventing a child's notification from deadlocking on a full mailbox. All messages consumed
+/// during this window are discarded: reply senders are dropped, so pending asks receive
+/// `ActorStopped`.
 async fn drain_until_children_closed<A>(links: &Links, mailbox_rx: &mut MailboxReceiver<A>)
 where
     A: Actor,
 {
-    let mut preserved = VecDeque::new();
     let wait = links.wait_children_closed();
     tokio::pin!(wait);
     loop {
         tokio::select! {
             biased;
             _ = &mut wait => break,
-            signal = mailbox_rx.recv() => {
-                if let Some(signal @ Signal::Message { .. }) = signal {
-                    preserved.push_back(signal);
-                }
+            signal = mailbox_rx.recv() => match signal {
+                Some(_) => {}
+                None => break,
             }
         }
     }
-    mailbox_rx.push_front(preserved);
 }
 
 async fn abortable_actor_loop<A>(

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -551,13 +551,6 @@ enum MailboxReceiverInner<A: Actor> {
 }
 
 impl<A: Actor> MailboxReceiver<A> {
-    /// Re-inserts signals ahead of the channel, preserving their order, so they are
-    /// yielded before anything still queued. Used to keep pending messages across a restart.
-    pub(crate) fn push_front(&mut self, mut signals: VecDeque<Signal<A>>) {
-        signals.append(&mut self.front);
-        self.front = signals;
-    }
-
     /// Moves up to `limit` already-buffered front signals into `buffer`, returning the count.
     fn drain_front_into(&mut self, buffer: &mut Vec<Signal<A>>, limit: usize) -> usize {
         let count = self.front.len().min(limit);

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -551,6 +551,13 @@ enum MailboxReceiverInner<A: Actor> {
 }
 
 impl<A: Actor> MailboxReceiver<A> {
+    /// Re-inserts signals ahead of the channel, preserving their order, so they are
+    /// yielded before anything still queued. Used to keep pending messages across a restart.
+    pub(crate) fn push_front(&mut self, mut signals: VecDeque<Signal<A>>) {
+        signals.append(&mut self.front);
+        self.front = signals;
+    }
+
     /// Moves up to `limit` already-buffered front signals into `buffer`, returning the count.
     fn drain_front_into(&mut self, buffer: &mut Vec<Signal<A>>, limit: usize) -> usize {
         let count = self.front.len().min(limit);

--- a/tests/supervision_mailbox.rs
+++ b/tests/supervision_mailbox.rs
@@ -375,3 +375,183 @@ async fn two_children_asking_supervisor_during_drain_both_get_actor_stopped() {
     assert!(r1.is_err(), "child1 expected ActorStopped, got: {r1:?}");
     assert!(r2.is_err(), "child2 expected ActorStopped, got: {r2:?}");
 }
+
+// ==================== Restart of an actor that has children ====================
+//
+// An actor that itself supervises children opens a "drain window" while it waits for those
+// children to close. These tests cover the gap #351 left: messages arriving during that window
+// must still survive a restart (tells), while asks are released with `ActorStopped`.
+
+struct RootSupervisor;
+
+impl Actor for RootSupervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+// A child whose handler stays busy so the `SupervisorRestart` signal queues behind it, keeping
+// the child's mailbox open — and therefore its parent's drain window open.
+#[derive(Clone)]
+struct SlowChild;
+
+impl Actor for SlowChild {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+struct BusyWork(Duration);
+
+impl Message<BusyWork> for SlowChild {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: BusyWork,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tokio::time::sleep(msg.0).await;
+    }
+}
+
+// The middle actor is both supervised (so it restarts) and a supervisor (so it has a drain
+// window during shutdown).
+#[derive(Clone)]
+struct Middle {
+    on_start_tx: mpsc::UnboundedSender<()>,
+    on_msg_tx: mpsc::UnboundedSender<Msg>,
+}
+
+impl Actor for Middle {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        this.on_start_tx.send(()).unwrap();
+        Ok(this)
+    }
+}
+
+impl Message<Panic> for Middle {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: Panic, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        panic!("intentional panic for testing");
+    }
+}
+
+impl Message<Msg> for Middle {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Msg, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.on_msg_tx.send(msg).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn tells_survive_restart_of_actor_with_children() {
+    for i in 0..ITERATIONS {
+        let root = RootSupervisor::spawn(RootSupervisor);
+
+        let (on_start_tx, mut on_start_rx) = mpsc::unbounded_channel();
+        let (on_msg_tx, mut on_msg_rx) = mpsc::unbounded_channel();
+        let middle = Middle::supervise(
+            &root,
+            Middle {
+                on_start_tx,
+                on_msg_tx,
+            },
+        )
+        .restart_policy(RestartPolicy::Permanent)
+        .restart_limit(5, Duration::from_secs(10))
+        .spawn()
+        .await;
+
+        recv_or_fail(&mut on_start_rx, "middle initial startup").await;
+
+        // Give middle a busy child so its shutdown opens a drain window that outlives the
+        // panic, ensuring the pending tells are pulled while it waits for the child to close.
+        let child = SlowChild::supervise(&middle, SlowChild).spawn().await;
+        child
+            .tell(BusyWork(Duration::from_millis(100)))
+            .await
+            .unwrap();
+
+        middle.tell(Panic).await.unwrap();
+        middle.tell(Msg(0)).await.unwrap();
+        middle.tell(Msg(1)).await.unwrap();
+
+        recv_or_fail(&mut on_start_rx, "middle restart startup").await;
+
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(0)").await,
+            Msg(0),
+            "iteration {i}: tell lost during the drain window of an actor with children"
+        );
+        assert_eq!(
+            recv_or_fail(&mut on_msg_rx, "Msg(1)").await,
+            Msg(1),
+            "iteration {i}: tell lost during the drain window of an actor with children"
+        );
+
+        root.kill();
+        root.wait_for_shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn ask_during_restart_of_actor_with_children_returns_actor_stopped() {
+    let root = RootSupervisor::spawn(RootSupervisor);
+
+    let (on_start_tx, mut on_start_rx) = mpsc::unbounded_channel();
+    let (on_msg_tx, mut on_msg_rx) = mpsc::unbounded_channel();
+    let middle = Middle::supervise(
+        &root,
+        Middle {
+            on_start_tx,
+            on_msg_tx,
+        },
+    )
+    .restart_policy(RestartPolicy::Permanent)
+    .restart_limit(5, Duration::from_secs(10))
+    .spawn()
+    .await;
+
+    recv_or_fail(&mut on_start_rx, "middle initial startup").await;
+
+    let child = SlowChild::supervise(&middle, SlowChild).spawn().await;
+    child
+        .tell(BusyWork(Duration::from_millis(100)))
+        .await
+        .unwrap();
+
+    middle.tell(Panic).await.unwrap();
+    // Enqueue an ask then a tell behind the panic, in order. The ask must be released with
+    // `ActorStopped` during the drain window; the tell must survive to the restarted instance.
+    let pending_ask = middle.ask(Msg(99)).enqueue().await.unwrap();
+    middle.tell(Msg(0)).await.unwrap();
+
+    let ask_result = pending_ask.await;
+    assert!(
+        matches!(ask_result, Err(SendError::ActorStopped)),
+        "ask during the restart drain window should return ActorStopped, got: {ask_result:?}"
+    );
+
+    recv_or_fail(&mut on_start_rx, "middle restart startup").await;
+    assert_eq!(
+        recv_or_fail(&mut on_msg_rx, "Msg(0)").await,
+        Msg(0),
+        "tell should survive the restart even when an ask in the same window is dropped"
+    );
+
+    root.kill();
+    root.wait_for_shutdown().await;
+}

--- a/tests/supervision_mailbox.rs
+++ b/tests/supervision_mailbox.rs
@@ -1,17 +1,6 @@
-//! Regression tests for https://github.com/tqwewe/kameo/issues/335
-//!
-//! When a supervised actor stops or panics, the messages still pending in its mailbox must
-//! survive the restart and be processed afterwards, in order. Previously they could be
-//! randomly dropped because the shutdown path drained and discarded the mailbox while
-//! waiting for children to close.
-//!
-//! Each test loops the scenario many times because the bug was non-deterministic: a single
-//! run could pass by luck. With enough iterations the probability of all passing on the
-//! buggy code is effectively zero.
-
 use std::time::Duration;
 
-use kameo::error::Infallible;
+use kameo::error::{Infallible, SendError};
 use kameo::prelude::*;
 use kameo::supervision::RestartPolicy;
 use tokio::sync::mpsc;
@@ -19,7 +8,6 @@ use tokio::sync::mpsc;
 const ITERATIONS: usize = 50;
 const RECV_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Receive the next item, failing the test (rather than hanging forever) if nothing arrives.
 async fn recv_or_fail<T>(rx: &mut mpsc::UnboundedReceiver<T>, what: &str) -> T {
     match tokio::time::timeout(RECV_TIMEOUT, rx.recv()).await {
         Ok(Some(v)) => v,
@@ -59,8 +47,6 @@ impl Actor for Worker {
     }
 }
 
-/// Makes the worker panic, but only after a short delay so that messages sent afterwards
-/// are guaranteed to be sitting in the mailbox when the panic occurs.
 struct Panic;
 
 impl Message<Panic> for Worker {
@@ -72,7 +58,6 @@ impl Message<Panic> for Worker {
     }
 }
 
-/// Stops the worker normally, again after a short delay.
 struct StopAfterDelay;
 
 impl Message<StopAfterDelay> for Worker {
@@ -118,18 +103,14 @@ async fn messages_survive_supervised_panic_restart() {
         .spawn()
         .await;
 
-        // Wait for the initial startup.
         recv_or_fail(&mut on_start_rx, "initial startup").await;
 
-        // Trigger the panic, then enqueue two messages behind it.
         worker.tell(Panic).await.unwrap();
         worker.tell(Msg(0)).await.unwrap();
         worker.tell(Msg(1)).await.unwrap();
 
-        // Wait for the actor to restart after the panic.
         recv_or_fail(&mut on_start_rx, "restart startup").await;
 
-        // The remaining messages must be processed, in order.
         assert_eq!(
             recv_or_fail(&mut on_msg_rx, "Msg(0)").await,
             Msg(0),
@@ -167,12 +148,10 @@ async fn messages_survive_supervised_normal_stop_restart() {
 
         recv_or_fail(&mut on_start_rx, "initial startup").await;
 
-        // Stop normally, then enqueue two messages behind the stop.
         worker.tell(StopAfterDelay).await.unwrap();
         worker.tell(Msg(0)).await.unwrap();
         worker.tell(Msg(1)).await.unwrap();
 
-        // Permanent policy restarts even on a normal exit.
         recv_or_fail(&mut on_start_rx, "restart startup").await;
 
         assert_eq!(
@@ -189,4 +168,218 @@ async fn messages_survive_supervised_normal_stop_restart() {
         supervisor.kill();
         supervisor.wait_for_shutdown().await;
     }
+}
+
+// ==================== ask-to-dying-supervisor deadlock (supervised) ====================
+
+struct PingSupervisor;
+
+impl Actor for PingSupervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+struct Ping;
+
+impl Message<Ping> for PingSupervisor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: Ping, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {}
+}
+
+#[derive(Clone)]
+struct AskBackChild {
+    supervisor: ActorRef<PingSupervisor>,
+    result_tx: mpsc::UnboundedSender<Result<(), SendError<Ping, Infallible>>>,
+}
+
+impl Actor for AskBackChild {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+struct TriggerAsk;
+
+impl Message<TriggerAsk> for AskBackChild {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: TriggerAsk,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let result = self.supervisor.ask(Ping).await;
+        let _ = self.result_tx.send(result);
+    }
+}
+
+#[tokio::test]
+async fn supervised_child_ask_to_stopping_supervisor_does_not_deadlock() {
+    let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+    let supervisor = PingSupervisor::spawn(PingSupervisor);
+    let child = AskBackChild::supervise(
+        &supervisor,
+        AskBackChild {
+            supervisor: supervisor.clone(),
+            result_tx,
+        },
+    )
+    .spawn()
+    .await;
+
+    child.tell(TriggerAsk).await.unwrap();
+    supervisor.stop_gracefully().await.unwrap();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        supervisor.wait_for_shutdown(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "supervisor deadlocked — child's ask() to the stopping supervisor prevented the child \
+         from finishing and its mailbox from closing"
+    );
+
+    let ask_result = recv_or_fail(&mut result_rx, "ask result from child").await;
+    assert!(
+        ask_result.is_err(),
+        "expected Err from ask to stopping supervisor — drain discards messages; got: {ask_result:?}"
+    );
+}
+
+// ==================== ask-to-dying actor (sibling link) ====================
+
+struct SiblingParent;
+
+impl Actor for SiblingParent {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+struct PingSibling;
+
+impl Message<PingSibling> for SiblingParent {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: PingSibling,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+    }
+}
+
+#[derive(Clone)]
+struct SiblingChild {
+    parent: ActorRef<SiblingParent>,
+}
+
+impl Actor for SiblingChild {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+struct TriggerAskSibling;
+
+impl Message<TriggerAskSibling> for SiblingChild {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: TriggerAskSibling,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = self.parent.ask(PingSibling).await;
+    }
+}
+
+#[tokio::test]
+async fn sibling_linked_child_ask_to_killed_parent_does_not_deadlock() {
+    let parent = SiblingParent::spawn(SiblingParent);
+    let child = SiblingChild::spawn_link(
+        &parent,
+        SiblingChild {
+            parent: parent.clone(),
+        },
+    )
+    .await;
+
+    child.tell(TriggerAskSibling).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    parent.kill();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), child.wait_for_shutdown()).await;
+
+    assert!(
+        result.is_ok(),
+        "child deadlocked — ask() to the killed parent hung instead of returning promptly"
+    );
+}
+
+// ==================== Multiple children asking supervisor during drain ====================
+
+#[tokio::test]
+async fn two_children_asking_supervisor_during_drain_both_get_actor_stopped() {
+    let (result1_tx, mut result1_rx) = mpsc::unbounded_channel();
+    let (result2_tx, mut result2_rx) = mpsc::unbounded_channel();
+    let supervisor = PingSupervisor::spawn(PingSupervisor);
+
+    let child1 = AskBackChild::supervise(
+        &supervisor,
+        AskBackChild {
+            supervisor: supervisor.clone(),
+            result_tx: result1_tx,
+        },
+    )
+    .spawn()
+    .await;
+
+    let child2 = AskBackChild::supervise(
+        &supervisor,
+        AskBackChild {
+            supervisor: supervisor.clone(),
+            result_tx: result2_tx,
+        },
+    )
+    .spawn()
+    .await;
+
+    child1.tell(TriggerAsk).await.unwrap();
+    child2.tell(TriggerAsk).await.unwrap();
+    supervisor.stop_gracefully().await.unwrap();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        supervisor.wait_for_shutdown(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "supervisor deadlocked with two children both asking during drain"
+    );
+
+    let r1 = recv_or_fail(&mut result1_rx, "child1 ask result").await;
+    let r2 = recv_or_fail(&mut result2_rx, "child2 ask result").await;
+    assert!(r1.is_err(), "child1 expected ActorStopped, got: {r1:?}");
+    assert!(r2.is_err(), "child2 expected ActorStopped, got: {r2:?}");
 }

--- a/tests/supervision_mailbox.rs
+++ b/tests/supervision_mailbox.rs
@@ -239,11 +239,7 @@ async fn supervised_child_ask_to_stopping_supervisor_does_not_deadlock() {
     child.tell(TriggerAsk).await.unwrap();
     supervisor.stop_gracefully().await.unwrap();
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(2),
-        supervisor.wait_for_shutdown(),
-    )
-    .await;
+    let result = tokio::time::timeout(Duration::from_secs(2), supervisor.wait_for_shutdown()).await;
 
     assert!(
         result.is_ok(),
@@ -368,11 +364,7 @@ async fn two_children_asking_supervisor_during_drain_both_get_actor_stopped() {
     child2.tell(TriggerAsk).await.unwrap();
     supervisor.stop_gracefully().await.unwrap();
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(2),
-        supervisor.wait_for_shutdown(),
-    )
-    .await;
+    let result = tokio::time::timeout(Duration::from_secs(2), supervisor.wait_for_shutdown()).await;
     assert!(
         result.is_ok(),
         "supervisor deadlocked with two children both asking during drain"


### PR DESCRIPTION
Closes #335

When a stopping actor has supervised children it enters a drain phase, keeping its mailbox clear while it waits for those children to close so that a child notifying it can't deadlock on a full mailbox. The open question is what to do with messages pulled during that window.

The original 0.21.0 fix for #335 buffered tells but also kept ask reply senders alive in the buffer, which brought back a deadlock: a child blocked on `parent.ask().await` never got a reply, so it never finished its handler, never processed its own shutdown, and never closed, leaving the parent's `wait_children_closed` hung forever.

This PR keeps the drain phase but treats the two message kinds differently. Tells are preserved and re-queued ahead of the channel so they survive a restart in order, the same way leaf actors (no children) already behave. Asks have their reply sender dropped so the caller gets `ActorStopped`, which is what breaks the deadlock: dropping the sender unblocks a child waiting on a reply, letting it finish shutting down so the parent can move on.

The result is that mailbox preservation now works for actors that are themselves supervisors, not just leaf actors, and it stays deadlock free.

### Tradeoff

An ask to an actor that's mid restart returns `Err(SendError::ActorStopped)`. There's no way around this while the parent waits for its children, since a child blocked on an inline `ask().await` has to be released for teardown to finish, and releasing it means failing the ask. The restart decision happens later on the parent's side, so at the point the sender is dropped the dying actor doesn't yet know whether it'll be restarted, and can't report anything more specific than `ActorStopped`. Retry if you expect the actor to come back.

### Tests

`tests/supervision_mailbox.rs` adds a three level tree (root, middle, busy child) where the busy child holds the middle actor's drain window open long enough to exercise it:

- `tells_survive_restart_of_actor_with_children` checks that pending tells survive a restart of an actor that has children, which is the case the discard everything approach missed.
- `ask_during_restart_of_actor_with_children_returns_actor_stopped` checks that an ask in that same window returns `ActorStopped` while a tell next to it survives.

Both fail on the old discard everything drain and pass now, and the existing deadlock tests still pass.
