### PR TITLE
feat(supervision)!: return pending ask's message as ActorRestarting/ActorNotRunning during drain

### DIFF
--- a/actors/src/pubsub.rs
+++ b/actors/src/pubsub.rs
@@ -140,7 +140,8 @@ impl<M> PubSub<M> {
                 Err(SendError::ActorNotRunning(_)) | Err(SendError::ActorStopped) => {
                     self.subscribers.remove(&id);
                 }
-                Err(SendError::MailboxFull(_))
+                Err(SendError::ActorRestarting(_))
+                | Err(SendError::MailboxFull(_))
                 | Err(SendError::HandlerError(_))
                 | Err(SendError::Timeout(_)) => {}
             }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -260,7 +260,8 @@ where
                 let mut actor = state.shutdown().await;
                 actor_ref.links.set_children_parent_shutdown().await;
                 actor_ref.links.send_children_shutdown().await;
-                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx).await;
+                let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
+                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
                 actor_ref
                     .links
                     .lock()
@@ -313,7 +314,9 @@ where
 
                 actor_ref.links.set_children_parent_shutdown().await;
                 actor_ref.links.send_children_shutdown().await;
-                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx).await;
+                // startup failed; the supervisor may still restart us per policy
+                let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
+                drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
                 actor_ref
                     .links
                     .lock()
@@ -356,11 +359,16 @@ where
 
 /// Keeps the mailbox drained while waiting for supervised children to close their channels,
 /// preventing a child's notification from deadlocking on a full mailbox. Tells consumed during
