### PR TITLE
fix(pool)!: propagate worker send errors

### DIFF
--- a/actors/src/pool.rs
+++ b/actors/src/pool.rs
@@ -283,10 +283,10 @@ where
     M: Send + 'static,
 {
     type Ok = <A::Reply as Reply>::Ok;
-    type Error = <A::Reply as Reply>::Error;
-    type Value = Result<Self::Ok, SendError<M, Self::Error>>;
+    type Error = SendError<M, <A::Reply as Reply>::Error>;
+    type Value = Result<Self::Ok, Self::Error>;
 
-    fn to_result(self) -> Result<<A::Reply as Reply>::Ok, <A::Reply as Reply>::Error> {
+    fn to_result(self) -> Result<Self::Ok, Self::Error> {
         unimplemented!("a WorkerReply cannot be converted to a result and is only a marker type")
     }
 

--- a/actors/tests/pool.rs
+++ b/actors/tests/pool.rs
@@ -1,0 +1,47 @@
+use kameo::{
+    actor::{Actor, ActorRef, Spawn},
+    error::{Infallible, SendError},
+    message::{Context, Message},
+};
+use kameo_actors::pool::{ActorPool, Dispatch};
+
+#[derive(Debug, PartialEq, Eq)]
+struct Job(u32);
+
+struct Worker;
+
+impl Actor for Worker {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(state)
+    }
+}
+
+impl Message<Job> for Worker {
+    type Reply = u32;
+
+    async fn handle(&mut self, Job(value): Job, _: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        value
+    }
+}
+
+#[tokio::test]
+async fn dispatch_propagates_worker_send_error() {
+    let unavailable_worker = Worker::spawn(Worker);
+    unavailable_worker.kill();
+    unavailable_worker.wait_for_shutdown().await;
+
+    let pool = ActorPool::spawn(ActorPool::new(1, {
+        let unavailable_worker = unavailable_worker.clone();
+        move || unavailable_worker.clone()
+    }));
+
+    let result = pool.ask(Dispatch(Job(42))).await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(SendError::ActorNotRunning(Job(42))))
+    ));
+}


### PR DESCRIPTION
## Problem

`ActorPool` forwards the caller's reply sender through its internal `Worker<A>` proxy. That proxy replies with:

```rust
Result<R::Ok, SendError<M, R::Error>>
```

but `WorkerReply` declared its reply error as only `R::Error`.

When the underlying worker actor was unavailable, the proxy sent a `SendError<M, R::Error>` through the forwarded reply channel. The caller then tried to downcast that boxed error as `R::Error`, which panicked inside `BoxSendError::downcast()`.

## Fix

Align `WorkerReply`'s associated `Error` and `Value` types with the value actually sent by the worker proxy:

```rust
type Error = SendError<M, R::Error>;
type Value = Result<Self::Ok, Self::Error>;
```

`WorkerReply` remains a marker reply type; this patch does not change the forwarding flow or add new API.

## Breaking change

`Dispatch<M>` reply errors now expose the worker `SendError<M, R::Error>` instead of only the inner handler error type. The previous public type did not match the runtime reply and could panic during downcast.

## Tests

Adds `actors/tests/pool.rs` covering a pool whose underlying worker actor is already stopped. The test expects:

```rust
Err(SendError::HandlerError(SendError::ActorNotRunning(Job(42))))
```

instead of a downcast panic.

Verified with:

- `cargo fmt --all -- --check`
- `cargo test -p kameo_actors --test pool`
- `cargo test -p kameo_actors --all-features`
- `cargo clippy -p kameo_actors --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo semver-checks -p kameo_actors`
