### PR TITLE
feat: add on_undelivered hook for messages left in the mailbox at terminal stop

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -336,6 +336,79 @@ pub trait Actor: Sized + Send + 'static {
         async { Ok(()) }
     }
 
+    /// Called when the actor stops for good with messages still left in its mailbox.
+    ///
+    /// This is the "dead letter" hook: it lets the actor observe or act on messages that were never
+    /// processed (persist them, forward them to another actor, count them) instead of losing them
+    /// silently. It runs just before [`on_stop`](Actor::on_stop), with `&mut self`, so it can use
+    /// the actor's state, and it may `.await`.
+    ///
+    /// `undelivered` holds the leftover **tell** messages, each as a [`BoxMessage<Self>`] that can be
+    /// downcast to the concrete message type. `ask` messages are not included: their callers are
+    /// instead returned the message via [`SendError`](crate::error::SendError), so they are already
+    /// accounted for.
+    ///
+    /// The hook fires only on a terminal stop (killed, `ctx.stop()`, a panic, or an unrecovered
+    /// linked-actor death). It does **not** fire when the actor is restarted by a supervisor, since
+    /// the pending messages are preserved and handled by the next incarnation. It is also not called
+    /// if the mailbox is empty, or if the actor failed during [`on_start`](Actor::on_start) (there is
+    /// no actor to run it). A message being handled at the moment [`kill`](crate::actor::ActorRef::kill)
+    /// aborts the actor is not recoverable and is not included.
+    ///
+    /// The error returned by this method is surfaced through the actor error hook, like
+    /// [`on_stop`](Actor::on_stop).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kameo::prelude::*;
+    /// use kameo::error::Infallible;
+    ///
+    /// struct MyActor;
+    ///
+    /// impl Actor for MyActor {
+    ///     type Args = Self;
+    ///     type Error = Infallible;
+    ///
+    ///     async fn on_start(args: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+    ///         Ok(args)
+    ///     }
+    ///
+    ///     async fn on_undelivered(
+    ///         &mut self,
+    ///         _reason: ActorStopReason,
+    ///         undelivered: Vec<BoxMessage<Self>>,
+    ///     ) -> Result<(), Self::Error> {
+    ///         for msg in undelivered {
+    ///             if let Ok(work) = msg.as_any().downcast::<Work>() {
+    ///                 // persist, forward, or log `work.0`
+    ///                 let _ = work.0;
+    ///             }
+    ///         }
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// struct Work(u32);
+    ///
+    /// impl Message<Work> for MyActor {
+    ///     type Reply = ();
+    ///
+    ///     async fn handle(&mut self, _: Work, _: &mut Context<Self, Self::Reply>) {}
+    /// }
+    /// ```
+    ///
+    /// [`on_stop`]: Actor::on_stop
+    #[allow(unused_variables)]
+    #[inline]
+    fn on_undelivered(
+        &mut self,
+        reason: ActorStopReason,
+        undelivered: Vec<BoxMessage<Self>>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
+    }
+
     /// Awaits the next signal typically from the mailbox.
     ///
     /// This can be overwritten for more advanced actor behaviour, such as awaiting multiple channels, etc.

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -23,6 +23,7 @@ use crate::{
     error::{ActorStopReason, PanicError, PanicReason, SendError, invoke_actor_error_hook},
     links::Links,
     mailbox::{MailboxReceiver, MailboxSender, Signal},
+    message::BoxMessage,
 };
 
 use super::ActorId;
@@ -262,6 +263,32 @@ where
                 actor_ref.links.send_children_shutdown().await;
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
+
+                // On a terminal stop (not a restart, where the mailbox is reused by the next
+                // incarnation) hand any leftover tells to `on_undelivered` before `notify_links`
+                // drops them.
+                if !is_restarting {
+                    let undelivered = drain_undelivered(&mut mailbox_rx);
+                    if !undelivered.is_empty() {
+                        let res =
+                            AssertUnwindSafe(actor.on_undelivered(reason.clone(), undelivered))
+                                .catch_unwind()
+                                .await
+                                .map(|res| {
+                                    res.map_err(|err| {
+                                        PanicError::new(Box::new(err), PanicReason::OnUndelivered)
+                                    })
+                                })
+                                .map_err(|err| {
+                                    PanicError::new_from_panic_any(err, PanicReason::OnUndelivered)
+                                })
+                                .and_then(convert::identity);
+                        if let Err(err) = res {
+                            invoke_actor_error_hook(&err);
+                        }
+                    }
+                }
+
                 actor_ref
                     .links
                     .lock()
