### PR TITLE
perf(actor)!: make ActorRef cloning a single Arc clone

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -2,7 +2,7 @@ use std::{
     cell::Cell,
     cmp, fmt,
     hash::{Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, Weak},
     time::Duration,
 };
 
@@ -46,13 +46,24 @@ thread_local! {
 /// and telling (without waiting for a reply). It also provides utilities for managing the actor's state,
 /// such as checking if the actor is alive, registering the actor under a name, and stopping the actor gracefully.
 pub struct ActorRef<A: Actor> {
+    /// State shared by all clones of this handle, so cloning is a single `Arc` clone.
+    inner: Arc<ActorRefInner<A>>,
+    /// Per-handle: mutable via [`Self::set_default_reply_timeout`], so clones diverge.
+    default_reply_timeout: Option<Duration>,
+}
+
+/// Shared state behind every clone of an [`ActorRef`].
+///
+/// Holds the one strong [`MailboxSender`] for the handle: the channel stays open while any
+/// `ActorRef` clone (or type-erased wrapper boxing one) is alive, and closes when the last
+/// `Arc<ActorRefInner>` drops.
+struct ActorRefInner<A: Actor> {
     id: ActorId,
     mailbox_sender: MailboxSender<A>,
     abort_handle: AbortHandle,
-    default_reply_timeout: Option<Duration>,
-    pub(crate) links: Links,
-    pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
-    pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+    links: Links,
+    startup_result: Arc<SetOnce<Result<(), PanicError>>>,
+    shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
 }
 
 impl<A> ActorRef<A>
@@ -69,14 +80,23 @@ where
         shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
     ) -> Self {
         ActorRef {
-            id,
-            mailbox_sender: mailbox,
-            abort_handle,
+            inner: Arc::new(ActorRefInner {
+                id,
+                mailbox_sender: mailbox,
+                abort_handle,
+                links,
+                startup_result,
+                shutdown_result,
+            }),
             default_reply_timeout: None,
-            links,
-            startup_result,
-            shutdown_result,
         }
+    }
+
+    /// Returns a reference to the actor's links.
+    #[cfg(any(feature = "console", feature = "remote"))]
+    #[inline]
+    pub(crate) fn links(&self) -> &Links {
+        &self.inner.links
     }
 
     /// Returns the default reply timeout applied to `ask` requests that don't set their own.
@@ -94,7 +114,7 @@ where
     /// Returns the unique identifier of the actor.
     #[inline]
     pub fn id(&self) -> ActorId {
-        self.id
+        self.inner.id
     }
 
     /// Returns whether the actor is currently alive.
@@ -104,7 +124,7 @@ where
     /// [`wait_for_shutdown`](Self::wait_for_shutdown) to wait for the actor to fully stop.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        !self.mailbox_sender.is_closed() && self.mailbox_sender.is_accepting()
+        !self.inner.mailbox_sender.is_closed() && self.inner.mailbox_sender.is_accepting()
     }
 
     /// Registers the actor under a given name in the actor registry.
@@ -215,38 +235,37 @@ where
     #[inline]
     pub fn downgrade(&self) -> WeakActorRef<A> {
         WeakActorRef {
-            id: self.id,
-            mailbox_sender: self.mailbox_sender.downgrade(),
-            abort_handle: self.abort_handle.clone(),
+            id: self.inner.id,
+            inner: Arc::downgrade(&self.inner),
+            mailbox_sender: self.inner.mailbox_sender.downgrade(),
+            abort_handle: self.inner.abort_handle.clone(),
             default_reply_timeout: self.default_reply_timeout,
-            links: self.links.clone(),
-            startup_result: self.startup_result.clone(),
-            shutdown_result: self.shutdown_result.clone(),
+            links: self.inner.links.clone(),
+            startup_result: self.inner.startup_result.clone(),
+            shutdown_result: self.inner.shutdown_result.clone(),
         }
     }
 
+    /// Downgrades, consuming this handle so its strong reference is released.
     pub(crate) fn into_downgrade(self) -> WeakActorRef<A> {
-        WeakActorRef {
-            id: self.id,
-            mailbox_sender: self.mailbox_sender.downgrade(),
-            abort_handle: self.abort_handle,
-            default_reply_timeout: self.default_reply_timeout,
-            links: self.links,
-            startup_result: self.startup_result,
-            shutdown_result: self.shutdown_result,
-        }
+        self.downgrade()
     }
 
     /// Returns the number of [`ActorRef`] handles.
