### PR TITLE
feat: add `ctx.pipe` and `ctx.pipe_with` for pipe-to-self

### DIFF
--- a/docs/core-concepts/messages.mdx
+++ b/docs/core-concepts/messages.mdx
@@ -44,20 +44,7 @@ The asynchronous nature of the `handle` function, combined with Rust's powerfu
 
 Because messages are processed one at a time, awaiting a long-running operation directly inside `handle` holds up the actor's mailbox until it finishes. When you want to start async work, such as a network request, but keep processing other messages while it runs, use `ctx.pipe`.
 
-`ctx.pipe` runs a future on a separate task and, once it resolves, applies the result back to the actor between messages. This is the "pipe to self" pattern: the actor stays responsive, and the continuation runs with `&mut self` so it can safely update the actor's state (and may `.await`).
-
-```rust
-ctx.pipe(
-    async { fetch_from_network().await },
-    |actor, _ctx, result| {
-        Box::pin(async move {
-            actor.last_result = result;
-        })
-    },
-);
-```
-
-If the completion should be handled by a message your actor already implements, rather than an inline closure, use `ctx.pipe_message`. It runs the future the same way, then delivers its output back to the actor as a message, so it flows through the normal handler:
+`ctx.pipe` runs a future on a separate task and, once it resolves, delivers its output back to the actor as a message. This is the "pipe to self" pattern: the actor stays responsive, and the result flows through a normal message handler:
 
 ```rust
 struct Fetched(Data);
@@ -71,10 +58,23 @@ impl Message<Fetched> for MyActor {
 }
 
 // In some other handler:
-ctx.pipe_message(async { Fetched(fetch_from_network().await) });
+ctx.pipe(async { Fetched(fetch_from_network().await) });
 ```
 
-In both cases the actor is kept alive until the future resolves. If it has already stopped by then, the continuation or message is simply skipped.
+If the completion is a one-off that doesn't warrant a dedicated message type, use `ctx.pipe_with` instead. It runs the future the same way, but applies the result via an inline continuation that runs with `&mut self` (and may `.await`):
+
+```rust
+ctx.pipe_with(
+    async { fetch_from_network().await },
+    |actor, _ctx, result| {
+        Box::pin(async move {
+            actor.last_result = result;
+        })
+    },
+);
+```
+
+In both cases the actor is kept alive until the future resolves. If it has already stopped by then, the message or continuation is simply skipped.
 
 ---
 

--- a/docs/core-concepts/messages.mdx
+++ b/docs/core-concepts/messages.mdx
@@ -40,6 +40,42 @@ While messages are processed sequentially within a single actor, Kameo allows fo
 
 The asynchronous nature of the `handle` function, combined with Rust's powerful futures and async/await syntax, makes it straightforward to perform non-blocking operations, such as I/O tasks or querying other actors, within a message handler.
 
+## Reacting to Async Work Without Blocking
+
+Because messages are processed one at a time, awaiting a long-running operation directly inside `handle` holds up the actor's mailbox until it finishes. When you want to start async work, such as a network request, but keep processing other messages while it runs, use `ctx.pipe`.
+
+`ctx.pipe` runs a future on a separate task and, once it resolves, applies the result back to the actor between messages. This is the "pipe to self" pattern: the actor stays responsive, and the continuation runs with `&mut self` so it can safely update the actor's state (and may `.await`).
+
+```rust
+ctx.pipe(
+    async { fetch_from_network().await },
+    |actor, _ctx, result| {
+        Box::pin(async move {
+            actor.last_result = result;
+        })
+    },
+);
+```
+
+If the completion should be handled by a message your actor already implements, rather than an inline closure, use `ctx.pipe_message`. It runs the future the same way, then delivers its output back to the actor as a message, so it flows through the normal handler:
+
+```rust
+struct Fetched(Data);
+
+impl Message<Fetched> for MyActor {
+    type Reply = ();
+
+    async fn handle(&mut self, Fetched(data): Fetched, _: &mut Context<Self, Self::Reply>) {
+        self.last_result = data;
+    }
+}
+
+// In some other handler:
+ctx.pipe_message(async { Fetched(fetch_from_network().await) });
+```
+
+In both cases the actor is kept alive until the future resolves. If it has already stopped by then, the continuation or message is simply skipped.
+
 ---
 
 #### Summary

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -16,7 +16,7 @@ use crate::{
     error::{ActorStopReason, PanicError, PanicReason},
     links::{BoxMailboxReceiver, Link, ShutdownFn},
     mailbox::{MailboxReceiver, Signal},
-    message::BoxMessage,
+    message::{BoxMessage, CallbackFn, Context},
     reply::BoxReplySender,
     supervision::SupervisionStrategy,
 };
