### PR TITLE
feat(kameo_actors): add `FutureActor` for running futures as actors

### DIFF
--- a/actors/src/future.rs
+++ b/actors/src/future.rs
@@ -1,0 +1,55 @@
+//! An actor that runs a future to completion as its behaviour.
+
+use std::{future::Future, pin::Pin};
+
+use kameo::{mailbox::Signal, prelude::*};
+
+/// An actor that runs a future to completion as its behaviour.
+///
+/// The future is driven on the actor's own task, so stopping the actor drops the future and cancels
+/// it. When the future completes, the actor stops: an `Ok` (or non-`Result`) output stops it with
+/// [`ActorStopReason::Normal`], while an `Err` output stops it with [`ActorStopReason::Panicked`],
+/// letting supervisors and linked actors observe the failure.
+///
+/// # Example
+///
+/// ```
+/// use kameo::prelude::*;
+/// use kameo_actors::future::FutureActor;
+///
+/// # tokio_test::block_on(async {
+/// let actor_ref = FutureActor::spawn(async {
+///     // background work
+/// });
+/// # })
+/// ```
+#[derive(Debug)]
+pub struct FutureActor<F>(Pin<Box<F>>);
+
+impl<F> Actor for FutureActor<F>
+where
+    F: Future + Send + 'static,
+    F::Output: Reply,
+{
+    type Args = F;
+    type Error = <F::Output as Reply>::Error;
+
+    async fn on_start(future: F, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(FutureActor(Box::pin(future)))
+    }
+
+    async fn next(
+        &mut self,
+        _: WeakActorRef<Self>,
+        mailbox_rx: &mut MailboxReceiver<Self>,
+    ) -> Result<Option<Signal<Self>>, Self::Error> {
+        tokio::select! {
+            biased;
+            out = &mut self.0 => match out.to_result() {
+                Ok(_) => Ok(None),
+                Err(err) => Err(err),
+            },
+            signal = mailbox_rx.recv() => Ok(signal),
+        }
+    }
+}

--- a/actors/src/lib.rs
+++ b/actors/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides reusable actor components:
 //!
 //! - `broker`: Topic-based message broker
+//! - `future`: Actor that runs a future to completion as its behaviour
 //! - `message_bus`: Type-based message bus
 //! - `pool`: Actor pool for managing concurrent task execution
 //! - `pubsub`: Publish-subscribe pattern implementation for actor communication
@@ -16,6 +17,7 @@
 use std::time::Duration;
 
 pub mod broker;
+pub mod future;
 pub mod message_bus;
 pub mod message_queue;
 pub mod pool;

--- a/actors/tests/future.rs
+++ b/actors/tests/future.rs
@@ -1,0 +1,68 @@
+use std::{
+    future::pending,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use kameo::prelude::*;
+use kameo_actors::future::FutureActor;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+async fn runs_future_to_completion() {
+    let ran = Arc::new(AtomicBool::new(false));
+    let actor_ref = FutureActor::spawn({
+        let ran = ran.clone();
+        async move {
+            ran.store(true, Ordering::SeqCst);
+        }
+    });
+
+    let reason = actor_ref.wait_for_shutdown_result().await.unwrap();
+
+    assert!(ran.load(Ordering::SeqCst), "the future should have run");
+    assert!(matches!(reason, ActorStopReason::Normal));
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TestError;
+
+#[tokio::test]
+async fn err_output_stops_with_error() {
+    let actor_ref = FutureActor::spawn(async { Err::<(), _>(TestError) });
+
+    let reason = actor_ref.wait_for_shutdown_result().await.unwrap();
+
+    let ActorStopReason::Panicked(err) = reason else {
+        panic!("expected Panicked, got {reason:?}");
+    };
+    assert_eq!(err.downcast::<TestError>(), Some(TestError));
+}
+
+#[tokio::test]
+async fn stopping_cancels_pending_future() {
+    struct Guard(Option<oneshot::Sender<()>>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            let _ = self.0.take().unwrap().send(());
+        }
+    }
+
+    let (tx, rx) = oneshot::channel();
+    let guard = Guard(Some(tx));
+    let actor_ref = FutureActor::spawn(async move {
+        let _guard = guard;
+        pending::<()>().await
+    });
+
+    actor_ref.stop_gracefully().await.unwrap();
+
+    // Stopping the actor drops the future, which drops the guard and fires the channel.
+    tokio::time::timeout(Duration::from_secs(5), rx)
+        .await
+        .expect("future was not cancelled when the actor stopped")
+        .unwrap();
+}


### PR DESCRIPTION
cc @npry 

Adds a new `FutureActor` to the kameo_actors crate, allowing you to spawn a regular future as an actor.

The future is driven on the actor's own task, so stopping the actor drops the future and cancels it. When the future completes, the actor stops: an `Ok` (or non-`Result`) output stops it with `ActorStopReason::Normal`, while an `Err` output stops it with `ActorStopReason::Panicked`, letting supervisors and linked actors observe the failure.

## Example

```rust
use kameo::prelude::*;
use kameo_actors::future::FutureActor;

let actor_ref = FutureActor::spawn(async {
    // background work
});
```