-/// this window are preserved and re-queued so they survive a supervisor restart; asks have their
-/// reply sender dropped (caller receives `ActorStopped`), which unblocks any child awaiting a
-/// reply so it can finish shutting down.
-async fn drain_until_children_closed<A>(links: &Links, mailbox_rx: &mut MailboxReceiver<A>)
-where
+/// this window are preserved and re-queued so they survive a supervisor restart. Asks are bounced
+/// back to their caller with the original message so nothing queued is silently dropped: on a
+/// restart the caller receives `ActorRestarting` (safe to retry against the new incarnation), on a
+/// terminal stop `ActorNotRunning`. Either way any child awaiting a reply is unblocked so it can
+/// finish shutting down.
+async fn drain_until_children_closed<A>(
+    links: &Links,
+    mailbox_rx: &mut MailboxReceiver<A>,
+    is_restarting: bool,
+) where
     A: Actor,
 {
     let mut preserved = VecDeque::new();
@@ -373,10 +381,15 @@ where
             signal = mailbox_rx.recv() => match signal {
                 // tell: preserve for the restart
                 Some(signal @ Signal::Message { reply: None, .. }) => preserved.push_back(signal),
-                // ask: drop the reply sender so the caller gets `ActorStopped`
-                Some(Signal::Message { reply: Some(_), .. }) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!("dropping pending ask during restart drain, caller will receive ActorStopped");
+                // ask: bounce the message back so it isn't dropped; label it by whether we expect
+                // to restart (`ActorRestarting`, retry-safe) or stop for good (`ActorNotRunning`)
+                Some(Signal::Message { reply: Some(tx), message, .. }) => {
+                    let err = if is_restarting {
+                        SendError::ActorRestarting(message.as_any())
+                    } else {
+                        SendError::ActorNotRunning(message.as_any())
+                    };
+                    let _ = tx.send(Err(err));
                 }
                 // lifecycle / link-died signals during our own teardown: discard
                 Some(_) => {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,9 @@ pub enum SendError<M = (), E = Infallible> {
     ActorNotRunning(M),
     /// The actor panicked or was stopped before a reply could be received.
     ActorStopped,
+    /// The actor is restarting; the message was pulled during the restart drain and never
+    /// handled. The returned message is the original, safe to retry against the new incarnation.
+    ActorRestarting(M),
     /// The actors mailbox is full.
     MailboxFull(M),
     /// An error returned by the actor's message handler.
@@ -108,6 +111,7 @@ impl<M, E> SendError<M, E> {
         match self {
             SendError::ActorNotRunning(msg) => SendError::ActorNotRunning(f(msg)),
             SendError::ActorStopped => SendError::ActorStopped,
+            SendError::ActorRestarting(msg) => SendError::ActorRestarting(f(msg)),
             SendError::MailboxFull(msg) => SendError::MailboxFull(f(msg)),
             SendError::HandlerError(err) => SendError::HandlerError(err),
             SendError::Timeout(msg) => SendError::Timeout(msg.map(f)),
@@ -122,6 +126,7 @@ impl<M, E> SendError<M, E> {
         match self {
             SendError::ActorNotRunning(msg) => SendError::ActorNotRunning(msg),
             SendError::ActorStopped => SendError::ActorStopped,
+            SendError::ActorRestarting(msg) => SendError::ActorRestarting(msg),
             SendError::MailboxFull(msg) => SendError::MailboxFull(msg),
             SendError::HandlerError(err) => SendError::HandlerError(op(err)),
             SendError::Timeout(msg) => SendError::Timeout(msg),
@@ -137,6 +142,7 @@ impl<M, E> SendError<M, E> {
         match self {
             SendError::ActorNotRunning(err) => SendError::ActorNotRunning(Box::new(err)),
             SendError::ActorStopped => SendError::ActorStopped,
+            SendError::ActorRestarting(err) => SendError::ActorRestarting(Box::new(err)),
             SendError::MailboxFull(msg) => SendError::MailboxFull(Box::new(msg)),
             SendError::HandlerError(err) => SendError::HandlerError(Box::new(err)),
             SendError::Timeout(msg) => {
@@ -149,6 +155,7 @@ impl<M, E> SendError<M, E> {
     pub fn msg(self) -> Option<M> {
         match self {
             SendError::ActorNotRunning(msg) => Some(msg),
+            SendError::ActorRestarting(msg) => Some(msg),
             SendError::MailboxFull(msg) => Some(msg),
             SendError::Timeout(msg) => msg,
             _ => None,
@@ -203,6 +210,10 @@ impl<M, E> SendError<M, SendError<M, E>> {
             SendError::ActorStopped | SendError::HandlerError(SendError::ActorStopped) => {
                 SendError::ActorStopped
             }
+            SendError::ActorRestarting(msg)
+            | SendError::HandlerError(SendError::ActorRestarting(msg)) => {
+                SendError::ActorRestarting(msg)
+            }
             SendError::MailboxFull(msg) | SendError::HandlerError(SendError::MailboxFull(msg)) => {
                 SendError::MailboxFull(msg)
             }
@@ -236,6 +247,9 @@ impl BoxSendError {
                 *err.downcast::<M>().map_err(SendError::ActorNotRunning)?,
             )),
             SendError::ActorStopped => Ok(SendError::ActorStopped),
+            SendError::ActorRestarting(err) => Ok(SendError::ActorRestarting(
+                *err.downcast::<M>().map_err(SendError::ActorRestarting)?,
+            )),
             SendError::MailboxFull(err) => Ok(SendError::MailboxFull(
                 *err.downcast().map_err(SendError::MailboxFull)?,
             )),
@@ -262,6 +276,7 @@ where
         match self {
             SendError::ActorNotRunning(_) => write!(f, "ActorNotRunning"),
             SendError::ActorStopped => write!(f, "ActorStopped"),
+            SendError::ActorRestarting(_) => write!(f, "ActorRestarting"),
             SendError::MailboxFull(_) => write!(f, "MailboxFull"),
             SendError::HandlerError(err) => err.fmt(f),
             SendError::Timeout(_) => write!(f, "Timeout"),
@@ -277,6 +292,7 @@ where
         match self {
             SendError::ActorNotRunning(_) => write!(f, "actor not running"),
             SendError::ActorStopped => write!(f, "actor stopped"),
+            SendError::ActorRestarting(_) => write!(f, "actor restarting"),
             SendError::MailboxFull(_) => write!(f, "mailbox full"),
             SendError::HandlerError(err) => err.fmt(f),
             SendError::Timeout(_) => write!(f, "timeout"),
@@ -1066,6 +1082,7 @@ impl<M, E> From<SendError<M, E>> for RemoteSendError<E> {
         match err {
             SendError::ActorNotRunning(_) => RemoteSendError::ActorNotRunning,
             SendError::ActorStopped => RemoteSendError::ActorStopped,
+            SendError::ActorRestarting(_) => RemoteSendError::ActorNotRunning,
             SendError::MailboxFull(_) => RemoteSendError::MailboxFull,
             SendError::HandlerError(err) => RemoteSendError::HandlerError(err),
             SendError::Timeout(_) => RemoteSendError::ReplyTimeout,

--- a/src/links.rs
+++ b/src/links.rs
@@ -91,9 +91,32 @@ pub struct LinksInner {
     /// instead of queuing it in the parent's mailbox, which would deadlock the parent's
     /// `shutdown_children` wait.
     pub parent_shutdown: Arc<AtomicBool>,
+    /// The restart policy our supervisor will apply to us, `Some` only when supervised. Lets the
+    /// actor guess, during its own teardown, whether it will be restarted (see [`Self::will_restart`]).
+    pub restart_policy: Option<RestartPolicy>,
 }
 
 impl LinksInner {
+    /// Best-effort guess, made during the actor's own teardown, of whether its supervisor will
+    /// restart it. Mirrors [`ErasedChildSpec::should_restart`] except for the parent-side
+    /// restart-limit check, which the child can't see; an actor that has exhausted its restart
+    /// limit is therefore guessed as restarting. Callers only use this to pick which message the
+    /// caller of a dropped `ask` receives, so the guess never drops a message, only mislabels it.
+    pub fn will_restart(&self, reason: &ActorStopReason) -> bool {
+        let Some(policy) = self.restart_policy else {
+            return false; // unsupervised: nobody will restart us
+        };
+        if self.parent_shutdown.load(Ordering::Acquire) {
+            return false; // our supervisor is going away too
+        }
+        match policy {
+            RestartPolicy::Never => false,
+            _ if matches!(reason, ActorStopReason::SupervisorRestart) => true,
+            RestartPolicy::Permanent => true,
+            RestartPolicy::Transient => !reason.is_normal(),
+        }
+    }
+
     /// Notify parent or sibblings, depending on supervision status.
     pub fn notify_links<A: Actor>(
         &mut self,

--- a/src/message.rs
+++ b/src/message.rs
@@ -387,8 +387,8 @@ where
         stop: &'a mut bool,
     ) -> BoxFuture<'a, Result<(), Box<dyn ReplyError>>>;
 
-    /// Casts the type to a `Box<dyn Any>`.
-    fn as_any(self: Box<Self>) -> Box<dyn any::Any>;
+    /// Casts the type to a `Box<dyn Any + Send>`.
+    fn as_any(self: Box<Self>) -> Box<dyn any::Any + Send>;
 }
 
 impl<A, T> DynMessage<A> for T
@@ -422,7 +422,7 @@ where
         .boxed()
     }
 
-    fn as_any(self: Box<Self>) -> Box<dyn any::Any> {
+    fn as_any(self: Box<Self>) -> Box<dyn any::Any + Send> {
         self
     }
 }

--- a/src/supervision.rs
+++ b/src/supervision.rs
@@ -638,6 +638,7 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
         let actor_id = ActorId::generate();
         let links = Links::default();
         let restart_policy = self.restart_policy;
+        links.lock().await.restart_policy = Some(restart_policy);
         let factory = Arc::new(new_factory(
             actor_id,
             mailbox_tx.clone(),

--- a/tests/supervision_mailbox.rs
+++ b/tests/supervision_mailbox.rs
@@ -249,8 +249,9 @@ async fn supervised_child_ask_to_stopping_supervisor_does_not_deadlock() {
 
     let ask_result = recv_or_fail(&mut result_rx, "ask result from child").await;
     assert!(
-        ask_result.is_err(),
-        "expected Err from ask to stopping supervisor — drain discards messages; got: {ask_result:?}"
+        matches!(ask_result, Err(SendError::ActorNotRunning(Ping))),
+        "ask to a terminally stopping supervisor should be bounced back as ActorNotRunning \
+         carrying its message, not silently dropped; got: {ask_result:?}"
     );
 }
 
@@ -335,7 +336,7 @@ async fn sibling_linked_child_ask_to_killed_parent_does_not_deadlock() {
 // ==================== Multiple children asking supervisor during drain ====================
 
 #[tokio::test]
-async fn two_children_asking_supervisor_during_drain_both_get_actor_stopped() {
+async fn two_children_asking_supervisor_during_drain_both_get_actor_not_running() {
     let (result1_tx, mut result1_rx) = mpsc::unbounded_channel();
     let (result2_tx, mut result2_rx) = mpsc::unbounded_channel();
     let supervisor = PingSupervisor::spawn(PingSupervisor);
@@ -372,15 +373,22 @@ async fn two_children_asking_supervisor_during_drain_both_get_actor_stopped() {
 
     let r1 = recv_or_fail(&mut result1_rx, "child1 ask result").await;
     let r2 = recv_or_fail(&mut result2_rx, "child2 ask result").await;
-    assert!(r1.is_err(), "child1 expected ActorStopped, got: {r1:?}");
-    assert!(r2.is_err(), "child2 expected ActorStopped, got: {r2:?}");
+    assert!(
+        matches!(r1, Err(SendError::ActorNotRunning(Ping))),
+        "child1 expected ActorNotRunning with message, got: {r1:?}"
+    );
+    assert!(
+        matches!(r2, Err(SendError::ActorNotRunning(Ping))),
+        "child2 expected ActorNotRunning with message, got: {r2:?}"
+    );
 }
 
 // ==================== Restart of an actor that has children ====================
 //
 // An actor that itself supervises children opens a "drain window" while it waits for those
 // children to close. These tests cover the gap #351 left: messages arriving during that window
-// must still survive a restart (tells), while asks are released with `ActorStopped`.
+// must still survive a restart (tells), while asks are bounced back carrying their message
+// (`ActorRestarting` when it will restart, `ActorNotRunning` on a terminal stop).
 
 struct RootSupervisor;
 
@@ -508,7 +516,7 @@ async fn tells_survive_restart_of_actor_with_children() {
 }
 
 #[tokio::test]
-async fn ask_during_restart_of_actor_with_children_returns_actor_stopped() {
+async fn ask_during_restart_of_actor_with_children_returns_actor_restarting() {
     let root = RootSupervisor::spawn(RootSupervisor);
 
     let (on_start_tx, mut on_start_rx) = mpsc::unbounded_channel();
@@ -534,15 +542,17 @@ async fn ask_during_restart_of_actor_with_children_returns_actor_stopped() {
         .unwrap();
 
     middle.tell(Panic).await.unwrap();
-    // Enqueue an ask then a tell behind the panic, in order. The ask must be released with
-    // `ActorStopped` during the drain window; the tell must survive to the restarted instance.
+    // Enqueue an ask then a tell behind the panic, in order. The ask is bounced back with
+    // `ActorRestarting` carrying its message during the drain window; the tell must survive to
+    // the restarted instance.
     let pending_ask = middle.ask(Msg(99)).enqueue().await.unwrap();
     middle.tell(Msg(0)).await.unwrap();
 
     let ask_result = pending_ask.await;
     assert!(
-        matches!(ask_result, Err(SendError::ActorStopped)),
-        "ask during the restart drain window should return ActorStopped, got: {ask_result:?}"
+        matches!(ask_result, Err(SendError::ActorRestarting(Msg(99)))),
+        "ask during the restart drain window should return ActorRestarting with the original \
+         message, got: {ask_result:?}"
     );
 
     recv_or_fail(&mut on_start_rx, "middle restart startup").await;


### PR DESCRIPTION
Follow-up to #351 for the ask side of issue #335.

When a supervised actor is draining its mailbox during teardown, any pending `ask` used to have its reply sender dropped, so the caller got a bare `ActorStopped` with no way to recover the message. This changes it so the message is always handed back to the caller instead of being silently dropped:

- If the actor is going to restart, the caller gets `SendError::ActorRestarting(msg)`, which is safe to retry against the new incarnation.
- If it's stopping for good, the caller gets `SendError::ActorNotRunning(msg)`.

Either way the original message comes back, so nothing queued is lost. The handler never ran during the drain, so retrying is safe.

### How the restart vs stop decision is made

The tricky part is that the restart decision is normally made by the supervisor *after* the child has fully stopped, so at drain time the actor doesn't strictly know whether it will come back. Since we have to resolve the reply sender during the drain (holding it open is what caused the original deadlock), we make a best-effort guess from the actor's restart policy, its stop reason, and whether its parent is also shutting down (`LinksInner::will_restart`).

This matches the supervisor's real decision in every case except one: if the actor has exhausted its restart limit, we guess `ActorRestarting` when it's actually terminal. That only affects the label, not the message. The caller retries once, gets `ActorNotRunning(msg)`, and stops. No message is dropped in any case.

### Notes

- Breaking: adds a new `SendError::ActorRestarting` variant, and `DynMessage::as_any` now returns `Box<dyn Any + Send>`. Targets 0.22.0.
- Only covers `ask`. A `tell` has no caller to return to, so a fire-and-forget message on an actor that stops for good is still dropped. That's the `on_undelivered` hook, which is a separate follow-up.
