### PR TITLE
feat(actor): add per-actor default reply timeout via `PreparedActor`

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -49,6 +49,7 @@ pub struct ActorRef<A: Actor> {
     id: ActorId,
     mailbox_sender: MailboxSender<A>,
     abort_handle: AbortHandle,
+    default_reply_timeout: Option<Duration>,
     pub(crate) links: Links,
     pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
@@ -71,10 +72,23 @@ where
             id,
             mailbox_sender: mailbox,
             abort_handle,
+            default_reply_timeout: None,
             links,
             startup_result,
             shutdown_result,
         }
+    }
+
+    /// Returns the default reply timeout applied to `ask` requests that don't set their own.
+    #[inline]
+    pub(crate) fn default_reply_timeout(&self) -> Option<Duration> {
+        self.default_reply_timeout
+    }
+
+    /// Sets the default reply timeout applied to `ask` requests that don't set their own.
+    #[inline]
+    pub(crate) fn set_default_reply_timeout(&mut self, timeout: Option<Duration>) {
+        self.default_reply_timeout = timeout;
     }
 
     /// Returns the unique identifier of the actor.
@@ -200,6 +214,7 @@ where
             id: self.id,
             mailbox_sender: self.mailbox_sender.downgrade(),
             abort_handle: self.abort_handle.clone(),
+            default_reply_timeout: self.default_reply_timeout,
             links: self.links.clone(),
             startup_result: self.startup_result.clone(),
             shutdown_result: self.shutdown_result.clone(),
@@ -211,6 +226,7 @@ where
             id: self.id,
             mailbox_sender: self.mailbox_sender.downgrade(),
             abort_handle: self.abort_handle,
+            default_reply_timeout: self.default_reply_timeout,
             links: self.links,
             startup_result: self.startup_result,
             shutdown_result: self.shutdown_result,
