### PR TITLE
fix(supervision): deliver leftover tells to on_undelivered when the restart budget is exhausted

### DIFF
--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -232,7 +232,7 @@ where
         dead_actor_sibblings: Option<HashMap<ActorId, Link>>,
     ) -> ControlFlow<ActorStopReason> {
         {
-            let mut links = self.actor_ref.links.lock().await;
+            let links = self.actor_ref.links.lock().await;
 
             // Check if we're already coordinating a restart
             if let CoordinationState::Coordinating {
@@ -256,13 +256,13 @@ where
                 return ControlFlow::Continue(());
             }
 
-            if let Some(spec) = links.children.get_mut(&id) {
+            if let Some(spec) = links.children.get(&id) {
                 let should_restart = spec.should_restart(&reason);
                 let factory = Arc::clone(&spec.factory);
                 #[cfg(feature = "tracing")]
-                let restart_count = spec.restart_count;
+                let restart_count = spec.restart_tracker.current_count();
 
-                // Extract what we need for coordination before dropping mutable borrow
+                // Extract what we need for coordination before borrowing children again
                 let strategy_info = match should_restart {
                     ControlFlow::Continue(()) => match A::supervision_strategy() {
                         SupervisionStrategy::OneForOne => None,

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -247,9 +247,9 @@ impl ActorMonitor {
                     .get(&self.id)
                     .map(|spec| wire::SupervisionInfo {
                         policy: wire_policy(spec.restart_policy),
-                        max_restarts: spec.max_restarts,
-                        restart_window: spec.restart_window,
-                        restart_count: spec.restart_count,
+                        max_restarts: spec.restart_tracker.max_restarts(),
+                        restart_window: spec.restart_tracker.restart_window(),
+                        restart_count: spec.restart_tracker.current_count(),
                     })
             }
             None => None,

--- a/src/links.rs
+++ b/src/links.rs
@@ -38,6 +38,24 @@ pub type ShutdownFn = Box<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>;
 pub struct Links(Arc<Mutex<LinksInner>>);
 
 impl Links {
+    /// Creates links for a supervised child, pre-populated with the restart configuration its
+    /// supervisor shares with it: the `restart_policy`, the shared `restart_tracker` (so the child
+    /// can predict its own restarts in [`LinksInner::will_restart`]), and the shared
+    /// `parent_shutdown` flag. Building the inner value up front avoids locking it right after
+    /// construction.
+    pub fn supervised(
+        restart_policy: RestartPolicy,
+        restart_tracker: Arc<RestartTracker>,
+        parent_shutdown: Arc<AtomicBool>,
+    ) -> Self {
+        Links(Arc::new(Mutex::new(LinksInner {
+            restart_policy: Some(restart_policy),
+            restart_tracker: Some(restart_tracker),
+            parent_shutdown,
+            ..Default::default()
+        })))
+    }
+
     /// Sets the `parent_shutdown` flag on all supervised children.
     ///
     /// This must be called before the parent stops processing its mailbox so that any child
@@ -92,16 +110,29 @@ pub struct LinksInner {
     /// `shutdown_children` wait.
     pub parent_shutdown: Arc<AtomicBool>,
     /// The restart policy our supervisor will apply to us, `Some` only when supervised. Lets the
-    /// actor guess, during its own teardown, whether it will be restarted (see [`Self::will_restart`]).
+    /// actor determine, during its own teardown, whether it will be restarted (see
+    /// [`Self::will_restart`]).
     pub restart_policy: Option<RestartPolicy>,
+    /// The restart intensity bookkeeping, shared by `Arc` with our supervisor's [`ErasedChildSpec`].
+    /// `Some` only when supervised. Lets [`Self::will_restart`] apply the same restart-limit check
+    /// the supervisor uses, instead of guessing.
+    pub restart_tracker: Option<Arc<RestartTracker>>,
 }
 
 impl LinksInner {
-    /// Best-effort guess, made during the actor's own teardown, of whether its supervisor will
-    /// restart it. Mirrors [`ErasedChildSpec::should_restart`] except for the parent-side
-    /// restart-limit check, which the child can't see; an actor that has exhausted its restart
-    /// limit is therefore guessed as restarting. Callers only use this to pick which message the
-    /// caller of a dropped `ask` receives, so the guess never drops a message, only mislabels it.
+    /// Determines, during the actor's own teardown, whether its supervisor will restart it.
+    /// Mirrors [`ErasedChildSpec::should_restart`], reading the same shared [`RestartTracker`] so
+    /// the restart-limit check matches the supervisor's decision. `run_actor_lifecycle` uses this
+    /// both to route a dropped `ask`'s message (`ActorRestarting` vs `ActorNotRunning`) and to
+    /// decide whether leftover tells go to `Actor::on_undelivered`, so it must not report a restart
+    /// that won't happen.
+    ///
+    /// The child reads the tracker slightly before the supervisor decides. Because the restart
+    /// count only changes on the supervisor's restart path (which hasn't run yet for this death)
+    /// and `now - last_restart` is monotonic, the only possible disagreement is at a restart-window
+    /// boundary, where the child predicts no restart but the supervisor restarts: the leftover
+    /// tells reach `on_undelivered` instead of the new incarnation. No message is dropped either
+    /// way. The opposite (predict restart, supervisor declines) cannot occur.
     pub fn will_restart(&self, reason: &ActorStopReason) -> bool {
         let Some(policy) = self.restart_policy else {
             return false; // unsupervised: nobody will restart us
@@ -111,10 +142,19 @@ impl LinksInner {
         }
         match policy {
             RestartPolicy::Never => false,
+            // a coordinator-initiated restart bypasses the intensity check, same as the supervisor
             _ if matches!(reason, ActorStopReason::SupervisorRestart) => true,
-            RestartPolicy::Permanent => true,
-            RestartPolicy::Transient => !reason.is_normal(),
+            RestartPolicy::Permanent => self.restart_intensity_allows(),
+            RestartPolicy::Transient => !reason.is_normal() && self.restart_intensity_allows(),
         }
+    }
+
+    /// Whether the shared restart budget still permits a restart. Falls back to `true`
+    /// if no tracker is set, which shouldn't happen while supervised.
+    fn restart_intensity_allows(&self) -> bool {
+        self.restart_tracker
+            .as_ref()
+            .is_none_or(|tracker| tracker.predict_restart())
     }
 
     /// Notify parent or sibblings, depending on supervision status.
@@ -239,14 +279,13 @@ pub struct ErasedChildSpec {
     /// its `mailbox_rx` immediately rather than forwarding it to the parent's queue.
     pub parent_shutdown: Arc<AtomicBool>,
     pub restart_policy: RestartPolicy,
-    pub restart_count: u32,
-    pub last_restart: Instant,
-    pub max_restarts: u32,
-    pub restart_window: Duration,
+    /// Restart intensity bookkeeping, shared by `Arc` with the child's
+    /// [`LinksInner::restart_tracker`] so the child can predict this same decision.
+    pub restart_tracker: Arc<RestartTracker>,
 }
 
 impl ErasedChildSpec {
-    pub fn should_restart(&mut self, reason: &ActorStopReason) -> ControlFlow<NoRestartReason> {
+    pub fn should_restart(&self, reason: &ActorStopReason) -> ControlFlow<NoRestartReason> {
         // Never policy takes precedence over everything, including coordinator-initiated restarts
         if matches!(self.restart_policy, RestartPolicy::Never) {
             return ControlFlow::Break(NoRestartReason::NeverPolicy);
@@ -267,24 +306,91 @@ impl ErasedChildSpec {
             RestartPolicy::Never => unreachable!(),
         }
 
+        self.restart_tracker.record_restart()
+    }
+}
+
+/// Restart intensity bookkeeping for a supervised child, shared by `Arc` between the supervisor's
+/// [`ErasedChildSpec`] and the child's [`LinksInner`]. The supervisor mutates it authoritatively
+/// via [`Self::record_restart`]; the child reads it via [`Self::predict_restart`] to decide, during
+/// its own teardown, whether it is about to be restarted.
+#[derive(Debug)]
+pub struct RestartTracker {
+    max_restarts: u32,
+    restart_window: Duration,
+    // std Mutex: only ever locked for the short, non-async body of the methods below, and
+    // independent of the async `Links` mutexes, so it can't deadlock against them.
+    state: std::sync::Mutex<RestartTrackerState>,
+}
+
+#[derive(Debug)]
+struct RestartTrackerState {
+    restart_count: u32,
+    last_restart: Instant,
+}
+
+impl RestartTracker {
+    pub fn new(max_restarts: u32, restart_window: Duration) -> Self {
+        RestartTracker {
+            max_restarts,
+            restart_window,
+            state: std::sync::Mutex::new(RestartTrackerState {
+                restart_count: 0,
+                last_restart: Instant::now(),
+            }),
+        }
+    }
+
+    /// Authoritative check made by the supervisor. Applies the restart-window reset and intensity
+    /// limit, recording the restart when it is allowed.
+    pub fn record_restart(&self) -> ControlFlow<NoRestartReason> {
+        let mut state = self.state.lock().unwrap();
+
         // Reset count if outside time window
         let now = Instant::now();
-        if now.duration_since(self.last_restart) > self.restart_window {
-            self.restart_count = 0;
+        if now.duration_since(state.last_restart) > self.restart_window {
+            state.restart_count = 0;
         }
 
         // Intensity check
-        if self.restart_count >= self.max_restarts {
+        if state.restart_count >= self.max_restarts {
             return ControlFlow::Break(NoRestartReason::MaxRestartsExceeded {
-                restart_count: self.restart_count,
+                restart_count: state.restart_count,
                 max_restarts: self.max_restarts,
             });
         }
 
-        self.restart_count += 1;
-        self.last_restart = now;
+        state.restart_count += 1;
+        state.last_restart = now;
 
         ControlFlow::Continue(())
+    }
+
+    /// Read-only mirror of [`Self::record_restart`]'s intensity decision, used by the child to
+    /// predict whether the supervisor will restart it. Does not mutate the count.
+    pub fn predict_restart(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        let count = if Instant::now().duration_since(state.last_restart) > self.restart_window {
+            0
+        } else {
+            state.restart_count
+        };
+        count < self.max_restarts
+    }
+
+    #[cfg(feature = "console")]
+    pub fn max_restarts(&self) -> u32 {
+        self.max_restarts
+    }
+
+    #[cfg(feature = "console")]
+    pub fn restart_window(&self) -> Duration {
+        self.restart_window
+    }
+
+    #[cfg(any(feature = "tracing", feature = "console"))]
+    pub fn current_count(&self) -> u32 {
+        self.state.lock().unwrap().restart_count
     }
 }
 

--- a/src/supervision.rs
+++ b/src/supervision.rs
@@ -77,15 +77,18 @@
 
 use std::{
     any::Any,
-    sync::{Arc, atomic::Ordering},
-    time::{Duration, Instant},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
 };
 
 use futures::{FutureExt, future::BoxFuture};
 
 use crate::{
     actor::{Actor, ActorId, ActorRef, DEFAULT_MAILBOX_CAPACITY, PreparedActor},
-    links::{BoxActorRef, ErasedChildSpec, Links, ShutdownFn, SpawnFactory},
+    links::{BoxActorRef, ErasedChildSpec, Links, RestartTracker, ShutdownFn, SpawnFactory},
     mailbox::{self, MailboxReceiver, MailboxSender, Signal},
 };
 
@@ -636,9 +639,14 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
         in_thread: bool,
     ) -> ActorRef<C> {
         let actor_id = ActorId::generate();
-        let links = Links::default();
         let restart_policy = self.restart_policy;
-        links.lock().await.restart_policy = Some(restart_policy);
+        let restart_tracker = Arc::new(RestartTracker::new(self.max_restarts, self.restart_window));
+        let parent_shutdown = Arc::new(AtomicBool::new(false));
+        let links = Links::supervised(
+            restart_policy,
+            restart_tracker.clone(),
+            parent_shutdown.clone(),
+        );
         let factory = Arc::new(new_factory(
             actor_id,
             mailbox_tx.clone(),
@@ -658,17 +666,13 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
                 .boxed()
             }
         }) as ShutdownFn);
-        let parent_shutdown = links.lock().await.parent_shutdown.clone();
         let spec = ErasedChildSpec {
             factory: factory.clone(),
             shutdown,
             signal_mailbox: Box::new(mailbox_tx.clone()),
             parent_shutdown,
             restart_policy,
-            restart_count: 0,
-            last_restart: Instant::now(),
-            max_restarts: self.max_restarts,
-            restart_window: self.restart_window,
+            restart_tracker,
         };
         self.supervisor_ref.link_child(actor_id, &links, spec).await;
         *(*factory)(Box::new(mailbox_rx)).await.downcast().unwrap()

--- a/tests/on_undelivered.rs
+++ b/tests/on_undelivered.rs
@@ -3,12 +3,13 @@
 // exact path, so they're skipped under `hotpath` (the hook is covered by every other feature combo).
 #![cfg(not(feature = "hotpath"))]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use kameo::error::{Infallible, SendError};
 use kameo::prelude::*;
 use kameo::supervision::RestartPolicy;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -173,6 +174,10 @@ struct RestartWorker {
     undelivered_tx: mpsc::UnboundedSender<Vec<u32>>,
     processed_tx: mpsc::UnboundedSender<u32>,
     started_tx: mpsc::UnboundedSender<()>,
+    entered_tx: mpsc::UnboundedSender<()>,
+    // Shared (Clone-friendly) so it survives being cloned into each restarted incarnation. It is
+    // never fired; the exhausted-budget test kills the actor while a Block handler waits on it.
+    gate: Arc<Notify>,
 }
 
 impl Actor for RestartWorker {
@@ -220,6 +225,15 @@ impl Message<Work> for RestartWorker {
     }
 }
 
+impl Message<Block> for RestartWorker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Block, _: &mut Context<Self, Self::Reply>) {
+        let _ = self.entered_tx.send(());
+        self.gate.notified().await;
+    }
+}
+
 // On a supervisor restart the pending tells are preserved for the next incarnation, so the hook
 // must not fire.
 #[tokio::test]
@@ -235,6 +249,8 @@ async fn undelivered_not_called_on_restart() {
             undelivered_tx,
             processed_tx,
             started_tx,
+            entered_tx: mpsc::unbounded_channel().0,
+            gate: Arc::new(Notify::new()),
         },
     )
     .restart_policy(RestartPolicy::Permanent)
@@ -256,6 +272,101 @@ async fn undelivered_not_called_on_restart() {
 
     // The hook was never called during the restart.
     assert!(undelivered_rx.try_recv().is_err());
+
+    supervisor.kill();
+    supervisor.wait_for_shutdown().await;
+}
+
+// A supervised actor that has exhausted its restart budget is not actually restarted, so its
+// leftover tells must reach on_undelivered rather than being dropped when the supervisor declines
+// the restart. Regression test for the restart-exhaustion leak.
+#[tokio::test]
+async fn undelivered_called_when_restart_budget_exhausted() {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (processed_tx, _processed_rx) = mpsc::unbounded_channel();
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+
+    let worker = RestartWorker::supervise(
+        &supervisor,
+        RestartWorker {
+            undelivered_tx,
+            processed_tx,
+            started_tx,
+            entered_tx,
+            gate: Arc::new(Notify::new()),
+        },
+    )
+    .restart_policy(RestartPolicy::Permanent)
+    // A budget of zero means the first death already exceeds the limit, so the supervisor never
+    // restarts it.
+    .restart_limit(0, Duration::from_secs(10))
+    .spawn()
+    .await;
+
+    recv(&mut started_rx).await;
+
+    worker.tell(Block).await.unwrap();
+    recv(&mut entered_rx).await; // Block is running (startup finished) and now blocked
+
+    worker.tell(Work(1)).await.unwrap();
+    worker.tell(Work(2)).await.unwrap();
+    worker.tell(Work(3)).await.unwrap();
+
+    worker.kill();
+    worker.wait_for_shutdown().await;
+
+    // The leftover tells reach the hook instead of being dropped by the declining supervisor.
+    assert_eq!(recv(&mut undelivered_rx).await, vec![1, 2, 3]);
+
+    // It was not restarted (no second startup).
+    assert!(started_rx.try_recv().is_err());
+
+    supervisor.kill();
+    supervisor.wait_for_shutdown().await;
+}
+
+// Like the above, but the budget is spent by a genuine restart first, proving the child reads the
+// same live restart count the supervisor mutates.
+#[tokio::test]
+async fn undelivered_called_after_restart_then_exhausted() {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (undelivered_tx, mut undelivered_rx) = mpsc::unbounded_channel();
+    let (processed_tx, _processed_rx) = mpsc::unbounded_channel();
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+
+    let worker = RestartWorker::supervise(
+        &supervisor,
+        RestartWorker {
+            undelivered_tx,
+            processed_tx,
+            started_tx,
+            entered_tx: mpsc::unbounded_channel().0,
+            gate: Arc::new(Notify::new()),
+        },
+    )
+    .restart_policy(RestartPolicy::Permanent)
+    .restart_limit(1, Duration::from_secs(10))
+    .spawn()
+    .await;
+
+    recv(&mut started_rx).await; // incarnation 1
+
+    // Spend the single allowed restart with a panic (nothing else queued, so nothing undelivered).
+    worker.tell(PanicMsg).await.unwrap();
+    recv(&mut started_rx).await; // incarnation 2, budget now exhausted
+
+    // Queue tells behind another panic. `PanicMsg` sleeps before panicking, so the tells are in the
+    // mailbox when incarnation 2 dies. Because the budget is exhausted it is not restarted, so the
+    // tells must reach on_undelivered rather than being preserved or dropped.
+    worker.tell(PanicMsg).await.unwrap();
+    worker.tell(Work(1)).await.unwrap();
+    worker.tell(Work(2)).await.unwrap();
+    worker.tell(Work(3)).await.unwrap();
+
+    assert_eq!(recv(&mut undelivered_rx).await, vec![1, 2, 3]);
+    assert!(started_rx.try_recv().is_err()); // not restarted a second time
 
     supervisor.kill();
     supervisor.wait_for_shutdown().await;


### PR DESCRIPTION
Follow-up to #363. LazyMechanic pointed out a case where the "no message is lost" guarantee still leaked (#335): a supervised actor that dies with queued tells after its restart budget is spent.

## The leak

During teardown the child calls `LinksInner::will_restart` to decide whether it's about to be restarted. That check skipped the restart-limit part (the child couldn't see the supervisor's live restart count), so it assumed a restart would happen. On that assumption `on_undelivered` was skipped and the mailbox was forwarded to the supervisor. The supervisor then ran its own `should_restart`, saw the budget was exhausted, declined the restart, and dropped the forwarded mailbox. The queued tells were lost and `on_undelivered` never fired.

The hook lives on the actor instance, which is gone by the time the supervisor decides, so the supervisor can't run it. The fix is to let the child make the same decision the supervisor will.

## The fix

The restart intensity bookkeeping (count, window, last restart) now lives in a single `RestartTracker` shared by one `Arc` between the supervisor's child spec and the child's links. The supervisor still mutates it authoritatively via `record_restart`; the child reads it via `predict_restart` during teardown. Both sides persist across restarts, so it stays the single source of truth for the whole supervised lifetime.

The child predicts slightly before the supervisor decides, but the restart count only changes on the supervisor's restart path (which hasn't run yet for this death) and `now - last_restart` is monotonic, so the two can only disagree right at a restart-window boundary, and only in the harmless direction: the child hands the tells to `on_undelivered` while the supervisor restarts fresh. No message is dropped. The message-losing direction can't happen. This is documented on `will_restart`.

This also makes the existing `ask` labeling (`ActorRestarting` vs `ActorNotRunning`) exact rather than a best guess.

## Tests

Two regression tests in `tests/on_undelivered.rs`:

- `undelivered_called_when_restart_budget_exhausted`: `restart_limit(0, _)` so the first death already exceeds the budget.
- `undelivered_called_after_restart_then_exhausted`: budget of 1, spent by a real restart first, proving the child sees the same live count the supervisor mutates.

Both hang/fail on the old `will_restart` (the hook never fires) and pass with this change. The full workspace suite passes on default and `--all-features`, along with the supervision suites, clippy, and fmt.