@@ -196,6 +196,31 @@ where
             Err(err) => ControlFlow::Break(ActorStopReason::Panicked(
                 PanicError::new_from_panic_any(err, PanicReason::HandlerPanic),
             )), // The handler panicked
+        }
+    }
+
+    pub(crate) async fn handle_callback(
+        &mut self,
+        actor_ref: ActorRef<A>,
+        callback: CallbackFn<A>,
+    ) -> ControlFlow<ActorStopReason> {
+        let mut ctx: Context<A, ()> = Context::new(actor_ref, None, false);
+
+        let res = AssertUnwindSafe(callback(&mut self.state, &mut ctx))
+            .catch_unwind()
+            .await;
+
+        match res {
+            Ok(()) => {
+                if ctx.should_stop() {
+                    ControlFlow::Break(ActorStopReason::Normal)
+                } else {
+                    ControlFlow::Continue(())
+                }
+            }
+            Err(err) => ControlFlow::Break(ActorStopReason::Panicked(
+                PanicError::new_from_panic_any(err, PanicReason::HandlerPanic),
+            )), // The continuation panicked
         }
     }
 

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -491,6 +491,15 @@ where
                     return reason;
                 }
             }
+            ControlFlow::Continue(Signal::Callback {
+                actor_ref,
+                callback,
+            }) => {
+                if let ControlFlow::Break(reason) = state.handle_callback(actor_ref, callback).await
+                {
+                    return reason;
+                }
+            }
             ControlFlow::Break(reason) => return reason,
         }
     }

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -208,9 +208,10 @@ impl ActorMonitor {
     pub(crate) fn record_received<A: Actor>(&self, signal: &Signal<A>) {
         let counter = match signal {
             Signal::Message { .. } => &self.messages_received,
-            Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                &self.lifecycle_signals_received
-            }
+            Signal::StartupFinished
+            | Signal::Stop
+            | Signal::SupervisorRestart
+            | Signal::Callback { .. } => &self.lifecycle_signals_received,
             Signal::LinkDied { .. } => &self.link_died_signals_received,
         };
         counter.fetch_add(1, Ordering::Relaxed);

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -935,10 +935,10 @@ pub enum Signal<A: Actor> {
     Stop,
     /// Signals the actor to restart.
     SupervisorRestart,
-    /// A continuation to run against the actor's state, produced by a resolved [`Context::pipe`]
-    /// future.
+    /// A continuation to run against the actor's state, produced by a resolved
+    /// [`Context::pipe_with`] future.
     ///
-    /// [`Context::pipe`]: crate::message::Context::pipe
+    /// [`Context::pipe_with`]: crate::message::Context::pipe_with
     Callback {
         /// The actor ref, to keep the actor from stopping due to RAII semantics.
         actor_ref: ActorRef<A>,

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -132,9 +132,10 @@ impl<A: Actor> From<&Signal<A>> for SignalKind {
     fn from(signal: &Signal<A>) -> Self {
         match signal {
             Signal::Message { .. } => SignalKind::Message,
-            Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                SignalKind::Lifecycle
-            }
+            Signal::StartupFinished
+            | Signal::Stop
+            | Signal::SupervisorRestart
+            | Signal::Callback { .. } => SignalKind::Lifecycle,
             Signal::LinkDied { .. } => SignalKind::LinkDied,
         }
     }
@@ -584,9 +585,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &signal {
             Some(Signal::Message { .. }) => self.messages_received.increment(1),
-            Some(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Some(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Some(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             None => {}
         }
@@ -616,9 +620,10 @@ impl<A: Actor> MailboxReceiver<A> {
             for signal in &buffer[len - 1 - count..len - 1] {
                 match signal {
                     Signal::Message { .. } => self.messages_received.increment(1),
-                    Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                        self.lifecycle_signals_received.increment(1)
-                    }
+                    Signal::StartupFinished
+                    | Signal::Stop
+                    | Signal::SupervisorRestart
+                    | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                     Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                 }
             }
@@ -646,9 +651,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &res {
             Ok(Signal::Message { .. }) => self.messages_received.increment(1),
-            Ok(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Ok(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Ok(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             Err(_) => {}
         }
@@ -675,9 +683,12 @@ impl<A: Actor> MailboxReceiver<A> {
         #[cfg(feature = "metrics")]
         match &signal {
             Some(Signal::Message { .. }) => self.messages_received.increment(1),
-            Some(Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart) => {
-                self.lifecycle_signals_received.increment(1)
-            }
+            Some(
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
+            ) => self.lifecycle_signals_received.increment(1),
             Some(Signal::LinkDied { .. }) => self.link_died_signals_received.increment(1),
             None => {}
         }
@@ -707,9 +718,10 @@ impl<A: Actor> MailboxReceiver<A> {
             for signal in &buffer[len - 1 - count..len - 1] {
                 match signal {
                     Signal::Message { .. } => self.messages_received.increment(1),
-                    Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                        self.lifecycle_signals_received.increment(1)
-                    }
+                    Signal::StartupFinished
+                    | Signal::Stop
+                    | Signal::SupervisorRestart
+                    | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                     Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                 }
             }
@@ -795,7 +807,10 @@ impl<A: Actor> MailboxReceiver<A> {
         match &poll {
             Poll::Ready(Some(Signal::Message { .. })) => self.messages_received.increment(1),
             Poll::Ready(Some(
-                Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart,
+                Signal::StartupFinished
+                | Signal::Stop
+                | Signal::SupervisorRestart
+                | Signal::Callback { .. },
             )) => self.lifecycle_signals_received.increment(1),
             Poll::Ready(Some(Signal::LinkDied { .. })) => {
                 self.link_died_signals_received.increment(1)
@@ -834,9 +849,10 @@ impl<A: Actor> MailboxReceiver<A> {
                 for signal in &buffer[len - 1 - count..len - 1] {
                     match signal {
                         Signal::Message { .. } => self.messages_received.increment(1),
-                        Signal::StartupFinished | Signal::Stop | Signal::SupervisorRestart => {
-                            self.lifecycle_signals_received.increment(1)
-                        }
+                        Signal::StartupFinished
+                        | Signal::Stop
+                        | Signal::SupervisorRestart
+                        | Signal::Callback { .. } => self.lifecycle_signals_received.increment(1),
                         Signal::LinkDied { .. } => self.link_died_signals_received.increment(1),
                     }
                 }
@@ -919,6 +935,16 @@ pub enum Signal<A: Actor> {
     Stop,
     /// Signals the actor to restart.
     SupervisorRestart,
+    /// A continuation to run against the actor's state, produced by a resolved [`Context::pipe`]
+    /// future.
+    ///
+    /// [`Context::pipe`]: crate::message::Context::pipe
+    Callback {
+        /// The actor ref, to keep the actor from stopping due to RAII semantics.
+        actor_ref: ActorRef<A>,
+        /// The continuation to run against the actor's state.
+        callback: crate::message::CallbackFn<A>,
+    },
 }
 
 impl<A: Actor> Signal<A> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -22,11 +22,19 @@ use crate::{
     Actor,
     actor::ActorRef,
     error::{self, PanicError, PanicReason, SendError},
+    mailbox::Signal,
     reply::{BoxReplySender, DelegatedReply, ForwardedReply, Reply, ReplyError, ReplySender},
 };
 
 /// A boxed dynamic message type for the actor `A`.
 pub type BoxMessage<A> = Box<dyn DynMessage<A>>;
+
+/// A boxed continuation run against an actor's state when a [`Context::pipe`] future resolves.
+///
+/// The continuation returns a future that borrows `&mut A`, so it is boxed behind a `for<'a>`
+/// bound rather than a plain `FnOnce`.
+pub(crate) type CallbackFn<A> =
+    Box<dyn for<'a> FnOnce(&'a mut A, &'a mut Context<A, ()>) -> BoxFuture<'a, ()> + Send>;
 
 /// A boxed dynamic type used for message replies.
 pub type BoxReply = Box<dyn any::Any + Send>;
@@ -111,6 +119,11 @@ where
     /// Stops the actor normally after processing the current message.
     pub fn stop(&mut self) {
         self.stop = true;
+    }
+
+    /// Whether [`Context::stop`] was called on this context.
+    pub(crate) fn should_stop(&self) -> bool {
+        self.stop
     }
 
     /// Extracts the reply sender, providing a mechanism for delegated responses and an optional reply sender.
@@ -249,6 +262,67 @@ where
         });
 
         delegated_reply
+    }
+
+    /// Runs a future off the actor's message loop, then applies its result back to the actor.
+    ///
+    /// This is the "pipe to self" pattern: `future` runs on a separate task so the actor keeps
+    /// processing other messages while it is in flight. When `future` resolves, `on_complete`
+    /// runs with `&mut self` (and its own [`Context`]) between messages, so it can mutate the
+    /// actor's state, and it may `.await`.
+    ///
+    /// The actor is kept alive until `future` resolves. If the actor has stopped or is
+    /// restarting by the time it resolves, `on_complete` is not run. The future itself is not
+    /// cancelled when the actor stops.
+    ///
+    /// Because `on_complete` returns a future that borrows `&mut self`, it is written as a
+    /// closure returning a boxed future (`Box::pin(async move { .. })`).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    ///
+    /// #[derive(Actor, Default)]
+    /// struct MyActor {
+    ///     last: u32,
+    /// }
+    ///
+    /// struct Fetch;
+    ///
+    /// impl Message<Fetch> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
+    ///         ctx.pipe(async { 40 + 2 }, |actor, _ctx, result| {
+    ///             Box::pin(async move {
+    ///                 actor.last = result;
+    ///             })
+    ///         });
+    ///     }
+    /// }
+    /// ```
+    pub fn pipe<F, Fun>(&self, future: F, on_complete: Fun)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+        Fun: for<'a> FnOnce(&'a mut A, &'a mut Context<A, ()>, F::Output) -> BoxFuture<'a, ()>
+            + Send
+            + 'static,
+    {
+        let actor_ref = self.actor_ref.clone();
+        tokio::spawn(async move {
+            let output = future.await;
+            let callback: CallbackFn<A> =
+                Box::new(move |actor, ctx| on_complete(actor, ctx, output));
+            // The signal carries a strong `ActorRef` so the actor stays alive until the
+            // callback is processed, even after this task drops its own ref.
+            let signal = Signal::Callback {
+                actor_ref: actor_ref.clone(),
+                callback,
+            };
+            let _ = actor_ref.mailbox_sender().send(signal).await;
+        });
     }
 
     /// Forwards the message to another actor, returning a [ForwardedReply].

--- a/src/message.rs
+++ b/src/message.rs
@@ -325,6 +325,66 @@ where
         });
     }
 
+    /// Runs a future off the actor's message loop, then sends its result back to the actor as a
+    /// message.
+    ///
+    /// This is the "pipe to self" pattern for cases where the completion should be handled by an
+    /// existing [`Message`] handler rather than an inline closure. `future` runs on a separate
+    /// task so the actor keeps processing other messages while it is in flight. When `future`
+    /// resolves, its output is delivered to the actor with [`tell`] semantics, so it runs through
+    /// the normal message pipeline (handler, ordering, tracing) and its reply is discarded.
+    ///
+    /// Use [`pipe`] instead when the completion logic is a one-off that should mutate the actor's
+    /// state inline.
+    ///
+    /// The actor is kept alive until `future` resolves. If the actor has stopped by the time it
+    /// resolves, the message is dropped. The future itself is not cancelled when the actor stops.
+    ///
+    /// [`tell`]: crate::actor::ActorRef::tell
+    /// [`pipe`]: Context::pipe
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    ///
+    /// #[derive(Actor, Default)]
+    /// struct MyActor {
+    ///     last: u32,
+    /// }
+    ///
+    /// struct Fetch;
+    /// struct Fetched(u32);
+    ///
+    /// impl Message<Fetch> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
+    ///         ctx.pipe_message(async { Fetched(40 + 2) });
+    ///     }
+    /// }
+    ///
+    /// impl Message<Fetched> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
+    ///         self.last = value;
+    ///     }
+    /// }
+    /// ```
+    pub fn pipe_message<F, M>(&self, future: F)
+    where
+        A: Message<M>,
+        F: Future<Output = M> + Send + 'static,
+        M: Send + 'static,
+    {
+        let actor_ref = self.actor_ref.clone();
+        tokio::spawn(async move {
+            let msg = future.await;
+            let _ = actor_ref.tell(msg).send().await;
+        });
+    }
+
     /// Forwards the message to another actor, returning a [ForwardedReply].
     pub async fn forward<B, M>(
         &mut self,

--- a/src/message.rs
+++ b/src/message.rs
@@ -29,7 +29,7 @@ use crate::{
 /// A boxed dynamic message type for the actor `A`.
 pub type BoxMessage<A> = Box<dyn DynMessage<A>>;
 
-/// A boxed continuation run against an actor's state when a [`Context::pipe`] future resolves.
+/// A boxed continuation run against an actor's state when a [`Context::pipe_with`] future resolves.
 ///
 /// The continuation returns a future that borrows `&mut A`, so it is boxed behind a `for<'a>`
 /// bound rather than a plain `FnOnce`.
@@ -264,12 +264,72 @@ where
         delegated_reply
     }
 
-    /// Runs a future off the actor's message loop, then applies its result back to the actor.
+    /// Runs a future off the actor's message loop, then sends its result back to the actor as a
+    /// message.
     ///
     /// This is the "pipe to self" pattern: `future` runs on a separate task so the actor keeps
-    /// processing other messages while it is in flight. When `future` resolves, `on_complete`
-    /// runs with `&mut self` (and its own [`Context`]) between messages, so it can mutate the
-    /// actor's state, and it may `.await`.
+    /// processing other messages while it is in flight. When `future` resolves, its output is
+    /// delivered to the actor with [`tell`] semantics, so it runs through the normal message
+    /// pipeline (handler, ordering, tracing) and its reply is discarded.
+    ///
+    /// Use [`pipe_with`] instead when the completion logic is a one-off that should mutate the
+    /// actor's state inline rather than go through a dedicated [`Message`] handler.
+    ///
+    /// The actor is kept alive until `future` resolves. If the actor has stopped by the time it
+    /// resolves, the message is dropped. The future itself is not cancelled when the actor stops.
+    ///
+    /// [`tell`]: crate::actor::ActorRef::tell
+    /// [`pipe_with`]: Context::pipe_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    ///
+    /// #[derive(Actor, Default)]
+    /// struct MyActor {
+    ///     last: u32,
+    /// }
+    ///
+    /// struct Fetch;
+    /// struct Fetched(u32);
+    ///
+    /// impl Message<Fetch> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
+    ///         ctx.pipe(async { Fetched(40 + 2) });
+    ///     }
+    /// }
+    ///
+    /// impl Message<Fetched> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
+    ///         self.last = value;
+    ///     }
+    /// }
+    /// ```
+    pub fn pipe<F, M>(&self, future: F)
+    where
+        A: Message<M>,
+        F: Future<Output = M> + Send + 'static,
+        M: Send + 'static,
+    {
+        let actor_ref = self.actor_ref.clone();
+        tokio::spawn(async move {
+            let msg = future.await;
+            let _ = actor_ref.tell(msg).send().await;
+        });
+    }
+
+    /// Runs a future off the actor's message loop, then applies its result back to the actor with
+    /// a custom continuation.
+    ///
+    /// Like [`pipe`], but instead of delivering the result as a message, `on_complete` runs with
+    /// `&mut self` (and its own [`Context`]) between messages, so it can mutate the actor's state
+    /// directly, and it may `.await`. Prefer [`pipe`] when the completion should go through an
+    /// existing [`Message`] handler.
     ///
     /// The actor is kept alive until `future` resolves. If the actor has stopped or is
     /// restarting by the time it resolves, `on_complete` is not run. The future itself is not
@@ -277,6 +337,8 @@ where
     ///
     /// Because `on_complete` returns a future that borrows `&mut self`, it is written as a
     /// closure returning a boxed future (`Box::pin(async move { .. })`).
+    ///
+    /// [`pipe`]: Context::pipe
     ///
     /// # Example
     ///
@@ -294,7 +356,7 @@ where
     ///     type Reply = ();
     ///
     ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
-    ///         ctx.pipe(async { 40 + 2 }, |actor, _ctx, result| {
+    ///         ctx.pipe_with(async { 40 + 2 }, |actor, _ctx, result| {
     ///             Box::pin(async move {
     ///                 actor.last = result;
     ///             })
@@ -302,7 +364,7 @@ where
     ///     }
     /// }
     /// ```
-    pub fn pipe<F, Fun>(&self, future: F, on_complete: Fun)
+    pub fn pipe_with<F, Fun>(&self, future: F, on_complete: Fun)
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
@@ -322,66 +384,6 @@ where
                 callback,
             };
             let _ = actor_ref.mailbox_sender().send(signal).await;
-        });
-    }
-
-    /// Runs a future off the actor's message loop, then sends its result back to the actor as a
-    /// message.
-    ///
-    /// This is the "pipe to self" pattern for cases where the completion should be handled by an
-    /// existing [`Message`] handler rather than an inline closure. `future` runs on a separate
-    /// task so the actor keeps processing other messages while it is in flight. When `future`
-    /// resolves, its output is delivered to the actor with [`tell`] semantics, so it runs through
-    /// the normal message pipeline (handler, ordering, tracing) and its reply is discarded.
-    ///
-    /// Use [`pipe`] instead when the completion logic is a one-off that should mutate the actor's
-    /// state inline.
-    ///
-    /// The actor is kept alive until `future` resolves. If the actor has stopped by the time it
-    /// resolves, the message is dropped. The future itself is not cancelled when the actor stops.
-    ///
-    /// [`tell`]: crate::actor::ActorRef::tell
-    /// [`pipe`]: Context::pipe
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use kameo::prelude::*;
-    ///
-    /// #[derive(Actor, Default)]
-    /// struct MyActor {
-    ///     last: u32,
-    /// }
-    ///
-    /// struct Fetch;
-    /// struct Fetched(u32);
-    ///
-    /// impl Message<Fetch> for MyActor {
-    ///     type Reply = ();
-    ///
-    ///     async fn handle(&mut self, _: Fetch, ctx: &mut Context<Self, Self::Reply>) {
-    ///         ctx.pipe_message(async { Fetched(40 + 2) });
-    ///     }
-    /// }
-    ///
-    /// impl Message<Fetched> for MyActor {
-    ///     type Reply = ();
-    ///
-    ///     async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
-    ///         self.last = value;
-    ///     }
-    /// }
-    /// ```
-    pub fn pipe_message<F, M>(&self, future: F)
-    where
-        A: Message<M>,
-        F: Future<Output = M> + Send + 'static,
-        M: Send + 'static,
-    {
-        let actor_ref = self.actor_ref.clone();
-        tokio::spawn(async move {
-            let msg = future.await;
-            let _ = actor_ref.tell(msg).send().await;
         });
     }
 

--- a/tests/context_pipe.rs
+++ b/tests/context_pipe.rs
@@ -27,7 +27,7 @@ impl Message<Trigger> for PipeActor {
     type Reply = ();
 
     async fn handle(&mut self, _: Trigger, ctx: &mut Context<Self, Self::Reply>) {
-        ctx.pipe(async { 40 + 2 }, |actor, _ctx, out| {
+        ctx.pipe_with(async { 40 + 2 }, |actor, _ctx, out| {
             Box::pin(async move {
                 actor.value = out;
                 actor.done_tx.send(actor.value).unwrap();
@@ -43,7 +43,7 @@ impl Message<TriggerDelayed> for PipeActor {
     type Reply = ();
 
     async fn handle(&mut self, _: TriggerDelayed, ctx: &mut Context<Self, Self::Reply>) {
-        ctx.pipe(
+        ctx.pipe_with(
             async {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 42
@@ -66,7 +66,7 @@ impl Message<TriggerStop> for PipeActor {
     type Reply = ();
 
     async fn handle(&mut self, _: TriggerStop, ctx: &mut Context<Self, Self::Reply>) {
-        ctx.pipe(async { 7 }, |actor, ctx, out| {
+        ctx.pipe_with(async { 7 }, |actor, ctx, out| {
             Box::pin(async move {
                 actor.value = out;
                 actor.done_tx.send(actor.value).unwrap();
@@ -83,7 +83,7 @@ impl Message<TriggerMessage> for PipeActor {
     type Reply = ();
 
     async fn handle(&mut self, _: TriggerMessage, ctx: &mut Context<Self, Self::Reply>) {
-        ctx.pipe_message(async { Fetched(99) });
+        ctx.pipe(async { Fetched(99) });
     }
 }
 
@@ -116,7 +116,7 @@ async fn recv(rx: &mut mpsc::UnboundedReceiver<u32>) -> u32 {
 }
 
 #[tokio::test]
-async fn pipe_applies_result_to_state() {
+async fn pipe_with_applies_result_to_state() {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
     let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
 
@@ -127,7 +127,7 @@ async fn pipe_applies_result_to_state() {
 }
 
 #[tokio::test]
-async fn pipe_continuation_may_await() {
+async fn pipe_with_continuation_may_await() {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
     let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
 
@@ -138,7 +138,7 @@ async fn pipe_continuation_may_await() {
 }
 
 #[tokio::test]
-async fn pipe_continuation_can_stop_actor() {
+async fn pipe_with_continuation_can_stop_actor() {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
     let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
 
@@ -152,7 +152,7 @@ async fn pipe_continuation_can_stop_actor() {
 }
 
 #[tokio::test]
-async fn pipe_message_delivers_to_handler() {
+async fn pipe_delivers_result_as_message() {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
     let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
 
@@ -163,7 +163,7 @@ async fn pipe_message_delivers_to_handler() {
 }
 
 #[tokio::test]
-async fn pipe_keeps_actor_alive_until_future_resolves() {
+async fn pipe_with_keeps_actor_alive_until_future_resolves() {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
     let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
 

--- a/tests/context_pipe.rs
+++ b/tests/context_pipe.rs
@@ -1,0 +1,143 @@
+use std::time::Duration;
+
+use kameo::error::Infallible;
+use kameo::prelude::*;
+use tokio::sync::mpsc;
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct PipeActor {
+    value: u32,
+    done_tx: mpsc::UnboundedSender<u32>,
+}
+
+impl Actor for PipeActor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+// Applies a piped future's result to the actor's state.
+struct Trigger;
+
+impl Message<Trigger> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Trigger, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe(async { 40 + 2 }, |actor, _ctx, out| {
+            Box::pin(async move {
+                actor.value = out;
+                actor.done_tx.send(actor.value).unwrap();
+            })
+        });
+    }
+}
+
+// The piped future and the continuation both await; the continuation still holds `&mut self`.
+struct TriggerDelayed;
+
+impl Message<TriggerDelayed> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerDelayed, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe(
+            async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                42
+            },
+            |actor, _ctx, out| {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    actor.value = out;
+                    actor.done_tx.send(actor.value).unwrap();
+                })
+            },
+        );
+    }
+}
+
+// The continuation stops the actor via `ctx.stop()`.
+struct TriggerStop;
+
+impl Message<TriggerStop> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerStop, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe(async { 7 }, |actor, ctx, out| {
+            Box::pin(async move {
+                actor.value = out;
+                actor.done_tx.send(actor.value).unwrap();
+                ctx.stop();
+            })
+        });
+    }
+}
+
+struct GetValue;
+
+impl Message<GetValue> for PipeActor {
+    type Reply = u32;
+
+    async fn handle(&mut self, _: GetValue, _: &mut Context<Self, Self::Reply>) -> u32 {
+        self.value
+    }
+}
+
+async fn recv(rx: &mut mpsc::UnboundedReceiver<u32>) -> u32 {
+    tokio::time::timeout(RECV_TIMEOUT, rx.recv())
+        .await
+        .expect("timed out waiting for pipe continuation")
+        .expect("channel closed before pipe continuation ran")
+}
+
+#[tokio::test]
+async fn pipe_applies_result_to_state() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(Trigger).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn pipe_continuation_may_await() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerDelayed).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn pipe_continuation_can_stop_actor() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerStop).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 7);
+    tokio::time::timeout(RECV_TIMEOUT, actor.wait_for_shutdown())
+        .await
+        .expect("actor did not stop after continuation called ctx.stop()");
+    assert!(!actor.is_alive());
+}
+
+#[tokio::test]
+async fn pipe_keeps_actor_alive_until_future_resolves() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerDelayed).await.unwrap();
+    // Drop the only external ref. The pipe task holds a strong ref, so the actor must stay
+    // alive long enough for the continuation to run.
+    drop(actor);
+
+    assert_eq!(recv(&mut done_rx).await, 42);
+}

--- a/tests/context_pipe.rs
+++ b/tests/context_pipe.rs
@@ -76,6 +76,28 @@ impl Message<TriggerStop> for PipeActor {
     }
 }
 
+// Pipes a future whose output is delivered back as a message the actor already handles.
+struct TriggerMessage;
+
+impl Message<TriggerMessage> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerMessage, ctx: &mut Context<Self, Self::Reply>) {
+        ctx.pipe_message(async { Fetched(99) });
+    }
+}
+
+struct Fetched(u32);
+
+impl Message<Fetched> for PipeActor {
+    type Reply = ();
+
+    async fn handle(&mut self, Fetched(value): Fetched, _: &mut Context<Self, Self::Reply>) {
+        self.value = value;
+        self.done_tx.send(self.value).unwrap();
+    }
+}
+
 struct GetValue;
 
 impl Message<GetValue> for PipeActor {
@@ -127,6 +149,17 @@ async fn pipe_continuation_can_stop_actor() {
         .await
         .expect("actor did not stop after continuation called ctx.stop()");
     assert!(!actor.is_alive());
+}
+
+#[tokio::test]
+async fn pipe_message_delivers_to_handler() {
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let actor = PipeActor::spawn(PipeActor { value: 0, done_tx });
+
+    actor.tell(TriggerMessage).await.unwrap();
+
+    assert_eq!(recv(&mut done_rx).await, 99);
+    assert_eq!(actor.ask(GetValue).await.unwrap(), 99);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Adds a first-class "pipe to self" API so an actor can kick off async work (e.g. a network request), keep processing other messages while it runs, and react to the result when it resolves. Today this requires manually spawning a task and telling yourself a message, with no lifecycle relationship to the actor.

Two methods on `Context`:

- `ctx.pipe(future)` runs `future` off the actor loop and delivers its output back to the actor as a message, so the result flows through a normal `Message<M>` handler (canonical pipe-to-self, mirrors Akka's `pipeToSelf`).
- `ctx.pipe_with(future, on_complete)` runs `future` the same way, but applies the result via an inline continuation that runs with `&mut self` and may `.await`. Use this when the completion is a one-off that doesn't warrant a dedicated message type.

### How it works

- `pipe` is a thin wrapper over `tell`, so it reuses the full message pipeline (handler, ordering, tracing) and the strong `ActorRef` keep-alive for free.
- `pipe_with` completions re-enter through the existing mailbox as a new internal `Signal::Callback` carrying a boxed continuation, rather than adding a second poll source to the core `select!` loop. This keeps the hot loop single-source and orders completions like any other message.
- Both are lifecycle-safe: the actor is kept alive until the future resolves (the task holds a strong `ActorRef`). If the actor has stopped by then, the message or continuation is simply skipped.
- A panic in a `pipe_with` continuation drives supervision exactly like a handler panic.

### Not covered

Cancel-on-restart for the in-flight future is out of scope for now (documented limitation).

### Tests

Integration tests in `tests/context_pipe.rs` cover: result delivered as a message, continuation mutating state, continuation awaiting, continuation stopping the actor via `ctx.stop()`, and the strong-ref keep-alive. Docs book updated in `docs/core-concepts/messages.mdx`.