@@ -1332,6 +1348,7 @@ impl<A: Actor> Clone for ActorRef<A> {
             id: self.id,
             mailbox_sender: self.mailbox_sender.clone(),
             abort_handle: self.abort_handle.clone(),
+            default_reply_timeout: self.default_reply_timeout,
             links: self.links.clone(),
             startup_result: self.startup_result.clone(),
             shutdown_result: self.shutdown_result.clone(),
@@ -2117,6 +2134,7 @@ pub struct WeakActorRef<A: Actor> {
     id: ActorId,
     mailbox_sender: WeakMailboxSender<A>,
     abort_handle: AbortHandle,
+    default_reply_timeout: Option<Duration>,
     pub(crate) links: Links,
     pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
@@ -2142,6 +2160,7 @@ impl<A: Actor> WeakActorRef<A> {
             id: self.id,
             mailbox_sender: mailbox,
             abort_handle: self.abort_handle.clone(),
+            default_reply_timeout: self.default_reply_timeout,
             links: self.links.clone(),
             startup_result: self.startup_result.clone(),
             shutdown_result: self.shutdown_result.clone(),
@@ -2430,6 +2449,7 @@ impl<A: Actor> Clone for WeakActorRef<A> {
             id: self.id,
             mailbox_sender: self.mailbox_sender.clone(),
             abort_handle: self.abort_handle.clone(),
+            default_reply_timeout: self.default_reply_timeout,
             links: self.links.clone(),
             startup_result: self.startup_result.clone(),
             shutdown_result: self.shutdown_result.clone(),

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque, convert, ops::ControlFlow, panic::AssertUnwindSafe, sync::Arc, thread,
+    time::Duration,
 };
 
 use futures::{
@@ -93,8 +94,26 @@ impl<A: Actor> PreparedActor<A> {
     /// Returns a reference to the [`ActorRef`], which can be used to send messages to the actor.
     ///
     /// The `ActorRef` can be used for interaction before the actor starts processing its event loop.
+    ///
+    /// Note: if you intend to configure a [default reply timeout](PreparedActor::reply_timeout),
+    /// do so before cloning the ref out, as the value is read off the clone at the time it's made.
     pub fn actor_ref(&self) -> &ActorRef<A> {
         &self.actor_ref
+    }
+
+    /// Sets a default reply timeout applied to every `ask` request that doesn't specify its own.
+    ///
+    /// An `ask` whose handler doesn't reply within this duration resolves with a timeout error
+    /// instead of waiting forever. A timeout set at the call site with
+    /// [`AskRequest::reply_timeout`](crate::request::AskRequest::reply_timeout) always takes
+    /// precedence over this default. The default applies to async `ask` requests; the blocking
+    /// variants are unaffected.
+    ///
+    /// Configure this before cloning the [`ActorRef`] out (see [`PreparedActor::actor_ref`]),
+    /// otherwise the clone won't observe the default.
+    pub fn reply_timeout(mut self, duration: Duration) -> Self {
+        self.actor_ref.set_default_reply_timeout(Some(duration));
+        self
     }
 
     /// Runs the actor in the current context **without** spawning a separate task, until the actor is stopped.

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -148,7 +148,11 @@ where
             self.actor_ref.id(),
             crate::console::wire::WaitKind::Ask,
         );
-        let reply = match self.reply_timeout.into() {
+        let reply_timeout = self
+            .reply_timeout
+            .into()
+            .or_else(|| self.actor_ref.default_reply_timeout());
+        let reply = match reply_timeout {
             Some(timeout) => tokio::time::timeout(timeout, rx).await??,
             None => rx.await?,
         };
@@ -214,8 +218,12 @@ where
             }
         }
 
+        let reply_timeout = self
+            .reply_timeout
+            .into()
+            .or_else(|| self.actor_ref.default_reply_timeout());
         let fut = async move {
-            let reply = match self.reply_timeout.into() {
+            let reply = match reply_timeout {
                 Some(timeout) => tokio::time::timeout(timeout, rx).await??,
                 None => rx.await?,
             };
@@ -333,7 +341,11 @@ where
             self.actor_ref.id(),
             crate::console::wire::WaitKind::Ask,
         );
-        let reply = match self.reply_timeout.into() {
+        let reply_timeout = self
+            .reply_timeout
+            .into()
+            .or_else(|| self.actor_ref.default_reply_timeout());
+        let reply = match reply_timeout {
             Some(timeout) => tokio::time::timeout(timeout, rx).await??,
             None => rx.await?,
         };
@@ -392,8 +404,12 @@ where
         let tx = self.actor_ref.mailbox_sender();
         tx.try_send(signal)?;
 
+        let reply_timeout = self
+            .reply_timeout
+            .into()
+            .or_else(|| self.actor_ref.default_reply_timeout());
         let fut = async move {
-            let reply = match self.reply_timeout.into() {
+            let reply = match reply_timeout {
                 Some(timeout) => tokio::time::timeout(timeout, rx).await??,
                 None => rx.await?,
             };
@@ -414,6 +430,9 @@ where
     M: Send + 'static,
 {
     /// Sends the message in a blocking context.
+    ///
+    /// Note: a [default reply timeout](crate::actor::PreparedActor::reply_timeout) does not
+    /// apply to blocking asks, only to the async variants.
     #[allow(clippy::type_complexity)]
     pub fn blocking_send(
         self,
@@ -468,6 +487,9 @@ where
     ///
     /// The actor will not progress until the pending reply has been received or dropped.
     /// This may lead to deadlocks if used incorrectly.
+    ///
+    /// Note: a [default reply timeout](crate::actor::PreparedActor::reply_timeout) does not
+    /// apply to blocking asks, only to the async variants.
     ///
     /// # Example
     ///
@@ -1458,6 +1480,135 @@ mod tests {
         );
         actor_ref.kill();
 
+        Ok(())
+    }
+
+    // Helper actor shared by the default reply timeout tests below.
+    struct SleepActor;
+
+    impl Actor for SleepActor {
+        type Args = Self;
+        type Error = Infallible;
+
+        async fn on_start(
+            state: Self::Args,
+            _actor_ref: ActorRef<Self>,
+        ) -> Result<Self, Self::Error> {
+            Ok(state)
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    struct Sleep(Duration);
+
+    impl Message<Sleep> for SleepActor {
+        type Reply = bool;
+
+        async fn handle(
+            &mut self,
+            Sleep(duration): Sleep,
+            _ctx: &mut Context<Self, Self::Reply>,
+        ) -> Self::Reply {
+            tokio::time::sleep(duration).await;
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn default_reply_timeout_applies_without_call_site_timeout()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let prepared = SleepActor::prepare_with_mailbox(mailbox::bounded(100))
+            .reply_timeout(Duration::from_millis(100));
+        let actor_ref = prepared.actor_ref().clone();
+        prepared.spawn(SleepActor);
+
+        // Replies within the default succeed.
+        assert_eq!(
+            actor_ref.ask(Sleep(Duration::from_millis(20))).await,
+            Ok(true)
+        );
+        // Exceeding the default times out.
+        assert_eq!(
+            actor_ref.ask(Sleep(Duration::from_millis(400))).await,
+            Err(SendError::Timeout(None))
+        );
+
+        actor_ref.kill();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn call_site_reply_timeout_overrides_default() -> Result<(), Box<dyn std::error::Error>> {
+        // Short default: a longer call-site timeout wins, so a slow reply succeeds.
+        let prepared = SleepActor::prepare_with_mailbox(mailbox::bounded(100))
+            .reply_timeout(Duration::from_millis(50));
+        let short_default = prepared.actor_ref().clone();
+        prepared.spawn(SleepActor);
+
+        assert_eq!(
+            short_default
+                .ask(Sleep(Duration::from_millis(150)))
+                .reply_timeout(Duration::from_millis(400))
+                .await,
+            Ok(true)
+        );
+        // Without a call-site timeout the short default still applies.
+        assert_eq!(
+            short_default.ask(Sleep(Duration::from_millis(150))).await,
+            Err(SendError::Timeout(None))
+        );
+
+        // Long default: a shorter call-site timeout wins, so a slow reply times out.
+        let prepared = SleepActor::prepare_with_mailbox(mailbox::bounded(100))
+            .reply_timeout(Duration::from_millis(400));
+        let long_default = prepared.actor_ref().clone();
+        prepared.spawn(SleepActor);
+
+        assert_eq!(
+            long_default
+                .ask(Sleep(Duration::from_millis(150)))
+                .reply_timeout(Duration::from_millis(50))
+                .await,
+            Err(SendError::Timeout(None))
+        );
+
+        short_default.kill();
+        long_default.kill();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_default_reply_timeout_waits() -> Result<(), Box<dyn std::error::Error>> {
+        let actor_ref = SleepActor::spawn_with_mailbox(SleepActor, mailbox::bounded(100));
+        // No default and no call-site timeout: the ask waits for the reply.
+        assert_eq!(
+            actor_ref.ask(Sleep(Duration::from_millis(50))).await,
+            Ok(true)
+        );
+        actor_ref.kill();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reply_recipient_honors_default_reply_timeout() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let prepared = SleepActor::prepare_with_mailbox(mailbox::bounded(100))
+            .reply_timeout(Duration::from_millis(100));
+        let actor_ref = prepared.actor_ref().clone();
+        prepared.spawn(SleepActor);
+
+        // The default carries through to a reply recipient, which has no call-site override.
+        let recipient = actor_ref.clone().reply_recipient::<Sleep>();
+        assert_eq!(
+            recipient.ask(Sleep(Duration::from_millis(20))).await,
+            Ok(true)
+        );
+        assert_eq!(
+            recipient.ask(Sleep(Duration::from_millis(400))).await,
+            Err(SendError::Timeout(None))
+        );
+
+        actor_ref.kill();
         Ok(())
     }
 }


### PR DESCRIPTION
Calling `.ask` by default has no reply timeout set. With this PR, you can set a default reply timeout for ask requests for an actor when spawning using the `prepare` builder:
```rust
MyActor::prepare().reply_timeout(Duration::from_secs(5)).spawn()
```