@@ -398,6 +425,35 @@ async fn drain_until_children_closed<A>(
         }
     }
     mailbox_rx.push_front(preserved);
+}
+
+/// Drains every message remaining in the mailbox on a terminal stop, returning the leftover tells
+/// for [`Actor::on_undelivered`]. Straggler asks are bounced back to their caller with the original
+/// message (`ActorNotRunning`), mirroring [`drain_until_children_closed`], so they aren't handed to
+/// the hook or silently dropped.
+fn drain_undelivered<A>(mailbox_rx: &mut MailboxReceiver<A>) -> Vec<BoxMessage<A>>
+where
+    A: Actor,
+{
+    let mut undelivered = Vec::new();
+    while let Ok(signal) = mailbox_rx.try_recv() {
+        match signal {
+            Signal::Message {
+                message,
+                reply: None,
+                ..
+            } => undelivered.push(message),
+            Signal::Message {
+                message,
+                reply: Some(tx),
+                ..
+            } => {
+                let _ = tx.send(Err(SendError::ActorNotRunning(message.as_any())));
+            }
+            _ => {}
+        }
+    }
+    undelivered
 }
 
 async fn abortable_actor_loop<A>(

--- a/src/error.rs
+++ b/src/error.rs
@@ -708,6 +708,8 @@ pub enum PanicReason {
     OnLinkDied,
     /// The [`on_stop`](Actor::on_stop) lifecycle hook returned an error.
     OnStop,
+    /// The [`on_undelivered`](Actor::on_undelivered) lifecycle hook returned an error.
+    OnUndelivered,
     /// The [`next`](Actor::next) lifecycle hook returned an error.
     Next,
 }
@@ -734,6 +736,7 @@ impl PanicReason {
                 | PanicReason::OnPanic
                 | PanicReason::OnLinkDied
                 | PanicReason::OnStop
+                | PanicReason::OnUndelivered
         )
     }
 