+    ///
+    /// This counts every clone of the actor ref, including type-erased handles wrapping one,
+    /// such as [`Recipient`] and registry entries.
     #[inline]
     pub fn strong_count(&self) -> usize {
-        self.mailbox_sender.strong_count()
+        Arc::strong_count(&self.inner)
     }
 
     /// Returns the number of [`WeakActorRef`] handles.
+    ///
+    /// This includes the weak handle held internally by the actor itself while it runs.
     #[inline]
     pub fn weak_count(&self) -> usize {
-        self.mailbox_sender.weak_count()
+        Arc::weak_count(&self.inner)
     }
 
     /// Returns `true` if the current task is the actor itself.
@@ -256,7 +275,7 @@ where
     pub fn is_current(&self) -> bool {
         CURRENT_ACTOR_ID
             .try_with(Clone::clone)
-            .map(|current_actor_id| current_actor_id == self.id)
+            .map(|current_actor_id| current_actor_id == self.inner.id)
             .unwrap_or(false)
     }
 
@@ -268,8 +287,9 @@ where
     pub async fn stop_gracefully(&self) -> Result<(), SendError> {
         // Reject new user messages before enqueuing the stop signal, so anything sent after this
         // point fails loudly with `ActorNotRunning` instead of being silently queued then dropped.
-        self.mailbox_sender.stop_accepting();
-        self.mailbox_sender
+        self.inner.mailbox_sender.stop_accepting();
+        self.inner
+            .mailbox_sender
             .send(Signal::Stop)
             .await
             .map_err(|_| SendError::ActorNotRunning(()))
@@ -284,7 +304,7 @@ where
     /// Note: If the actor is in the middle of processing a message, it will abort processing of that message.
     #[inline]
     pub fn kill(&self) {
-        self.abort_handle.abort()
+        self.inner.abort_handle.abort()
     }
 
     /// Returns the startup result if the actor has finished starting up, or `None` if startup
@@ -330,7 +350,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.startup_result.get()? {
+        match self.inner.startup_result.get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -383,7 +403,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.startup_result.get()? {
+        match self.inner.startup_result.get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -436,7 +456,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.shutdown_result.get()? {
+        match self.inner.shutdown_result.get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -492,7 +512,7 @@ where
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.shutdown_result.get()? {
+        match self.inner.shutdown_result.get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -536,7 +556,7 @@ where
     /// ```
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.startup_result.wait().await;
+        self.inner.startup_result.wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -576,7 +596,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.startup_result.wait().await {
+        match self.inner.startup_result.wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -623,7 +643,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.startup_result.wait().await {
+        match self.inner.startup_result.wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -641,7 +661,7 @@ where
     /// before calling this method.
     #[inline]
     pub async fn wait_for_shutdown(&self) {
-        self.mailbox_sender.closed().await
+        self.inner.mailbox_sender.closed().await
     }
 
     /// Waits for the actor to finish shutdown, returning the shutdown result with a clone of the error.
@@ -712,8 +732,8 @@ where
     where
         A::Error: Clone,
     {
-        self.mailbox_sender.closed().await;
-        match self.shutdown_result.wait().await {
+        self.inner.mailbox_sender.closed().await;
+        match self.inner.shutdown_result.wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -793,8 +813,8 @@ where
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        self.mailbox_sender.closed().await;
-        match self.shutdown_result.wait().await {
+        self.inner.mailbox_sender.closed().await;
+        match self.inner.shutdown_result.wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -910,32 +930,32 @@ where
     /// ```
     #[inline]
     pub async fn link<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
-            let mut this_links = self.links.lock().await;
-            let mut sibling_links = sibling_ref.links.lock().await;
+        if self.inner.id < sibling_ref.inner.id {
+            let mut this_links = self.inner.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
 
             this_links.sibblings.insert(
-                sibling_ref.id,
+                sibling_ref.inner.id,
                 Link::Local(sibling_ref.weak_signal_mailbox()),
             );
             sibling_links
                 .sibblings
-                .insert(self.id, Link::Local(self.weak_signal_mailbox()));
+                .insert(self.inner.id, Link::Local(self.weak_signal_mailbox()));
         } else {
-            let mut sibling_links = sibling_ref.links.lock().await;
-            let mut this_links = self.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
+            let mut this_links = self.inner.links.lock().await;
 
             this_links.sibblings.insert(
-                sibling_ref.id,
+                sibling_ref.inner.id,
                 Link::Local(sibling_ref.weak_signal_mailbox()),
             );
             sibling_links
                 .sibblings
-                .insert(self.id, Link::Local(self.weak_signal_mailbox()));
+                .insert(self.inner.id, Link::Local(self.weak_signal_mailbox()));
         }
     }
 
@@ -968,32 +988,32 @@ where
     /// [`link`]: ActorRef::link
     #[inline]
     pub fn blocking_link<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
-            let mut this_links = self.links.blocking_lock();
-            let mut sibling_links = sibling_ref.links.blocking_lock();
+        if self.inner.id < sibling_ref.inner.id {
+            let mut this_links = self.inner.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
 
             this_links.sibblings.insert(
-                sibling_ref.id,
+                sibling_ref.inner.id,
                 Link::Local(sibling_ref.weak_signal_mailbox()),
             );
             sibling_links
                 .sibblings
-                .insert(self.id, Link::Local(self.weak_signal_mailbox()));
+                .insert(self.inner.id, Link::Local(self.weak_signal_mailbox()));
         } else {
-            let mut sibling_links = sibling_ref.links.blocking_lock();
-            let mut this_links = self.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
+            let mut this_links = self.inner.links.blocking_lock();
 
             this_links.sibblings.insert(
-                sibling_ref.id,
+                sibling_ref.inner.id,
                 Link::Local(sibling_ref.weak_signal_mailbox()),
             );
             sibling_links
                 .sibblings
-                .insert(self.id, Link::Local(self.weak_signal_mailbox()));
+                .insert(self.inner.id, Link::Local(self.weak_signal_mailbox()));
         }
     }
 
@@ -1003,22 +1023,22 @@ where
         child_links: &Links,
         spec: ErasedChildSpec,
     ) {
-        if self.id == child_id {
+        if self.inner.id == child_id {
             return;
         }
 
-        if self.id < child_id {
-            let mut this_links = self.links.lock().await;
+        if self.inner.id < child_id {
+            let mut this_links = self.inner.links.lock().await;
             let mut child_links = child_links.lock().await;
 
             this_links.children.insert(child_id, spec);
-            child_links.parent = Some((self.id, Link::Local(self.weak_signal_mailbox())));
+            child_links.parent = Some((self.inner.id, Link::Local(self.weak_signal_mailbox())));
         } else {
             let mut child_links = child_links.lock().await;
-            let mut this_links = self.links.lock().await;
+            let mut this_links = self.inner.links.lock().await;
 
             this_links.children.insert(child_id, spec);
-            child_links.parent = Some((self.id, Link::Local(self.weak_signal_mailbox())));
+            child_links.parent = Some((self.inner.id, Link::Local(self.weak_signal_mailbox())));
         }
     }
 
@@ -1053,23 +1073,23 @@ where
         A: remote::RemoteActor,
         B: Actor + remote::RemoteActor,
     {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.id {
             return Ok(());
         }
 
         remote::REMOTE_REGISTRY
             .lock()
             .await
-            .entry(self.id)
+            .entry(self.inner.id)
             .or_insert_with(|| remote::RemoteRegistryActorRef::new(self.clone(), None));
 
-        self.links.lock().await.sibblings.insert(
+        self.inner.links.lock().await.sibblings.insert(
             sibling_ref.id,
             Link::Remote(std::borrow::Cow::Borrowed(B::REMOTE_ID)),
         );
         remote::ActorSwarm::get()
             .ok_or(error::RemoteSendError::SwarmNotBootstrapped)?
-            .link::<A, B>(self.id, sibling_ref.id)
+            .link::<A, B>(self.inner.id, sibling_ref.id)
             .await
     }
 
@@ -1094,22 +1114,22 @@ where
     /// ```
     #[inline]
     pub async fn unlink<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
-            let mut this_links = self.links.lock().await;
-            let mut sibling_links = sibling_ref.links.lock().await;
+        if self.inner.id < sibling_ref.inner.id {
+            let mut this_links = self.inner.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
 
-            this_links.sibblings.remove(&sibling_ref.id);
-            sibling_links.sibblings.remove(&self.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
+            sibling_links.sibblings.remove(&self.inner.id);
         } else {
-            let mut sibling_links = sibling_ref.links.lock().await;
-            let mut this_links = self.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
+            let mut this_links = self.inner.links.lock().await;
 
-            this_links.sibblings.remove(&sibling_ref.id);
-            sibling_links.sibblings.remove(&self.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
+            sibling_links.sibblings.remove(&self.inner.id);
         }
     }
 
@@ -1144,22 +1164,22 @@ where
     /// [`unlink`]: ActorRef::unlink
     #[inline]
     pub fn blocking_unlink<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
-            let mut this_links = self.links.blocking_lock();
-            let mut sibling_links = sibling_ref.links.blocking_lock();
+        if self.inner.id < sibling_ref.inner.id {
+            let mut this_links = self.inner.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
 
-            this_links.sibblings.remove(&sibling_ref.id);
-            sibling_links.sibblings.remove(&self.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
+            sibling_links.sibblings.remove(&self.inner.id);
         } else {
-            let mut sibling_links = sibling_ref.links.blocking_lock();
-            let mut this_links = self.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
+            let mut this_links = self.inner.links.blocking_lock();
 
-            this_links.sibblings.remove(&sibling_ref.id);
-            sibling_links.sibblings.remove(&self.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
+            sibling_links.sibblings.remove(&self.inner.id);
         }
     }
 
@@ -1194,14 +1214,19 @@ where
         A: remote::RemoteActor,
         B: Actor + remote::RemoteActor,
     {
-        if self.id == sibling_ref.id {
+        if self.inner.id == sibling_ref.id {
             return Ok(());
         }
 
-        self.links.lock().await.sibblings.remove(&sibling_ref.id);
+        self.inner
+            .links
+            .lock()
+            .await
+            .sibblings
+            .remove(&sibling_ref.id);
         remote::ActorSwarm::get()
             .ok_or(error::RemoteSendError::SwarmNotBootstrapped)?
-            .unlink::<B>(self.id, sibling_ref.id)
+            .unlink::<B>(self.inner.id, sibling_ref.id)
             .await
     }
 
@@ -1295,7 +1320,7 @@ where
 
     /// Returns a reference to the mailbox sender.
     pub fn mailbox_sender(&self) -> &MailboxSender<A> {
-        &self.mailbox_sender
+        &self.inner.mailbox_sender
     }
 
     /// Converts this ActorRef to a RemoteActorRef, registering it in the actor registry.
@@ -1345,20 +1370,15 @@ where
 
     #[inline]
     pub(crate) fn weak_signal_mailbox(&self) -> Box<dyn SignalMailbox> {
-        Box::new(self.mailbox_sender.downgrade())
+        Box::new(self.inner.mailbox_sender.downgrade())
     }
 }
 
 impl<A: Actor> Clone for ActorRef<A> {
     fn clone(&self) -> Self {
         ActorRef {
-            id: self.id,
-            mailbox_sender: self.mailbox_sender.clone(),
-            abort_handle: self.abort_handle.clone(),
+            inner: Arc::clone(&self.inner),
             default_reply_timeout: self.default_reply_timeout,
-            links: self.links.clone(),
-            startup_result: self.startup_result.clone(),
-            shutdown_result: self.shutdown_result.clone(),
         }
     }
 }
@@ -1366,8 +1386,8 @@ impl<A: Actor> Clone for ActorRef<A> {
 impl<A: Actor> fmt::Debug for ActorRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("ActorRef");
-        d.field("id", &self.id);
-        match self.links.try_lock() {
+        d.field("id", &self.inner.id);
+        match self.inner.links.try_lock() {
             Ok(guard) => {
                 d.field(
                     "parent",
@@ -1386,7 +1406,7 @@ impl<A: Actor> fmt::Debug for ActorRef<A> {
 
 impl<A: Actor> PartialEq for ActorRef<A> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.inner.id == other.inner.id
     }
 }
 
@@ -1400,13 +1420,13 @@ impl<A: Actor> PartialOrd for ActorRef<A> {
 
 impl<A: Actor> Ord for ActorRef<A> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.id.cmp(&other.id)
+        self.inner.id.cmp(&other.inner.id)
     }
 }
 
 impl<A: Actor> Hash for ActorRef<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
+        self.inner.id.hash(state);
     }
 }
 
@@ -2139,6 +2159,11 @@ impl<'de, A: Actor> serde::Deserialize<'de> for RemoteActorRef<A> {
 /// if all `ActorRef`s have been dropped, and otherwise it returns an `ActorRef`.
 pub struct WeakActorRef<A: Actor> {
     id: ActorId,
+    /// Weak handle to the shared state, used for [`Self::upgrade`] and handle counts.
+    inner: Weak<ActorRefInner<A>>,
+    /// The fields below are held directly rather than through `inner`, because the actor's
+    /// own lifecycle task holds a `WeakActorRef` and still needs them during teardown, after
+    /// the last strong handle may already be gone.
     mailbox_sender: WeakMailboxSender<A>,
     abort_handle: AbortHandle,
     default_reply_timeout: Option<Duration>,
@@ -2163,25 +2188,25 @@ impl<A: Actor> WeakActorRef<A> {
     /// if there are other `ActorRef` instances alive, otherwise `None` is returned.
     #[must_use]
     pub fn upgrade(&self) -> Option<ActorRef<A>> {
-        self.mailbox_sender.upgrade().map(|mailbox| ActorRef {
-            id: self.id,
-            mailbox_sender: mailbox,
-            abort_handle: self.abort_handle.clone(),
+        self.inner.upgrade().map(|inner| ActorRef {
+            inner,
             default_reply_timeout: self.default_reply_timeout,
-            links: self.links.clone(),
-            startup_result: self.startup_result.clone(),
-            shutdown_result: self.shutdown_result.clone(),
         })
     }
 
     /// Returns the number of [`ActorRef`] handles.
+    ///
+    /// This counts every clone of the actor ref, including type-erased handles wrapping one,
+    /// such as [`Recipient`] and registry entries.
     pub fn strong_count(&self) -> usize {
-        self.mailbox_sender.strong_count()
+        self.inner.strong_count()
     }
 
     /// Returns the number of [`WeakActorRef`] handles.
+    ///
+    /// This includes the weak handle held internally by the actor itself while it runs.
     pub fn weak_count(&self) -> usize {
-        self.mailbox_sender.weak_count()
+        Weak::weak_count(&self.inner)
     }
 
     /// Returns `true` if the current task is the actor itself.
@@ -2340,21 +2365,21 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::unlink`] for full details and examples.
     #[inline]
     pub async fn unlink<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
+        if self.id < sibling_ref.inner.id {
             let mut this_links = self.links.lock().await;
-            let mut sibling_links = sibling_ref.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
 
-            this_links.sibblings.remove(&sibling_ref.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
             sibling_links.sibblings.remove(&self.id);
         } else {
-            let mut sibling_links = sibling_ref.links.lock().await;
+            let mut sibling_links = sibling_ref.inner.links.lock().await;
             let mut this_links = self.links.lock().await;
 
-            this_links.sibblings.remove(&sibling_ref.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
             sibling_links.sibblings.remove(&self.id);
         }
     }
@@ -2364,21 +2389,21 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::blocking_unlink`] for full details and examples.
     #[inline]
     pub fn blocking_unlink<B: Actor>(&self, sibling_ref: &ActorRef<B>) {
-        if self.id == sibling_ref.id {
+        if self.id == sibling_ref.inner.id {
             return;
         }
 
-        if self.id < sibling_ref.id {
+        if self.id < sibling_ref.inner.id {
             let mut this_links = self.links.blocking_lock();
-            let mut sibling_links = sibling_ref.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
 
-            this_links.sibblings.remove(&sibling_ref.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
             sibling_links.sibblings.remove(&self.id);
         } else {
-            let mut sibling_links = sibling_ref.links.blocking_lock();
+            let mut sibling_links = sibling_ref.inner.links.blocking_lock();
             let mut this_links = self.links.blocking_lock();
 
-            this_links.sibblings.remove(&sibling_ref.id);
+            this_links.sibblings.remove(&sibling_ref.inner.id);
             sibling_links.sibblings.remove(&self.id);
         }
     }
@@ -2454,6 +2479,7 @@ impl<A: Actor> Clone for WeakActorRef<A> {
     fn clone(&self) -> Self {
         WeakActorRef {
             id: self.id,
+            inner: self.inner.clone(),
             mailbox_sender: self.mailbox_sender.clone(),
             abort_handle: self.abort_handle.clone(),
             default_reply_timeout: self.default_reply_timeout,
@@ -2715,7 +2741,7 @@ where
 {
     #[inline]
     fn id(&self) -> ActorId {
-        self.id
+        self.inner.id
     }
 
     #[inline]

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -77,11 +77,7 @@ impl<A: Actor> PreparedActor<A> {
         );
 
         #[cfg(feature = "console")]
-        let monitor = crate::console::registry::register_or_get::<A>(
-            actor_id,
-            actor_ref.mailbox_sender(),
-            &actor_ref.links,
-        );
+        let monitor = crate::console::registry::register_or_get(&actor_ref);
 
         PreparedActor {
             actor_ref,

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -17,10 +17,10 @@ use std::{
 };
 
 use crate::{
-    actor::{Actor, ActorId},
+    actor::{Actor, ActorId, ActorRef, WeakActorRef},
     error::ActorStopReason,
     links::Links,
-    mailbox::{MailboxSender, Signal, WeakMailboxSender},
+    mailbox::Signal,
     supervision::{RestartPolicy, SupervisionStrategy},
 };
 
@@ -56,17 +56,17 @@ trait LiveProbe: Send + Sync {
     fn live_mailbox_len(&self) -> Option<usize>;
 }
 
-impl<A: Actor> LiveProbe for WeakMailboxSender<A> {
+impl<A: Actor> LiveProbe for WeakActorRef<A> {
     fn strong_count(&self) -> usize {
-        WeakMailboxSender::strong_count(self)
+        WeakActorRef::strong_count(self)
     }
 
     fn weak_count(&self) -> usize {
-        WeakMailboxSender::weak_count(self)
+        WeakActorRef::weak_count(self)
     }
 
     fn live_mailbox_len(&self) -> Option<usize> {
-        let tx = self.upgrade()?;
+        let tx = self.mailbox_sender().upgrade()?;
         Some(tx.max_capacity()?.saturating_sub(tx.capacity()?))
     }
 }
@@ -149,7 +149,9 @@ pub(crate) struct ActorMonitor {
     mailbox_kind: wire::MailboxKind,
     mailbox_capacity: Option<usize>,
     links: Links,
-    probe: Box<dyn LiveProbe>,
+    /// Swapped out on restart: each incarnation has its own `ActorRef` allocation, so the
+    /// probe must track the latest one for its handle counts to stay meaningful.
+    probe: Mutex<Box<dyn LiveProbe>>,
     status: AtomicU8,
     stopped: Mutex<Option<Stopped>>,
     current_handler: Mutex<Option<CurrentHandler>>,
@@ -268,6 +270,15 @@ impl ActorMonitor {
             counts
         };
 
+        let (live_mailbox_len, ref_strong, ref_weak) = {
+            let probe = self.probe.lock().unwrap();
+            (
+                probe.live_mailbox_len(),
+                probe.strong_count(),
+                probe.weak_count(),
+            )
+        };
+
         let is_supervisor = !Vec::is_empty(&children);
         let status = self.wire_status();
 
@@ -310,17 +321,14 @@ impl ActorMonitor {
                 kind: self.mailbox_kind,
                 // Prefer the live depth for bounded mailboxes (accurate even mid slow handler);
                 // fall back to the cached value for unbounded or already-dropped ones.
-                len: self
-                    .probe
-                    .live_mailbox_len()
-                    .unwrap_or_else(|| self.mailbox_len.load(Ordering::Relaxed)),
+                len: live_mailbox_len.unwrap_or_else(|| self.mailbox_len.load(Ordering::Relaxed)),
                 capacity: self.mailbox_capacity,
             },
             counters: self.wire_counters(),
             message_types,
             refs: wire::RefCounts {
-                strong: self.probe.strong_count(),
-                weak: self.probe.weak_count(),
+                strong: ref_strong,
+                weak: ref_weak,
             },
             links: wire::Links {
                 parent: parent_id.map(wire_id),
@@ -361,11 +369,9 @@ impl ActorMonitor {
 
 /// Registers a freshly prepared actor, or — when the id already exists — records a restart
 /// of the same logical actor (its id and mailbox are reused across supervised restarts).
-pub(crate) fn register_or_get<A: Actor>(
-    id: ActorId,
-    mailbox_tx: &MailboxSender<A>,
-    links: &Links,
-) -> Arc<ActorMonitor> {
+pub(crate) fn register_or_get<A: Actor>(actor_ref: &ActorRef<A>) -> Arc<ActorMonitor> {
+    let id = actor_ref.id();
+    let mailbox_tx = actor_ref.mailbox_sender();
     let mut registry = REGISTRY.lock().unwrap();
     if let Some(monitor) = registry.get(&id) {
         monitor.restarts.fetch_add(1, Ordering::Relaxed);
@@ -375,6 +381,8 @@ pub(crate) fn register_or_get<A: Actor>(
         // handler here — otherwise the restarted actor would show as forever handling the old
         // message (an ever-growing "Stuck" elapsed).
         *monitor.current_handler.lock().unwrap() = None;
+        // The new incarnation is a new allocation; repoint the probe so handle counts track it.
+        *monitor.probe.lock().unwrap() = Box::new(actor_ref.downgrade());
         monitor.status.store(RESTARTING, Ordering::Relaxed);
         return Arc::clone(monitor);
     }
@@ -400,8 +408,8 @@ pub(crate) fn register_or_get<A: Actor>(
             None => wire::MailboxKind::Unbounded,
         },
         mailbox_capacity: mailbox_tx.max_capacity(),
-        links: links.clone(),
-        probe: Box::new(mailbox_tx.downgrade()),
+        links: actor_ref.links().clone(),
+        probe: Mutex::new(Box::new(actor_ref.downgrade())),
         status: AtomicU8::new(STARTING),
         stopped: Mutex::new(None),
         current_handler: Mutex::new(None),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -99,7 +99,7 @@ pub(crate) struct RemoteRegistryActorRef {
 impl RemoteRegistryActorRef {
     pub(crate) fn new<A: Actor>(actor_ref: ActorRef<A>, name: Option<Arc<str>>) -> Self {
         let signal_mailbox = actor_ref.weak_signal_mailbox();
-        let links = actor_ref.links.clone();
+        let links = actor_ref.links().clone();
         RemoteRegistryActorRef {
             actor_ref: BoxRegisteredActorRef::Strong(Box::new(actor_ref)),
             name,

--- a/src/remote/_internal.rs
+++ b/src/remote/_internal.rs
@@ -230,7 +230,7 @@ where
     };
 
     actor_ref
-        .links
+        .links()
         .lock()
         .await
         .sibblings
@@ -254,7 +254,7 @@ where
             .downcast::<A>()?
     };
 
-    actor_ref.links.lock().await.sibblings.remove(&sibling_id);
+    actor_ref.links().lock().await.sibblings.remove(&sibling_id);
 
     Ok(())
 }

--- a/tests/actor_ref_counts.rs
+++ b/tests/actor_ref_counts.rs
@@ -1,0 +1,133 @@
+//! Handle-count and liveness semantics of `ActorRef`/`WeakActorRef`, which are backed by a
+//! single shared `Arc` so cloning is cheap.
+
+use std::time::Duration;
+
+use kameo::error::Infallible;
+use kameo::prelude::*;
+use tokio::sync::mpsc;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+struct CountActor {
+    stopped_tx: mpsc::UnboundedSender<()>,
+}
+
+struct Ping;
+
+impl Actor for CountActor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+
+    async fn on_stop(
+        &mut self,
+        _: WeakActorRef<Self>,
+        _: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        let _ = self.stopped_tx.send(());
+        Ok(())
+    }
+}
+
+impl Message<Ping> for CountActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Ping, _: &mut Context<Self, Self::Reply>) -> Self::Reply {}
+}
+
+fn new_actor() -> (CountActor, mpsc::UnboundedReceiver<()>) {
+    let (stopped_tx, stopped_rx) = mpsc::unbounded_channel();
+    (CountActor { stopped_tx }, stopped_rx)
+}
+
+async fn wait_stopped(stopped_rx: &mut mpsc::UnboundedReceiver<()>) {
+    tokio::time::timeout(TIMEOUT, stopped_rx.recv())
+        .await
+        .expect("timed out waiting for the actor to stop")
+        .expect("stopped channel closed");
+}
+
+// A prepared (not yet spawned) actor has no lifecycle task touching counts, so they are exact.
+#[tokio::test]
+async fn prepared_actor_counts_are_exact() {
+    let prepared = CountActor::prepare();
+    let actor_ref = prepared.actor_ref().clone();
+
+    // The prepared actor holds one handle, plus ours.
+    assert_eq!(actor_ref.strong_count(), 2);
+
+    let clone = actor_ref.clone();
+    assert_eq!(actor_ref.strong_count(), 3);
+    drop(clone);
+    assert_eq!(actor_ref.strong_count(), 2);
+
+    // Under the console feature the monitor's probe holds a weak handle too, so assert deltas.
+    let baseline_weak = actor_ref.weak_count();
+    let weak = actor_ref.downgrade();
+    assert_eq!(actor_ref.weak_count(), baseline_weak + 1);
+    assert_eq!(weak.strong_count(), 2);
+    drop(weak);
+    assert_eq!(actor_ref.weak_count(), baseline_weak);
+}
+
+// Once running, the actor's own task holds only weak handles, so the user's refs are the only
+// strong counts.
+#[tokio::test]
+async fn clone_and_drop_tracks_strong_count() {
+    let (actor, _stopped_rx) = new_actor();
+    let actor_ref = CountActor::spawn(actor);
+    actor_ref.wait_for_startup().await;
+
+    assert_eq!(actor_ref.strong_count(), 1);
+    let clone1 = actor_ref.clone();
+    let clone2 = actor_ref.clone();
+    assert_eq!(actor_ref.strong_count(), 3);
+    drop(clone1);
+    drop(clone2);
+    assert_eq!(actor_ref.strong_count(), 1);
+}
+
+// A recipient boxes an ActorRef, so it counts as (and acts as) a strong handle.
+#[tokio::test]
+async fn recipient_counts_as_strong_handle() {
+    let (actor, mut stopped_rx) = new_actor();
+    let actor_ref = CountActor::spawn(actor);
+    actor_ref.wait_for_startup().await;
+
+    let recipient = actor_ref.clone().recipient::<Ping>();
+    assert_eq!(actor_ref.strong_count(), 2);
+
+    // The recipient alone keeps the actor alive and usable.
+    drop(actor_ref);
+    assert_eq!(recipient.strong_count(), 1);
+    recipient.tell(Ping).await.expect("tell through recipient");
+
+    // Dropping the last handle stops the actor.
+    drop(recipient);
+    wait_stopped(&mut stopped_rx).await;
+}
+
+#[tokio::test]
+async fn actor_stops_when_last_ref_dropped() {
+    let (actor, mut stopped_rx) = new_actor();
+    let actor_ref = CountActor::spawn(actor);
+    actor_ref.wait_for_startup().await;
+
+    let weak = actor_ref.downgrade();
+
+    // While a strong handle exists, the weak ref upgrades and the upgraded handle works.
+    let upgraded = weak.upgrade().expect("upgrade while actor ref alive");
+    upgraded.ask(Ping).await.expect("ask through upgraded ref");
+    drop(upgraded);
+
+    drop(actor_ref);
+
+    // The last strong handle is gone: no resurrection, and the actor stops.
+    assert!(weak.upgrade().is_none());
+    assert_eq!(weak.strong_count(), 0);
+    wait_stopped(&mut stopped_rx).await;
+}


### PR DESCRIPTION
`ActorRef` had grown to 7 fields, and cloning one performed 5 to 6 separate atomic refcount bumps (mpsc sender, accepting flag, abort handle, links, two `SetOnce` arcs) plus a wide struct copy. This matters beyond user code: every `tell` and `ask` embeds an `ActorRef` clone in `Signal::Message`, so every send paid the full clone cost.

`ActorRef` is now `{ inner: Arc<ActorRefInner>, default_reply_timeout }`, making clone a single `Arc` clone plus a `Copy`. The reply timeout stays outside the arc because `set_default_reply_timeout` takes `&mut self` and clones must be able to diverge.

## Changes

- `ActorRefInner` holds `id`, `mailbox_sender`, `abort_handle`, `links`, `startup_result` and `shutdown_result`. It owns the one strong `MailboxSender` for the handle, so the channel still closes (and the actor still stops) exactly when the last handle drops.
- `WeakActorRef` gains a `Weak<ActorRefInner>` for `upgrade()` and handle counts, but keeps its direct fields: the lifecycle task holds a `WeakActorRef` through teardown and still needs `links` and the result slots after the last strong handle is gone.
- `upgrade()` goes through `Weak::upgrade` instead of re-stronging the mpsc sender. It now returns `Some` only while another `ActorRef` actually exists, which is what its doc already said. Previously it could mint a fresh strong sender even when no `ActorRef` was alive.
- `strong_count()` and `weak_count()` now report handle counts (arc counts) rather than mpsc channel sender counts. The docs always described them as handle counts; the old numbers also included supervisor-held raw senders and other channel noise.
- The console monitor's probe is now a `WeakActorRef` swapped out on restart, since each incarnation gets a fresh allocation. Console ref counts now track real handles.

## Behavior notes

The public API is unchanged. Two observable behaviors shift, both toward the documented semantics:

- `strong_count`/`weak_count` values are handle counts now, as described above.
- `WeakActorRef::upgrade` on a supervised actor whose user handles have all dropped returns `None` instead of `Some`, even though the supervisor keeps the actor running through its own raw senders. Weak refs no longer resurrect handles out of channel internals.

Message dispatch never relied on self-upgrading: handlers receive the strong `ActorRef` embedded in the signal by the sender, so `ctx.actor_ref()` and pipe-to-self are unaffected.

## Tests

New `tests/actor_ref_counts.rs`:

- exact strong/weak counts on a prepared (not yet spawned) actor
- clone/drop tracking on a running actor (the lifecycle task holds only weak handles)
- a recipient counts as a strong handle and alone keeps the actor alive and usable
- dropping the last strong handle stops the actor, and the weak ref neither upgrades nor resurrects it

Full workspace suite plus `console`, `remote`, `metrics` and `--all-features` pass, clippy is clean on default and all features, and the new tests ran repeatedly alongside `on_undelivered` and `supervision_mailbox` without flakes.
