### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0](https://github.com/tqwewe/kameo/compare/v0.21.1...v0.22.0) - 2026-07-02
+
+### <!-- 0 -->Added
+
+- Add `ctx.pipe` and `ctx.pipe_with` for pipe-to-self ([#360](https://github.com/tqwewe/kameo/pull/360)) [</>](https://github.com/tqwewe/kameo/commit/2e53f73bff6f2146921c61f3de3768f567d99478)
+
+### <!-- 4 -->Documentation
+
+- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
+
+
 ## [0.21.1](https://github.com/tqwewe/kameo/compare/v0.21.0...v0.21.1) - 2026-07-01
 
 ### <!-- 0 -->Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "actors", "console", "macros"]
 
 [workspace.dependencies]
-kameo = { path = ".", version = "0.21.1" }
+kameo = { path = ".", version = "0.22.0" }
 
 futures = "0.3"
 tokio = "1.47"
@@ -18,7 +18,7 @@ all-features = true
 
 [package]
 name = "kameo"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Fault-tolerant Async Actors Built on Tokio"
@@ -47,7 +47,7 @@ metrics = ["dep:metrics"]
 hotpath = ["dep:hotpath", "hotpath/hotpath"]
 
 [dependencies]
-kameo_macros = { version = "0.21.0", path = "./macros", optional = true }
+kameo_macros = { version = "0.21.1", path = "./macros", optional = true }
 
 const-fnv1a-hash = { version = "1.1.0", optional = true }
 const-str = { version = "1.1", features = ["proc"], optional = true }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add Kameo as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-kameo = "0.21"
+kameo = "0.22"
 ```
 
 Alternatively, you can add it via command line:
@@ -134,7 +134,7 @@ Kameo ships a terminal UI, the **kameo console**, for monitoring a running actor
 Enable the `console` feature and start the collector once in `main`:
 
 ```toml
-kameo = { version = "0.21", features = ["console"] }
+kameo = { version = "0.22", features = ["console"] }
 ```
 
 ```rust,ignore

--- a/actors/Cargo.toml
+++ b/actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_actors"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Utility actors for kameo"

--- a/console/CHANGELOG.md
+++ b/console/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2](https://github.com/tqwewe/kameo/compare/console-v0.1.1...console-v0.1.2) - 2026-07-02
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.1.1](https://github.com/tqwewe/kameo/compare/console-v0.1.0...console-v0.1.1) - 2026-07-01
 
 ### <!-- 5 -->Misc

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_console"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal UI for monitoring a running kameo actor system"

--- a/console/README.md
+++ b/console/README.md
@@ -24,7 +24,7 @@ Add the feature:
 
 ```toml
 [dependencies]
-kameo = { version = "0.21", features = ["console"] }
+kameo = { version = "0.22", features = ["console"] }
 ```
 
 Start the collector once, early in `main`:

--- a/docs/core-concepts/messages.mdx
+++ b/docs/core-concepts/messages.mdx
@@ -40,6 +40,42 @@ While messages are processed sequentially within a single actor, Kameo allows fo
 
 The asynchronous nature of the `handle` function, combined with Rust's powerful futures and async/await syntax, makes it straightforward to perform non-blocking operations, such as I/O tasks or querying other actors, within a message handler.
 
+## Reacting to Async Work Without Blocking
+
+Because messages are processed one at a time, awaiting a long-running operation directly inside `handle` holds up the actor's mailbox until it finishes. When you want to start async work, such as a network request, but keep processing other messages while it runs, use `ctx.pipe`.
+
+`ctx.pipe` runs a future on a separate task and, once it resolves, delivers its output back to the actor as a message. This is the "pipe to self" pattern: the actor stays responsive, and the result flows through a normal message handler:
+
+```rust
+struct Fetched(Data);
+
+impl Message<Fetched> for MyActor {
+    type Reply = ();
+
+    async fn handle(&mut self, Fetched(data): Fetched, _: &mut Context<Self, Self::Reply>) {
+        self.last_result = data;
+    }
+}
+
+// In some other handler:
+ctx.pipe(async { Fetched(fetch_from_network().await) });
+```
+
+If the completion is a one-off that doesn't warrant a dedicated message type, use `ctx.pipe_with` instead. It runs the future the same way, but applies the result via an inline continuation that runs with `&mut self` (and may `.await`):
+
+```rust
+ctx.pipe_with(
+    async { fetch_from_network().await },
+    |actor, _ctx, result| {
+        Box::pin(async move {
+            actor.last_result = result;
+        })
+    },
+);
+```
+
+In both cases the actor is kept alive until the future resolves. If it has already stopped by then, the message or continuation is simply skipped.
+
 ---
 
 #### Summary

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -12,7 +12,7 @@ With Rust installed, you can add Kameo to your project by editing your `Cargo.t
 
 ```toml
 [dependencies]
-kameo = "0.21"
+kameo = "0.22"
 ```
 
 Alternatively you can run `cargo add kameo`.

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -5,16 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2](https://github.com/tqwewe/kameo/compare/actors-v0.6.1...actors-v0.6.2) - 2026-07-02
+## [0.21.1](https://github.com/tqwewe/kameo/compare/macros-v0.21.0...macros-v0.21.1) - 2026-07-02
 
 ### <!-- 4 -->Documentation
 
 - Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
-
-
-## [0.6.1](https://github.com/tqwewe/kameo/compare/actors-v0.6.0...actors-v0.6.1) - 2026-07-01
-
-### <!-- 3 -->Fixed
-
-- De-flake scheduler interval doctest [</>](https://github.com/tqwewe/kameo/commit/293d11d1e005783884727df9236e45d40521883a)
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_macros"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Fault-tolerant Async Actors Built on Tokio macros"

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -16,7 +16,7 @@ use crate::{
     error::{ActorStopReason, PanicError, PanicReason},
     links::{BoxMailboxReceiver, Link, ShutdownFn},
     mailbox::{MailboxReceiver, Signal},
-    message::BoxMessage,
+    message::{BoxMessage, CallbackFn, Context},
     reply::BoxReplySender,
     supervision::SupervisionStrategy,
 };
@@ -196,6 +196,31 @@ where
             Err(err) => ControlFlow::Break(ActorStopReason::Panicked(
                 PanicError::new_from_panic_any(err, PanicReason::HandlerPanic),
             )), // The handler panicked
+        }
+    }
+
+    pub(crate) async fn handle_callback(
+        &mut self,
+        actor_ref: ActorRef<A>,
+        callback: CallbackFn<A>,
+    ) -> ControlFlow<ActorStopReason> {
+        let mut ctx: Context<A, ()> = Context::new(actor_ref, None, false);
+
+        let res = AssertUnwindSafe(callback(&mut self.state, &mut ctx))
+            .catch_unwind()
+            .await;
+
+        match res {
+            Ok(()) => {
+                if ctx.should_stop() {
+                    ControlFlow::Break(ActorStopReason::Normal)
+                } else {
+                    ControlFlow::Continue(())
+                }
+            }
+            Err(err) => ControlFlow::Break(ActorStopReason::Panicked(
+                PanicError::new_from_panic_any(err, PanicReason::HandlerPanic),
+            )), // The continuation panicked
         }
     }
 

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -491,6 +491,15 @@ where
                     return reason;
                 }
             }
+            ControlFlow::Continue(Signal::Callback {
+                actor_ref,
+                callback,
+            }) => {
+                if let ControlFlow::Break(reason) = state.handle_callback(actor_ref, callback).await
+                {
+                    return reason;
+                }
+            }
             ControlFlow::Break(reason) => return reason,
         }
     }

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -208,9 +208,10 @@ impl ActorMonitor {
     pub(crate) fn record_received<A: Actor>(&self, signal: &Signal<A>) {
         let counter = match signal {
             Signal::Message { .. } => &self.messages_received,
-            Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                &self.lifecycle_signals_received
-            }
+            Signal::StartupFinished
+            | Signal::Stop
+            | Signal::SupervisorRestart
+            | Signal::Callback { .. } => &self.lifecycle_signals_received,
             Signal::LinkDied { .. } => &self.link_died_signals_received,
         };
         counter.fetch_add(1, Ordering::Relaxed);

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -132,9 +132,10 @@ impl<A: Actor> From<&Signal<A>> for SignalKind {
     fn from(signal: &Signal<A>) -> Self {
         match signal {
             Signal::Message { .. } => SignalKind::Message,
-            Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                SignalKind::Lifecycle
-            }
+            Signal::StartupFinished
+            | Signal::Stop
+            | Signal::SupervisorRestart
+            | Signal::Callback { .. } => SignalKind::Lifecycle,
             Signal::LinkDied { .. } => SignalKind::LinkDied,
         }
     }
@@ -584,9 +585,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &signal {
             Some(Signal::Message { .. }) => self.messages_received.increment(1),
-            Some(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Some(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Some(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             None => {}
         }
@@ -616,9 +620,10 @@ impl<A: Actor> MailboxReceiver<A> {
             for signal in &buffer[len - 1 - count..len - 1] {
                 match signal {
                     Signal::Message { .. } => self.messages_received.increment(1),
-                    Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                        self.lifecycle_signals_received.increment(1)
-                    }
+                    Signal::StartupFinished
+                    | Signal::Stop
+                    | Signal::SupervisorRestart
+                    | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                     Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                 }
             }
@@ -646,9 +651,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &res {
             Ok(Signal::Message { .. }) => self.messages_received.increment(1),
-            Ok(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Ok(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Ok(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             Err(_) => {}
         }
@@ -675,9 +683,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &signal {
             Some(Signal::Message { .. }) => self.messages_received.increment(1),
-            Some(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Some(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Some(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             None => {}
         }
@@ -707,9 +718,10 @@ impl<A: Actor> MailboxReceiver<A> {
             for signal in &buffer[len - 1 - count..len - 1] {
                 match signal {
                     Signal::Message { .. } => self.messages_received.increment(1),
-                    Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                        self.lifecycle_signals_received.increment(1)
-                    }
+                    Signal::StartupFinished
+                    | Signal::Stop
+                    | Signal::SupervisorRestart
+                    | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                     Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                 }
             }
@@ -795,7 +807,10 @@ impl<A: Actor> MailboxReceiver<A> {
         match &poll {
             Poll::Ready(Some(Signal::Message { .. })) => self.messages_received.increment(1),
             Poll::Ready(Some(
-                Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart,
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
             )) => self.lifecycle_signals_received.increment(1),
             Poll::Ready(Some(Signal::LinkDied { .. })) => {
                 self.link_died_signals_received.increment(1)
@@ -834,9 +849,10 @@ impl<A: Actor> MailboxReceiver<A> {
                 for signal in &buffer[len - 1 - count..len - 1] {
                     match signal {
                         Signal::Message { .. } => self.messages_received.increment(1),
-                        Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                            self.lifecycle_signals_received.increment(1)
-                        }
+                        Signal::StartupFinished
+                        | Signal::Stop
+                        | Signal::SupervisorRestart
+                        | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                         Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                     }
                 }
@@ -919,6 +935,16 @@ pub enum Signal<A: Actor> {
     Stop,
     /// Signals the actor to restart.
     SupervisorRestart,
+    /// A continuation to run against the actor's state, produced by a resolved
+    /// [`Context::pipe_with`] future.
+    ///
+    /// [`Context::pipe_with`]: crate::message::Context::pipe_with
+    Callback {
+        /// The actor ref, to keep the actor from stopping due to RAII semantics.
+        actor_ref: ActorRef<A>,
+        /// The continuation to run against the actor's state.
+        callback: crate::message::CallbackFn<A>,
+    },
 }
 
 impl<A: Actor> Signal<A> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -22,11 +22,19 @@ use crate::{
     Actor,
     actor::ActorRef,
     error::{self, PanicError, PanicReason, SendError},
+    mailbox::Signal,
     reply::{BoxReplySender, DelegatedReply, ForwardedReply, Reply, ReplyError, ReplySender},
 };
 
 /// A boxed dynamic message type for the actor `A`.
 pub type BoxMessage<A> = Box<dyn DynMessage<A>>;
+
+/// A boxed continuation run against an actor's state when a [`Context::pipe_with`] future resolves.
+///
+/// The continuation returns a future that borrows `&mut A`, so it is boxed behind a `for<'a>`
+/// bound rather than a plain `FnOnce`.
+pub(crate) type CallbackFn<A> =
+    Box<dyn for<'a> FnOnce(&'a mut A, &'a mut Context<A, ()>) -> BoxFuture<'a, ()> + Send>;
 
 /// A boxed dynamic type used for message replies.
 pub type BoxReply = Box<dyn any::Any + Send>;
@@ -111,6 +119,11 @@ where
     /// Stops the actor normally after processing the current message.
     pub fn stop(&mut self) {
         self.stop = true;
+    }
+
+    /// Whether [`Context::stop`] was called on this context.
+    pub(crate) fn should_stop(&self) -> bool {
+        self.stop
     }
 
     /// Extracts the reply sender, providing a mechanism for delegated responses and an optional reply sender.
@@ -249,6 +262,129 @@ where
         });
 
         delegated_reply
