### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0](https://github.com/tqwewe/kameo/compare/v0.21.1...v0.22.0) - 2026-07-05
+
+### <!-- 0 -->Added
+
+- Add on_undelivered hook for messages left in the mailbox at terminal stop ([#363](https://github.com/tqwewe/kameo/pull/363)) [</>](https://github.com/tqwewe/kameo/commit/c1c14b95f0efe41c532345438802c19cc9d8d19c)
+- Reject new messages after stop_gracefully instead of silently dropping them ([#362](https://github.com/tqwewe/kameo/pull/362)) [</>](https://github.com/tqwewe/kameo/commit/e8a0bce041af295eb3c013be08b5282fda4d9b7b)
+- **BREAKING:** Add `ctx.pipe` and `ctx.pipe_with` for pipe-to-self ([#360](https://github.com/tqwewe/kameo/pull/360)) [</>](https://github.com/tqwewe/kameo/commit/4d897f2c5418fd0b297bd3fbfe49f174c382b3d1)
+
+### <!-- 1 -->Changed
+
+- **BREAKING:** Make `ActorRef` cloning a single `Arc` clone ([#365](https://github.com/tqwewe/kameo/pull/365)) [</>](https://github.com/tqwewe/kameo/commit/39018860114723a86c705b37c62ae3d3c0511426)
+- **BREAKING:** Return pending ask's message as ActorRestarting/ActorNotRunning during drain ([#359](https://github.com/tqwewe/kameo/pull/359)) [</>](https://github.com/tqwewe/kameo/commit/4e0594abbb550ccb679e9c696d2393a4907184fb)
+
+### <!-- 3 -->Fixed
+
+- Deliver leftover tells to on_undelivered when the restart budget is exhausted ([#364](https://github.com/tqwewe/kameo/pull/364)) [</>](https://github.com/tqwewe/kameo/commit/77feb7a5e5c1ab2cfde9ab20242af5c0ea71d0c3)
+
+### <!-- 4 -->Documentation
+
+- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
+
+
 ## [0.21.1](https://github.com/tqwewe/kameo/compare/v0.21.0...v0.21.1) - 2026-07-01
 
 ### <!-- 0 -->Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "actors", "console", "macros"]
 
 [workspace.dependencies]
-kameo = { path = ".", version = "0.21.1" }
+kameo = { path = ".", version = "0.22.0" }
 
 futures = "0.3"
 tokio = "1.47"
@@ -18,7 +18,7 @@ all-features = true
 
 [package]
 name = "kameo"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Fault-tolerant Async Actors Built on Tokio"
@@ -47,7 +47,7 @@ metrics = ["dep:metrics"]
 hotpath = ["dep:hotpath", "hotpath/hotpath"]
 
 [dependencies]
-kameo_macros = { version = "0.21.0", path = "./macros", optional = true }
+kameo_macros = { version = "0.21.1", path = "./macros", optional = true }
 
 const-fnv1a-hash = { version = "1.1.0", optional = true }
 const-str = { version = "1.1", features = ["proc"], optional = true }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add Kameo as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-kameo = "0.21"
+kameo = "0.22"
 ```
 
 Alternatively, you can add it via command line:
@@ -134,7 +134,7 @@ Kameo ships a terminal UI, the **kameo console**, for monitoring a running actor
 Enable the `console` feature and start the collector once in `main`:
 
 ```toml
-kameo = { version = "0.21", features = ["console"] }
+kameo = { version = "0.22", features = ["console"] }
 ```
 
 ```rust,ignore

--- a/actors/CHANGELOG.md
+++ b/actors/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0](https://github.com/tqwewe/kameo/compare/actors-v0.6.1...actors-v0.7.0) - 2026-07-05
+
+### <!-- 1 -->Changed
+
+- **BREAKING:** Return pending ask's message as ActorRestarting/ActorNotRunning during drain ([#359](https://github.com/tqwewe/kameo/pull/359)) [</>](https://github.com/tqwewe/kameo/commit/4e0594abbb550ccb679e9c696d2393a4907184fb)
+
+### <!-- 4 -->Documentation
+
+- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
+
+
 ## [0.6.1](https://github.com/tqwewe/kameo/compare/actors-v0.6.0...actors-v0.6.1) - 2026-07-01
 
 ### <!-- 3 -->Fixed

--- a/actors/Cargo.toml
+++ b/actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_actors"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Utility actors for kameo"

--- a/console/CHANGELOG.md
+++ b/console/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2](https://github.com/tqwewe/kameo/compare/console-v0.1.1...console-v0.1.2) - 2026-07-05
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.1.1](https://github.com/tqwewe/kameo/compare/console-v0.1.0...console-v0.1.1) - 2026-07-01
 
 ### <!-- 5 -->Misc

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_console"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal UI for monitoring a running kameo actor system"

--- a/console/README.md
+++ b/console/README.md
@@ -24,7 +24,7 @@ Add the feature:
 
 ```toml
 [dependencies]
-kameo = { version = "0.21", features = ["console"] }
+kameo = { version = "0.22", features = ["console"] }
 ```
 
 Start the collector once, early in `main`:

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -12,7 +12,7 @@ With Rust installed, you can add Kameo to your project by editing your `Cargo.t
 
 ```toml
 [dependencies]
-kameo = "0.21"
+kameo = "0.22"
 ```
 
 Alternatively you can run `cargo add kameo`.

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.21.1](https://github.com/tqwewe/kameo/compare/macros-v0.21.0...macros-v0.21.1) - 2026-07-05
+
+### <!-- 4 -->Documentation
+
+- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
+

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_macros"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Fault-tolerant Async Actors Built on Tokio macros"


### PR DESCRIPTION



## 🤖 New release

* `kameo_macros`: 0.21.0 -> 0.21.1
* `kameo`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `kameo_actors`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `kameo_console`: 0.1.1 -> 0.1.2

### ⚠ `kameo` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant PanicReason::Next 6 -> 7 in /tmp/.tmpHI6dhD/kameo/src/error.rs:714
  variant PanicReason::Next 6 -> 7 in /tmp/.tmpHI6dhD/kameo/src/error.rs:714

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Signal:Callback in /tmp/.tmpHI6dhD/kameo/src/mailbox.rs:989
  variant Signal:Callback in /tmp/.tmpHI6dhD/kameo/src/mailbox.rs:989
  variant SendError:ActorRestarting in /tmp/.tmpHI6dhD/kameo/src/error.rs:96
  variant SendError:ActorRestarting in /tmp/.tmpHI6dhD/kameo/src/error.rs:96
  variant PanicReason:OnUndelivered in /tmp/.tmpHI6dhD/kameo/src/error.rs:712
  variant PanicReason:OnUndelivered in /tmp/.tmpHI6dhD/kameo/src/error.rs:712

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  PanicReason::Next moved from position 7 to 8, in /tmp/.tmpHI6dhD/kameo/src/error.rs:714
  PanicReason::Next moved from position 7 to 8, in /tmp/.tmpHI6dhD/kameo/src/error.rs:714
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kameo_macros`

<blockquote>

## [0.21.1](https://github.com/tqwewe/kameo/compare/macros-v0.21.0...macros-v0.21.1) - 2026-07-05

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo`

<blockquote>

## [0.22.0](https://github.com/tqwewe/kameo/compare/v0.21.1...v0.22.0) - 2026-07-05

### <!-- 0 -->Added

- Add on_undelivered hook for messages left in the mailbox at terminal stop ([#363](https://github.com/tqwewe/kameo/pull/363)) [</>](https://github.com/tqwewe/kameo/commit/c1c14b95f0efe41c532345438802c19cc9d8d19c)
- Reject new messages after stop_gracefully instead of silently dropping them ([#362](https://github.com/tqwewe/kameo/pull/362)) [</>](https://github.com/tqwewe/kameo/commit/e8a0bce041af295eb3c013be08b5282fda4d9b7b)
- **BREAKING:** Add `ctx.pipe` and `ctx.pipe_with` for pipe-to-self ([#360](https://github.com/tqwewe/kameo/pull/360)) [</>](https://github.com/tqwewe/kameo/commit/4d897f2c5418fd0b297bd3fbfe49f174c382b3d1)

### <!-- 1 -->Changed

- **BREAKING:** Make `ActorRef` cloning a single `Arc` clone ([#365](https://github.com/tqwewe/kameo/pull/365)) [</>](https://github.com/tqwewe/kameo/commit/39018860114723a86c705b37c62ae3d3c0511426)
- **BREAKING:** Return pending ask's message as ActorRestarting/ActorNotRunning during drain ([#359](https://github.com/tqwewe/kameo/pull/359)) [</>](https://github.com/tqwewe/kameo/commit/4e0594abbb550ccb679e9c696d2393a4907184fb)

### <!-- 3 -->Fixed

- Deliver leftover tells to on_undelivered when the restart budget is exhausted ([#364](https://github.com/tqwewe/kameo/pull/364)) [</>](https://github.com/tqwewe/kameo/commit/77feb7a5e5c1ab2cfde9ab20242af5c0ea71d0c3)

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo_actors`

<blockquote>

## [0.7.0](https://github.com/tqwewe/kameo/compare/actors-v0.6.1...actors-v0.7.0) - 2026-07-05

### <!-- 1 -->Changed

- **BREAKING:** Return pending ask's message as ActorRestarting/ActorNotRunning during drain ([#359](https://github.com/tqwewe/kameo/pull/359)) [</>](https://github.com/tqwewe/kameo/commit/4e0594abbb550ccb679e9c696d2393a4907184fb)

### <!-- 4 -->Documentation

- Fix spacing between sponsor avatars in README [</>](https://github.com/tqwewe/kameo/commit/c75376967806c8c22fb4f6e3b559b08e798167b4)
</blockquote>

## `kameo_console`

<blockquote>

## [0.1.2](https://github.com/tqwewe/kameo/compare/console-v0.1.1...console-v0.1.2) - 2026-07-05

### <!-- 5 -->Misc

- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).