### PR TITLE
chore(deps): Update hotpath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ downcast-rs = "2.0.1"
 dyn-clone = "1.0"
 either = { version = "1.15.0", optional = true }
 futures.workspace = true
-hotpath = { version = "0.11", optional = true, features = ["tokio"] }
+hotpath = { version = "0.21", optional = true, features = ["tokio"] }
 libp2p = { version = "0.56.0", features = [
   "cbor",
   "kad",

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -18,6 +18,22 @@ use dyn_clone::DynClone;
 use futures::{FutureExt, future::BoxFuture};
 use tokio::sync::mpsc::{self, error::TryRecvError};
 
+/// Channel endpoint types backing the mailbox. With the `hotpath` feature these are
+/// hotpath's instrumented wrappers around tokio mpsc; they mirror tokio's API and
+/// reuse tokio's error types, so only the endpoint types themselves are swapped.
+#[cfg(not(feature = "hotpath"))]
+mod chan {
+    pub(super) use tokio::sync::mpsc::{
+        Receiver, Sender, UnboundedReceiver, UnboundedSender, WeakSender, WeakUnboundedSender,
+    };
+}
+#[cfg(feature = "hotpath")]
+mod chan {
+    pub(super) use hotpath::wrap::tokio::sync::mpsc::{
+        Receiver, Sender, UnboundedReceiver, UnboundedSender, WeakSender, WeakUnboundedSender,
+    };
+}
+
 use crate::{
     Actor,
     actor::{ActorId, ActorRef},
@@ -112,9 +128,9 @@ pub struct MailboxSender<A: Actor> {
 
 enum MailboxSenderInner<A: Actor> {
     /// Bounded mailbox sender.
-    Bounded(mpsc::Sender<Signal<A>>),
+    Bounded(chan::Sender<Signal<A>>),
     /// Unbounded mailbox sender.
-    Unbounded(mpsc::UnboundedSender<Signal<A>>),
+    Unbounded(chan::UnboundedSender<Signal<A>>),
 }
 
 #[cfg(feature = "metrics")]
@@ -475,9 +491,9 @@ pub struct WeakMailboxSender<A: Actor> {
 
 enum WeakMailboxSenderInner<A: Actor> {
     /// Bounded weak mailbox sender.
-    Bounded(mpsc::WeakSender<Signal<A>>),
+    Bounded(chan::WeakSender<Signal<A>>),
     /// Unbounded weak mailbox sender.
-    Unbounded(mpsc::WeakUnboundedSender<Signal<A>>),
+    Unbounded(chan::WeakUnboundedSender<Signal<A>>),
 }
 
 impl<A: Actor> WeakMailboxSender<A> {
@@ -593,9 +609,9 @@ pub struct MailboxReceiver<A: Actor> {
 
 enum MailboxReceiverInner<A: Actor> {
     /// Bounded mailbox receiver.
-    Bounded(mpsc::Receiver<Signal<A>>),
+    Bounded(chan::Receiver<Signal<A>>),
     /// Unbounded mailbox receiver.
-    Unbounded(mpsc::UnboundedReceiver<Signal<A>>),
+    Unbounded(chan::UnboundedReceiver<Signal<A>>),
 }
 
 impl<A: Actor> MailboxReceiver<A> {

--- a/src/request/ask.rs
+++ b/src/request/ask.rs
@@ -1253,9 +1253,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // hotpath wraps the channel with a proxy on a separate background runtime, making the
-    // observable fill count non-deterministic; backpressure semantics are unchanged.
-    #[cfg_attr(feature = "hotpath", ignore)]
     async fn bounded_ask_requests_mailbox_full() -> Result<(), Box<dyn std::error::Error>> {
         struct MyActor;
 
@@ -1346,10 +1343,7 @@ mod tests {
             Ok(())
         );
         // Mailbox is empty, this will make there be one item in the mailbox
-        #[cfg(not(feature = "hotpath"))]
         let fill_count = 1;
-        #[cfg(feature = "hotpath")]
-        let fill_count = 3; // Sadly, hotpath adds some proxy layers, causing the fill count to be 3 instead of 1
         for _ in 0..fill_count {
             assert_eq!(
                 actor_ref

--- a/src/request/tell.rs
+++ b/src/request/tell.rs
@@ -857,13 +857,10 @@ mod tests {
         let actor_ref = MyActor::spawn_with_mailbox(MyActor, mailbox::bounded(1));
         actor_ref.wait_for_startup().await;
         // We need enough messages to both (a) occupy the actor (sleeping 5s
-        // in the handler) and (b) fill the bounded channel.  Without hotpath
-        // the channel capacity is 1, so 2 messages suffice: the first is
-        // dequeued by the actor after the 2ms yield, the second stays queued.
-        #[cfg(not(feature = "hotpath"))]
+        // in the handler) and (b) fill the bounded channel. The channel
+        // capacity is 1, so 2 messages suffice: the first is dequeued by the
+        // actor after the 2ms yield, the second stays queued.
         let fill_count = 2;
-        #[cfg(feature = "hotpath")]
-        let fill_count = 4;
         for _ in 0..fill_count {
             assert_eq!(actor_ref.tell(Msg).try_send(), Ok(()));
             tokio::time::sleep(Duration::from_millis(2)).await;
@@ -879,9 +876,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // hotpath wraps the channel with a proxy on a separate background runtime, making the
-    // observable fill count non-deterministic; backpressure semantics are unchanged.
-    #[cfg_attr(feature = "hotpath", ignore)]
     async fn bounded_tell_requests_mailbox_timeout() -> Result<(), Box<dyn std::error::Error>> {
         struct MyActor;
 

--- a/tests/on_undelivered.rs
+++ b/tests/on_undelivered.rs
@@ -1,8 +1,3 @@
-// The `hotpath` profiling feature wraps the mailbox channel and changes its delivery timing, so
-// messages sent to a blocked actor aren't reliably drained at teardown. These tests exercise that
-// exact path, so they're skipped under `hotpath` (the hook is covered by every other feature combo).
-#![cfg(not(feature = "hotpath"))]
-
 use std::sync::Arc;
 use std::time::Duration;
 


### PR DESCRIPTION
Hi, this PR updates hotpath version. The primary difference is new `wrap` api used by `hotpath::channel!`. Instead of inserting proxy channels to observe messages, macro now returns new instrumented types. For the price of toggling types depending on feature flag, you'll now get precise delay values, perf histogram, and massively smaller profiling overhead:

```
tokio channel: 100000 send/recv cycles per mode
  baseline (raw)    1071.2 ns/op
  wrap (default)    1124.9 ns/op  (+53.7 ns/op vs baseline)
  proxy = true      6987.4 ns/op  (+5916.2 ns/op vs baseline)
```

A big win is that you no longer need to modify or skip tests for `hotpath` flag. 

As always feedback welcome!