+    }
+
+    /// Runs a future off the actor's message loop, then sends its result back to the actor as a
+    /// message.
+    ///
+    /// This is the "pipe to self" pattern: `future` runs on a separate task so the actor keeps
+    /// processing other messages while it is in flight. When `future` resolves, its output is
+    /// delivered to the actor with [`tell`] semantics, so it runs through the normal message
+    /// pipeline (handler, ordering, tracing) and its reply is discarded.
+    ///
+    /// Use [`pipe_with`] instead when the completion logic is a one-off that should mutate the
+    /// actor's state inline rather than go through a dedicated [`Message`] handler.
+    ///
+    /// The actor is kept alive until `future` resolves. If the actor has stopped by the time it
+    /// resolves, the message is dropped. The future itself is not cancelled when the actor stops.
+    ///
+    /// [`tell`]: crate::actor::ActorRef::tell
+    /// [`pipe_with`]: Context::pipe_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    ///
+    /// #[derive(Actor, Default)]
+    /// struct MyActor {
+    ///     last: u32,
+    /// }
+    ///
+    /// struct Fetch;
+    /// struct Fetched(u32);
+    ///
+    /// impl Message<Fetch> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
+    ///         ctx.pipe(async { Fetched(40 + 2) });
+    ///     }
+    /// }
+    ///
+    /// impl Message<Fetched> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
+    ///         self.last = value;
+    ///     }
+    /// }
+    /// ```
+    pub fn pipe<F, M>(&self, future: F)
+    where
+        A: Message<M>,
+        F: Future<Output = M> + Send + 'static,
+        M: Send + 'static,
+    {
+        let actor_ref = self.actor_ref.clone();
+        tokio::spawn(async move {
+            let msg = future.await;
+            let _ = actor_ref.tell(msg).send().await;
+        });
+    }
+
+    /// Runs a future off the actor's message loop, then applies its result back to the actor with
+    /// a custom continuation.
+    ///
+    /// Like [`pipe`], but instead of delivering the result as a message, `on_complete` runs with
+    /// `&mut self` (and its own [`Context`]) between messages, so it can mutate the actor's state
+    /// directly, and it may `.await`. Prefer [`pipe`] when the completion should go through an
+    /// existing [`Message`] handler.
+    ///
+    /// The actor is kept alive until `future` resolves. If the actor has stopped or is
+    /// restarting by the time it resolves, `on_complete` is not run. The future itself is not
+    /// cancelled when the actor stops.
+    ///
+    /// Because `on_complete` returns a future that borrows `&mut self`, it is written as a
+    /// closure returning a boxed future (`Box::pin(async move { .. })`).
+    ///
+    /// [`pipe`]: Context::pipe
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    ///
+    /// #[derive(Actor, Default)]
+    /// struct MyActor {
+    ///     last: u32,
+    /// }
+    ///
+    /// struct Fetch;
+    ///
+    /// impl Message<Fetch> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
+    ///         ctx.pipe_with(async { 40 + 2 }, |actor, _ctx, result| {
+    ///             Box::pin(async move {
+    ///                 actor.last = result;
+    ///             })
+    ///         });
+    ///     }
+    /// }
+    /// ```
+    pub fn pipe_with<F, Fun>(&self, future: F, on_complete: Fun)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+        Fun: for<'a> FnOnce(&'a mut A, &'a mut Context<A, ()>, F::Output) -> BoxFuture<'a, ()>
+            + Send
+            + 'static,
+    {
+        let actor_ref = self.actor_ref.clone();
+        tokio::spawn(async move {
+            let output = future.await;
+            let callback: CallbackFn<A> =
+                Box::new(move |actor, ctx| on_complete(actor, ctx, output));
+            // The signal carries a strong `ActorRef` so the actor stays alive until the
+            // callback is processed, even after this task drops its own ref.
+            let signal = Signal::Callback {
+                actor_ref: actor_ref.clone(),
+                callback,
+            };
+            let _ = actor_ref.mailbox_sender().send(signal).await;
+        });
     }
 
     /// Forwards the message to another actor, returning a [ForwardedReply].

