### PR TITLE
feat: reject new messages after stop_gracefully instead of dropping them

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -98,9 +98,13 @@ where
     }
 
     /// Returns whether the actor is currently alive.
+    ///
+    /// Returns `false` once [`stop_gracefully`](Self::stop_gracefully) has been called, even while
+    /// the actor is still draining already-queued messages. Use
+    /// [`wait_for_shutdown`](Self::wait_for_shutdown) to wait for the actor to fully stop.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        !self.mailbox_sender.is_closed()
+        !self.mailbox_sender.is_closed() && self.mailbox_sender.is_accepting()
     }
 
     /// Registers the actor under a given name in the actor registry.
@@ -262,6 +266,9 @@ where
     /// before it shuts down. Any new messages sent after the stop signal will be ignored.
     #[inline]
     pub async fn stop_gracefully(&self) -> Result<(), SendError> {
+        // Reject new user messages before enqueuing the stop signal, so anything sent after this
+        // point fails loudly with `ActorNotRunning` instead of being silently queued then dropped.
+        self.mailbox_sender.stop_accepting();
         self.mailbox_sender
             .send(Signal::Stop)
             .await

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -6,6 +6,10 @@ use std::{
     any::Any,
     collections::{HashMap, VecDeque},
     fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     task::{Context, Poll},
     time::Duration,
 };
@@ -35,6 +39,7 @@ pub fn bounded<A: Actor>(buffer: usize) -> (MailboxSender<A>, MailboxReceiver<A>
     (
         MailboxSender {
             inner: MailboxSenderInner::Bounded(tx),
+            accepting: Arc::new(AtomicBool::new(true)),
             #[cfg(feature = "metrics")]
             messages_sent: metrics::counter!("kameo_messages_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
@@ -67,6 +72,7 @@ pub fn unbounded<A: Actor>() -> (MailboxSender<A>, MailboxReceiver<A>) {
     (
         MailboxSender {
             inner: MailboxSenderInner::Unbounded(tx),
+            accepting: Arc::new(AtomicBool::new(true)),
             #[cfg(feature = "metrics")]
             messages_sent: metrics::counter!("kameo_messages_sent", "actor_name" => A::name()),
             #[cfg(feature = "metrics")]
@@ -92,6 +98,10 @@ pub fn unbounded<A: Actor>() -> (MailboxSender<A>, MailboxReceiver<A>) {
 /// Instances are created by the [`bounded`] and [`unbounded`] functions.
 pub struct MailboxSender<A: Actor> {
     inner: MailboxSenderInner<A>,
+    /// Whether the mailbox still accepts user messages. Flipped to `false` by
+    /// [`ActorRef::stop_gracefully`], after which [`Signal::Message`] sends are rejected while
+    /// lifecycle signals still pass. Shared across all sender handles for the same channel.
+    accepting: Arc<AtomicBool>,
     #[cfg(feature = "metrics")]
     messages_sent: metrics::Counter,
     #[cfg(feature = "metrics")]
@@ -149,6 +159,10 @@ impl<A: Actor> MailboxSender<A> {
     /// [`mpsc::Sender::send`]: tokio::sync::mpsc::Sender::send
     /// [`mpsc::UnboundedSender::send`]: tokio::sync::mpsc::UnboundedSender::send
     pub async fn send(&self, signal: Signal<A>) -> Result<(), mpsc::error::SendError<Signal<A>>> {
+        if !self.is_accepting() && matches!(signal, Signal::Message { .. }) {
+            return Err(mpsc::error::SendError(signal));
+        }
+
         #[cfg(feature = "metrics")]
         let signal_kind = SignalKind::from(&signal);
 
@@ -174,6 +188,10 @@ impl<A: Actor> MailboxSender<A> {
     /// [`mpsc::UnboundedSender::send`]: tokio::sync::mpsc::UnboundedSender::send
     #[allow(clippy::result_large_err)]
     pub fn try_send(&self, signal: Signal<A>) -> Result<(), mpsc::error::TrySendError<Signal<A>>> {
+        if !self.is_accepting() && matches!(signal, Signal::Message { .. }) {
+            return Err(mpsc::error::TrySendError::Closed(signal));
+        }
+
         #[cfg(feature = "metrics")]
         let signal_kind = SignalKind::from(&signal);
 
@@ -204,6 +222,10 @@ impl<A: Actor> MailboxSender<A> {
         signal: Signal<A>,
         timeout: Duration,
     ) -> Result<(), mpsc::error::SendTimeoutError<Signal<A>>> {
+        if !self.is_accepting() && matches!(signal, Signal::Message { .. }) {
+            return Err(mpsc::error::SendTimeoutError::Closed(signal));
+        }
+
         #[cfg(feature = "metrics")]
         let signal_kind = SignalKind::from(&signal);
 
@@ -234,6 +256,10 @@ impl<A: Actor> MailboxSender<A> {
         &self,
         signal: Signal<A>,
     ) -> Result<(), mpsc::error::SendError<Signal<A>>> {
+        if !self.is_accepting() && matches!(signal, Signal::Message { .. }) {
+            return Err(mpsc::error::SendError(signal));
+        }
+
         #[cfg(feature = "metrics")]
         let signal_kind = SignalKind::from(&signal);
 
@@ -276,6 +302,18 @@ impl<A: Actor> MailboxSender<A> {
             MailboxSenderInner::Bounded(tx) => tx.is_closed(),
             MailboxSenderInner::Unbounded(tx) => tx.is_closed(),
         }
+    }
+
+    /// Whether the mailbox still accepts user messages. Returns `false` once
+    /// [`ActorRef::stop_gracefully`] has been called.
+    pub(crate) fn is_accepting(&self) -> bool {
+        self.accepting.load(Ordering::Relaxed)
+    }
+
+    /// Stops the mailbox from accepting new user messages. Already-queued messages and lifecycle
+    /// signals are unaffected.
+    pub(crate) fn stop_accepting(&self) {
+        self.accepting.store(false, Ordering::Relaxed);
     }
 
     /// Returns `true` if senders belong to the same channel.
@@ -334,6 +372,7 @@ impl<A: Actor> MailboxSender<A> {
         match &self.inner {
             MailboxSenderInner::Bounded(tx) => WeakMailboxSender {
                 inner: WeakMailboxSenderInner::Bounded(tx.downgrade()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -343,6 +382,7 @@ impl<A: Actor> MailboxSender<A> {
             },
             MailboxSenderInner::Unbounded(tx) => WeakMailboxSender {
                 inner: WeakMailboxSenderInner::Unbounded(tx.downgrade()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -385,6 +425,7 @@ impl<A: Actor> Clone for MailboxSender<A> {
         match &self.inner {
             MailboxSenderInner::Bounded(tx) => MailboxSender {
                 inner: MailboxSenderInner::Bounded(tx.clone()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -394,6 +435,7 @@ impl<A: Actor> Clone for MailboxSender<A> {
             },
             MailboxSenderInner::Unbounded(tx) => MailboxSender {
                 inner: MailboxSenderInner::Unbounded(tx.clone()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -422,6 +464,7 @@ impl<A: Actor> fmt::Debug for MailboxSender<A> {
 /// [`mpsc::WeakUnboundedSender`]: tokio::sync::mpsc::WeakUnboundedSender
 pub struct WeakMailboxSender<A: Actor> {
     inner: WeakMailboxSenderInner<A>,
+    accepting: Arc<AtomicBool>,
     #[cfg(feature = "metrics")]
     messages_sent: metrics::Counter,
     #[cfg(feature = "metrics")]
@@ -450,6 +493,7 @@ impl<A: Actor> WeakMailboxSender<A> {
         match &self.inner {
             WeakMailboxSenderInner::Bounded(tx) => tx.upgrade().map(|tx| MailboxSender {
                 inner: MailboxSenderInner::Bounded(tx),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -459,6 +503,7 @@ impl<A: Actor> WeakMailboxSender<A> {
             }),
             WeakMailboxSenderInner::Unbounded(tx) => tx.upgrade().map(|tx| MailboxSender {
                 inner: MailboxSenderInner::Unbounded(tx),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -501,6 +546,7 @@ impl<A: Actor> Clone for WeakMailboxSender<A> {
         match &self.inner {
             WeakMailboxSenderInner::Bounded(tx) => WeakMailboxSender {
                 inner: WeakMailboxSenderInner::Bounded(tx.clone()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]
@@ -510,6 +556,7 @@ impl<A: Actor> Clone for WeakMailboxSender<A> {
             },
             WeakMailboxSenderInner::Unbounded(tx) => WeakMailboxSender {
                 inner: WeakMailboxSenderInner::Unbounded(tx.clone()),
+                accepting: self.accepting.clone(),
                 #[cfg(feature = "metrics")]
                 messages_sent: self.messages_sent.clone(),
                 #[cfg(feature = "metrics")]

--- a/tests/stop_gracefully_closes_mailbox.rs
+++ b/tests/stop_gracefully_closes_mailbox.rs
@@ -1,0 +1,188 @@
+use std::time::Duration;
+
+use kameo::error::{Infallible, SendError};
+use kameo::prelude::*;
+use tokio::sync::{mpsc, oneshot};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+struct TestActor {
+    handled_tx: mpsc::UnboundedSender<u32>,
+    gate: Option<oneshot::Receiver<()>>,
+}
+
+impl Actor for TestActor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+// Occupies the actor until the gate is released, so a backlog can build up behind it.
+struct Block;
+
+impl Message<Block> for TestActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Block, _: &mut Context<Self, Self::Reply>) {
+        if let Some(gate) = self.gate.take() {
+            let _ = gate.await;
+        }
+    }
+}
+
+// Reports that it was handled by forwarding its value.
+struct Record(u32);
+
+impl Message<Record> for TestActor {
+    type Reply = ();
+
+    async fn handle(&mut self, Record(n): Record, _: &mut Context<Self, Self::Reply>) {
+        let _ = self.handled_tx.send(n);
+    }
+}
+
+fn spawn_gated() -> (
+    ActorRef<TestActor>,
+    mpsc::UnboundedReceiver<u32>,
+    oneshot::Sender<()>,
+) {
+    let (handled_tx, handled_rx) = mpsc::unbounded_channel();
+    let (gate_tx, gate_rx) = oneshot::channel();
+    let actor = TestActor::spawn(TestActor {
+        handled_tx,
+        gate: Some(gate_rx),
+    });
+    (actor, handled_rx, gate_tx)
+}
+
+async fn recv(rx: &mut mpsc::UnboundedReceiver<u32>) -> u32 {
+    tokio::time::timeout(TIMEOUT, rx.recv())
+        .await
+        .expect("timed out waiting for handled message")
+        .expect("channel closed before message was handled")
+}
+
+// Messages already queued before the stop signal are still processed.
+#[tokio::test]
+async fn queued_messages_are_processed_before_graceful_stop() {
+    let (actor, mut handled_rx, gate_tx) = spawn_gated();
+
+    actor.tell(Block).await.unwrap();
+    // Queued while the actor is still accepting.
+    actor.tell(Record(0)).await.unwrap();
+    actor.tell(Record(1)).await.unwrap();
+    actor.tell(Record(2)).await.unwrap();
+    // Enqueues Stop behind the records and flips the actor to not-accepting.
+    actor.stop_gracefully().await.unwrap();
+    // Let the actor drain the backlog.
+    gate_tx.send(()).unwrap();
+
+    assert_eq!(recv(&mut handled_rx).await, 0);
+    assert_eq!(recv(&mut handled_rx).await, 1);
+    assert_eq!(recv(&mut handled_rx).await, 2);
+
+    tokio::time::timeout(TIMEOUT, actor.wait_for_shutdown())
+        .await
+        .expect("actor did not stop");
+}
+
+// A `tell` after graceful stop is rejected via the flag while the actor is still draining.
+#[tokio::test]
+async fn tell_after_graceful_stop_is_rejected() {
+    let (actor, _handled_rx, gate_tx) = spawn_gated();
+
+    actor.tell(Block).await.unwrap();
+    actor.stop_gracefully().await.unwrap();
+
+    let err = actor.tell(Record(9)).await.unwrap_err();
+    assert!(matches!(err, SendError::ActorNotRunning(Record(9))));
+
+    gate_tx.send(()).unwrap();
+}
+
+// An `ask` after graceful stop is rejected and returns the message.
+#[tokio::test]
+async fn ask_after_graceful_stop_is_rejected() {
+    let (actor, _handled_rx, gate_tx) = spawn_gated();
+
+    actor.tell(Block).await.unwrap();
+    actor.stop_gracefully().await.unwrap();
+
+    let err = actor.ask(Record(9)).await.unwrap_err();
+    assert!(matches!(err, SendError::ActorNotRunning(Record(9))));
+
+    gate_tx.send(()).unwrap();
+}
+
+// `try_send` and `blocking_send` are also gated (the flag short-circuits before the channel call,
+// so `blocking_send` never actually blocks here).
+#[tokio::test]
+async fn try_and_blocking_sends_after_graceful_stop_are_rejected() {
+    let (actor, _handled_rx, gate_tx) = spawn_gated();
+
+    actor.tell(Block).await.unwrap();
+    actor.stop_gracefully().await.unwrap();
+
+    let try_err = actor.tell(Record(1)).try_send().unwrap_err();
+    assert!(matches!(try_err, SendError::ActorNotRunning(Record(1))));
+
+    let blocking_err = actor.tell(Record(2)).blocking_send().unwrap_err();
+    assert!(matches!(
+        blocking_err,
+        SendError::ActorNotRunning(Record(2))
+    ));
+
+    gate_tx.send(()).unwrap();
+}
+
+// `is_alive` flips to false immediately, even while the actor is still draining.
+#[tokio::test]
+async fn is_alive_is_false_after_graceful_stop() {
+    let (actor, _handled_rx, gate_tx) = spawn_gated();
+    assert!(actor.is_alive());
+
+    actor.tell(Block).await.unwrap();
+    actor.stop_gracefully().await.unwrap();
+    assert!(!actor.is_alive());
+
+    gate_tx.send(()).unwrap();
+}
+
+// Graceful stop still actually stops the actor, and sends after full stop still map to
+// `ActorNotRunning` (the closed-channel path).
+#[tokio::test]
+async fn graceful_stop_still_stops_the_actor() {
+    let (handled_tx, _handled_rx) = mpsc::unbounded_channel();
+    let actor = TestActor::spawn(TestActor {
+        handled_tx,
+        gate: None,
+    });
+
+    actor.stop_gracefully().await.unwrap();
+    tokio::time::timeout(TIMEOUT, actor.wait_for_shutdown())
+        .await
+        .expect("actor did not stop");
+    assert!(!actor.is_alive());
+
+    let err = actor.tell(Record(0)).await.unwrap_err();
+    assert!(matches!(err, SendError::ActorNotRunning(Record(0))));
+}
+
+// The gate flip propagates through the type-erased `Recipient` (it delegates to the same actor).
+#[tokio::test]
+async fn recipient_graceful_stop_rejects_sends() {
+    let (actor, _handled_rx, gate_tx) = spawn_gated();
+    actor.tell(Block).await.unwrap();
+
+    let recipient: Recipient<Record> = actor.clone().recipient();
+    recipient.stop_gracefully().await.unwrap();
+
+    assert!(!recipient.is_alive());
+    let err = recipient.tell(Record(5)).await.unwrap_err();
+    assert!(matches!(err, SendError::ActorNotRunning(Record(5))));
+
+    gate_tx.send(()).unwrap();
+}


### PR DESCRIPTION
## Problem

`ActorRef::stop_gracefully()` enqueued `Signal::Stop` at the back of the mailbox but left the mailbox open. Any message sent after that, but before the loop reached `Signal::Stop`, was accepted, queued behind `Stop`, and then dropped when the loop exited. The method's doc already noted that "any new messages sent after the stop signal will be ignored", so the caller had no way to know their message was lost.

## Change

After `stop_gracefully()`, new user-message sends now return `SendError::ActorNotRunning(msg)` (with the message handed back to the caller) rather than being accepted and dropped.

tokio `mpsc` senders can't close a channel, so this uses a shared `accepting: Arc<AtomicBool>` on `MailboxSender`, which every send path goes through:

- The four send methods (`send`, `try_send`, `send_timeout`, `blocking_send`) return early for `Signal::Message` when the flag is off, using tokio's own closed-error shapes. The existing `From` impls already turn those into `ActorNotRunning(M)`, so the error types, request builders, remote path, and recipients are unchanged.
- Only `Signal::Message` is gated. Lifecycle signals (`Stop`, `SupervisorRestart`, `LinkDied`, `Callback`, `StartupFinished`) still pass, so shutdown doesn't deadlock.
- `stop_gracefully()` sets the flag (`Relaxed`) before enqueuing `Signal::Stop`.
- `is_alive()` now also checks the flag, so it returns `false` as soon as graceful stop begins. Use `wait_for_shutdown()` to wait for full termination.

The added cost is one `Relaxed` load per send, which is small next to the boxed-message allocation and the channel's existing atomics on that path.

## Behaviour and scope

- Messages already queued before the stop signal are still processed.
- The flag is not set on `SupervisorRestart` or `kill()`. A restart reuses the same mailbox and flag and preserves tells for the next incarnation, so setting it there would make the restarted actor reject everything. Graceful stop is safe because it ends in a terminal `Normal` stop.
- Remote sends are covered, since they call the same local `ActorRef` send paths.
- The narrow case where a `tell` runs concurrently with `stop_gracefully` is not addressed here; that is left for a future `on_undelivered` hook.

## Tests

New integration tests in `tests/stop_gracefully_closes_mailbox.rs`:

- queued messages are still processed before graceful stop
- `tell` / `ask` / `try_send` / `blocking_send` after graceful stop are rejected with `ActorNotRunning` and return the message
- `is_alive()` returns false immediately while the actor is still draining
- graceful stop still stops the actor; sends after full stop still map to `ActorNotRunning`
- the flag applies through the type-erased `Recipient`

Verified with `cargo test --workspace`, and `clippy --all-targets` on default + remote + console + metrics.

Inspired by this comment: https://github.com/tqwewe/kameo/issues/335#issuecomment-4819187984