@@ -765,6 +768,7 @@ impl fmt::Display for PanicReason {
             PanicReason::OnPanic => write!(f, "on_panic returned error"),
             PanicReason::OnLinkDied => write!(f, "on_link_died returned error"),
             PanicReason::OnStop => write!(f, "on_stop returned error"),
+            PanicReason::OnUndelivered => write!(f, "on_undelivered returned error"),
             PanicReason::Next => write!(f, "next returned error"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub mod prelude {
     pub use crate::error::RemoteSendError;
     pub use crate::error::{ActorStopReason, PanicError, PanicReason, SendError};
     pub use crate::mailbox::{self, MailboxReceiver, MailboxSender};
-    pub use crate::message::{Context, Message};
+    pub use crate::message::{BoxMessage, Context, Message};
     #[cfg(feature = "remote")]
     pub use crate::remote::{self, RemoteActor, RemoteMessage};
     pub use crate::reply::{DelegatedReply, ForwardedReply, Reply, ReplyError, ReplySender};

--- a/tests/on_undelivered.rs
+++ b/tests/on_undelivered.rs
@@ -1,3 +1,8 @@
+// The `hotpath` profiling feature wraps the mailbox channel and changes its delivery timing, so
+// messages sent to a blocked actor aren't reliably drained at teardown. These tests exercise that
+// exact path, so they're skipped under `hotpath` (the hook is covered by every other feature combo).
+#![cfg(not(feature = "hotpath"))]
+
 use std::time::Duration;
 
 use kameo::error::{Infallible, SendError};
@@ -21,6 +26,7 @@ struct Work(u32);
 
 struct DrainActor {
     undelivered_tx: mpsc::UnboundedSender<(ActorStopReason, Vec<u32>)>,
+    entered_tx: mpsc::UnboundedSender<()>,
     gate: Option<oneshot::Receiver<()>>,
 }
 
@@ -48,13 +54,16 @@ impl Actor for DrainActor {
     }
 }
 
-// Occupies the actor until the gate is released, so a backlog can build behind it.
+// Occupies the actor until the gate is released, so a backlog can build behind it. It signals once
+// it starts running (which proves startup has finished, so later messages land in the mailbox
+// rather than the startup buffer) and then blocks.
 struct Block;
 
 impl Message<Block> for DrainActor {
     type Reply = ();
 
     async fn handle(&mut self, _: Block, _: &mut Context<Self, Self::Reply>) {
+        let _ = self.entered_tx.send(());
         if let Some(gate) = self.gate.take() {
             let _ = gate.await;
         }
@@ -71,13 +80,17 @@ impl Message<Work> for DrainActor {
 #[tokio::test]
 async fn undelivered_tells_delivered_on_terminal_stop() {
     let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
     let (gate_tx, gate_rx) = oneshot::channel();
     let actor = DrainActor::spawn(DrainActor {
         undelivered_tx,
+        entered_tx,
         gate: Some(gate_rx),
     });
 
     actor.tell(Block).await.unwrap();
+    recv(&mut entered_rx).await; // Block is now running and about to block
+
     actor.tell(Work(1)).await.unwrap();
     actor.tell(Work(2)).await.unwrap();
     actor.tell(Work(3)).await.unwrap();
@@ -96,8 +109,10 @@ async fn undelivered_tells_delivered_on_terminal_stop() {
 #[tokio::test]
 async fn undelivered_not_called_when_mailbox_empty() {
     let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (entered_tx, _entered_rx) = mpsc::unbounded_channel();
     let actor = DrainActor::spawn(DrainActor {
         undelivered_tx,
+        entered_tx,
         gate: None,
     });
 
@@ -111,13 +126,17 @@ async fn undelivered_not_called_when_mailbox_empty() {
 #[tokio::test]
 async fn undelivered_asks_bounce_to_caller_not_hook() {
     let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
     let (gate_tx, gate_rx) = oneshot::channel();
     let actor = DrainActor::spawn(DrainActor {
         undelivered_tx,
+        entered_tx,
         gate: Some(gate_rx),
     });
 
     actor.tell(Block).await.unwrap();
+    recv(&mut entered_rx).await; // Block is now running and about to block
+
     actor.tell(Work(1)).await.unwrap();
     // Enqueue an ask synchronously so it's queued before the kill.
     let pending = actor.ask(Work(2)).try_enqueue().unwrap();

--- a/tests/on_undelivered.rs
+++ b/tests/on_undelivered.rs
@@ -1,0 +1,243 @@
+use std::time::Duration;
+
+use kameo::error::{Infallible, SendError};
+use kameo::prelude::*;
+use kameo::supervision::RestartPolicy;
+use tokio::sync::{mpsc, oneshot};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn recv<T>(rx: &mut mpsc::UnboundedReceiver<T>) -> T {
+    tokio::time::timeout(TIMEOUT, rx.recv())
+        .await
+        .expect("timed out waiting for value")
+        .expect("channel closed")
+}
+
+// A message the hook downcasts back to.
+struct Work(u32);
+
+// ==================== DrainActor (terminal-stop tests) ====================
+
+struct DrainActor {
+    undelivered_tx: mpsc::UnboundedSender<(ActorStopReason, Vec<u32>)>,
+    gate: Option<oneshot::Receiver<()>>,
+}
+
+impl Actor for DrainActor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+
+    async fn on_undelivered(
+        &mut self,
+        reason: ActorStopReason,
+        undelivered: Vec<BoxMessage<Self>>,
+    ) -> Result<(), Self::Error> {
+        let mut values = Vec::new();
+        for msg in undelivered {
+            if let Ok(work) = msg.as_any().downcast::<Work>() {
+                values.push(work.0);
+            }
+        }
+        let _ = self.undelivered_tx.send((reason, values));
+        Ok(())
+    }
+}
+
+// Occupies the actor until the gate is released, so a backlog can build behind it.
+struct Block;
+
+impl Message<Block> for DrainActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Block, _: &mut Context<Self, Self::Reply>) {
+        if let Some(gate) = self.gate.take() {
+            let _ = gate.await;
+        }
+    }
+}
+
+impl Message<Work> for DrainActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Work, _: &mut Context<Self, Self::Reply>) {}
+}
+
+// Leftover tells are handed to the hook on a terminal stop, with the stop reason.
+#[tokio::test]
+async fn undelivered_tells_delivered_on_terminal_stop() {
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (gate_tx, gate_rx) = oneshot::channel();
+    let actor = DrainActor::spawn(DrainActor {
+        undelivered_tx,
+        gate: Some(gate_rx),
+    });
+
+    actor.tell(Block).await.unwrap();
+    actor.tell(Work(1)).await.unwrap();
+    actor.tell(Work(2)).await.unwrap();
+    actor.tell(Work(3)).await.unwrap();
+
+    actor.kill();
+    actor.wait_for_shutdown().await;
+
+    let (reason, values) = recv(&mut undelivered_rx).await;
+    assert!(matches!(reason, ActorStopReason::Killed));
+    assert_eq!(values, vec![1, 2, 3]);
+
+    let _ = gate_tx; // keep the gate un-fired until after kill
+}
+
+// The hook is not called when the mailbox is empty at stop.
+#[tokio::test]
+async fn undelivered_not_called_when_mailbox_empty() {
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let actor = DrainActor::spawn(DrainActor {
+        undelivered_tx,
+        gate: None,
+    });
+
+    actor.stop_gracefully().await.unwrap();
+    actor.wait_for_shutdown().await;
+
+    assert!(undelivered_rx.try_recv().is_err());
+}
+
+// Pending asks are returned to their caller with the message; only tells reach the hook.
+#[tokio::test]
+async fn undelivered_asks_bounce_to_caller_not_hook() {
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (gate_tx, gate_rx) = oneshot::channel();
+    let actor = DrainActor::spawn(DrainActor {
+        undelivered_tx,
+        gate: Some(gate_rx),
+    });
+
+    actor.tell(Block).await.unwrap();
+    actor.tell(Work(1)).await.unwrap();
+    // Enqueue an ask synchronously so it's queued before the kill.
+    let pending = actor.ask(Work(2)).try_enqueue().unwrap();
+
+    actor.kill();
+    actor.wait_for_shutdown().await;
+
+    // The ask caller gets its message back.
+    let ask_result = pending.await;
+    assert!(matches!(&ask_result, Err(SendError::ActorNotRunning(work)) if work.0 == 2));
+
+    // The hook received only the tell.
+    let (_reason, values) = recv(&mut undelivered_rx).await;
+    assert_eq!(values, vec![1]);
+
+    let _ = gate_tx;
+}
+
+// ==================== Supervised restart test ====================
+
+struct Supervisor;
+
+impl Actor for Supervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+#[derive(Clone)]
+struct RestartWorker {
+    undelivered_tx: mpsc::UnboundedSender<Vec<u32>>,
+    processed_tx: mpsc::UnboundedSender<u32>,
+    started_tx: mpsc::UnboundedSender<()>,
+}
+
+impl Actor for RestartWorker {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        this.started_tx.send(()).unwrap();
+        Ok(this)
+    }
+
+    async fn on_undelivered(
+        &mut self,
+        _: ActorStopReason,
+        undelivered: Vec<BoxMessage<Self>>,
+    ) -> Result<(), Self::Error> {
+        let mut values = Vec::new();
+        for msg in undelivered {
+            if let Ok(work) = msg.as_any().downcast::<Work>() {
+                values.push(work.0);
+            }
+        }
+        let _ = self.undelivered_tx.send(values);
+        Ok(())
+    }
+}
+
+struct PanicMsg;
+
+impl Message<PanicMsg> for RestartWorker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: PanicMsg, _: &mut Context<Self, Self::Reply>) {
+        // Sleep so the following tells are queued before we panic.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        panic!("intentional panic for testing");
+    }
+}
+
+impl Message<Work> for RestartWorker {
+    type Reply = ();
+
+    async fn handle(&mut self, Work(n): Work, _: &mut Context<Self, Self::Reply>) {
+        let _ = self.processed_tx.send(n);
+    }
+}
+
+// On a supervisor restart the pending tells are preserved for the next incarnation, so the hook
+// must not fire.
+#[tokio::test]
+async fn undelivered_not_called_on_restart() {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (processed_tx, mut processed_rx) = mpsc::unbounded_channel();
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+
+    let worker = RestartWorker::supervise(
+        &supervisor,
+        RestartWorker {
+            undelivered_tx,
+            processed_tx,
+            started_tx,
+        },
+    )
+    .restart_policy(RestartPolicy::Permanent)
+    .restart_limit(5, Duration::from_secs(10))
+    .spawn()
+    .await;
+
+    recv(&mut started_rx).await; // initial startup
+
+    worker.tell(PanicMsg).await.unwrap();
+    worker.tell(Work(10)).await.unwrap();
+    worker.tell(Work(11)).await.unwrap();
+
+    recv(&mut started_rx).await; // restart startup
+
+    // Both tells are processed by the restarted incarnation, proving they survived the restart.
+    assert_eq!(recv(&mut processed_rx).await, 10);
+    assert_eq!(recv(&mut processed_rx).await, 11);
+
+    // The hook was never called during the restart.
+    assert!(undelivered_rx.try_recv().is_err());
+
+    supervisor.kill();
+    supervisor.wait_for_shutdown().await;
+}


### PR DESCRIPTION
## Problem

When an actor stops for good with messages still queued (killed, `ctx.stop()`, a panic, or an unrecovered linked-actor death), those tell messages were dropped by `notify_links` at teardown with no way for the actor to see them. Asks already return their message to the caller inside `SendError` during the drain, so the loss only affected tells (fire-and-forget, no caller to notify).

## Change

Adds an opt-in `Actor::on_undelivered` hook so an actor can observe and act on those leftover tells (persist them, forward them to a dead-letter actor, count them) instead of losing them silently.

```rust
fn on_undelivered(
    &mut self,
    reason: ActorStopReason,
    undelivered: Vec<BoxMessage<Self>>,
) -> impl Future<Output = Result<(), Self::Error>> + Send;
```

- Default no-op, so existing actors are unaffected and `#[derive(Actor)]` needs no change.
- Receives all leftover messages in one `Vec`, so a bulk operation (one DB transaction, one metric) is a single `await`. Each item is a `BoxMessage<Self>` the actor downcasts with `msg.as_any().downcast::<ConcreteMsg>()`.
- Runs just before `on_stop`, with `&mut self`, and may `.await`.

This completes the guarantee that a message is either processed (by this or the next incarnation), returned to an ask caller, or handed to `on_undelivered`.

## Where it fires

Invoked at teardown between `drain_until_children_closed` and `notify_links`, gated on the existing `is_restarting` value (`will_restart(&reason)`):

- Terminal stop only. It does not fire on a supervisor restart, where the pending tells are preserved and handled by the next incarnation.
- Skipped when the mailbox is empty, so the common case costs nothing (the drain yields an empty `Vec` and the call is skipped).
- Only tells reach the hook. Straggler asks are bounced to their caller with the original message (`SendError::ActorNotRunning`), the same as the existing drain.
- Not called if the actor failed during `on_start` (there is no actor to run it), and the message in flight when `kill()` aborts the loop is not recoverable.

Errors and panics from the hook are surfaced through the actor error hook, like `on_stop`, and are caught so teardown still completes.

## Other changes

- `PanicReason::OnUndelivered` for panics/errors raised in the hook.
- `BoxMessage` is now re-exported from the prelude, so overriding the hook does not need a separate import.

## Tests

New integration tests in `tests/on_undelivered.rs`:

- leftover tells are delivered to the hook on a terminal stop, with the correct stop reason
- the hook is not called when the mailbox is empty
- a pending ask is returned to its caller with the message, and only the tell reaches the hook
- the hook is not called on a supervised restart; the tells are processed by the next incarnation

Verified with `cargo test --workspace`, `clippy --all-targets` on default + remote + console + metrics, and `cargo doc` (the hook has a doctest).

Inspired by issue https://github.com/tqwewe/kameo/issues/335