--- a/tests/context_pipe.rs
+++ b/tests/context_pipe.rs
@@ -1,0 +1,176 @@
+use std::time::Duration;
+
+use kameo::error::Infallible;
+use kameo::prelude::*;
+use tokio::sync::mpsc;
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct PipeActor {
+    value: u32,
+    done_tx: mpsc::UnboundedSender<u32>,
+}
+
+impl Actor for PipeActor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+// Applies a piped future's result to the actor's state.
+struct Trigger;
+
+impl Message<Trigger> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Trigger, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe_with(async { 40 + 2 }, |actor, _ctx, out| {
+            Box::pin(async move {
+                actor.value = out;
+                actor.done_tx.send(actor.value).unwrap();
+            })
+        });
+    }
+}
+
+// The piped future and the continuation both await; the continuation still holds `&mut self`.
+struct TriggerDelayed;
+
+impl Message<TriggerDelayed> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerDelayed, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe_with(
+            async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                42
+            },
+            |actor, _ctx, out| {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    actor.value = out;
+                    actor.done_tx.send(actor.value).unwrap();
+                })
+            },
+        );
+    }
+}
+
+// The continuation stops the actor via `ctx.stop()`.
+struct TriggerStop;
+
+impl Message<TriggerStop> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerStop, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe_with(async { 7 }, |actor, ctx, out| {
+            Box::pin(async move {
+                actor.value = out;
+                actor.done_tx.send(actor.value).unwrap();
+                ctx.stop();
+            })
+        });
+    }
+}
+
+// Pipes a future whose output is delivered back as a message the actor already handles.
+struct TriggerMessage;
+
+impl Message<TriggerMessage> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerMessage, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe(async { Fetched(99) });
+    }
+}
+
+struct Fetched(u32);
+
+impl Message<Fetched> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
+        self.value = value;
+        self.done_tx.send(self.value).unwrap();
+    }
+}
+
+struct GetValue;
+
+impl Message<GetValue> for PipeActor {
+    type Reply = u32;
+
+    async fn handle(&mut self, _: GetValue, _: &mut Context<Self, Self::Reply>) -> u32 {
+        self.value
+    }
+}
+
+async fn recv(rx: &mut mpsc::UnboundedReceiver<u32>) -> u32 {
+    tokio::time::timeout(RECV_TIMEOUT, rx.recv())
+        .await
+        .expect("timed out waiting for pipe continuation")
+        .expect("channel closed before pipe continuation ran")
+}
+
+#[tokio::test]
+async fn pipe_with_applies_result_to_state() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(Trigger).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn pipe_with_continuation_may_await() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerDelayed).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn pipe_with_continuation_can_stop_actor() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerStop).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 7);
+    tokio::time::timeout(RECV_TIMEOUT, actor.wait_for_shutdown())
+        .await
+        .expect("actor did not stop after continuation called ctx.stop()");
+    assert!(!actor.is_alive());
+}
+
+#[tokio::test]
+async fn pipe_delivers_result_as_message() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerMessage).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 99);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 99);
+}
+
+#[tokio::test]
+async fn pipe_with_keeps_actor_alive_until_future_resolves() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerDelayed).await.unwrap();
+    // Drop the only external ref. The pipe task holds a strong ref, so the actor must stay
+    // alive long enough for the continuation to run.
+    drop(actor);
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+}


### PR DESCRIPTION



## 🤖 New release

* `kameo_macros`: 0.21.0 -> 0.21.1
* `kameo`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `kameo_actors`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `kameo_console`: 0.1.1 -> 0.1.2

### ⚠ `kameo` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Signal:Callback in /tmp/.tmp9OAppH/kameo/src/mailbox.rs:942
  variant Signal:Callback in /tmp/.tmp9OAppH/kameo/src/mailbox.rs:942
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kameo_macros`

<blockquote>

## [0.21.1](https://github.com/tqwewe/kameo/compare/macros-v0.21.0...macros-v0.21.1) - 2026-07-02

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo`

<blockquote>

## [0.22.0](https://github.com/tqwewe/kameo/compare/v0.21.1...v0.22.0) - 2026-07-02

### <!-- 0 -->Added

- Add `ctx.pipe` and `ctx.pipe_with` for pipe-to-self ([#360](https://github.com/tqwewe/kameo/pull/360)) [</>](https://github.com/tqwewe/kameo/commit/2e53f73bff6f2146921c61f3de3768f567d99478)

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo_actors`

<blockquote>

## [0.6.2](https://github.com/tqwewe/kameo/compare/actors-v0.6.1...actors-v0.6.2) - 2026-07-02

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo_console`

<blockquote>

## [0.1.2](https://github.com/tqwewe/kameo/compare/console-v0.1.1...console-v0.1.2) - 2026-07-02

### <!-- 5 -->Misc

- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).