### PR TITLE
feat(remote): add kameo_remote crate with gossip registry and TCP messaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
           # kameo_console crate (the TUI; no additional features)
           - package: "kameo_console"
             features: ""
+          # kameo_remote crate (no additional features)
+          - package: "kameo_remote"
+            features: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -150,6 +153,9 @@ jobs:
           # kameo_console crate (the TUI; no additional features)
           - package: "kameo_console"
             features: ""
+          # kameo_remote crate (no additional features)
+          - package: "kameo_remote"
+            features: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -224,6 +230,9 @@ jobs:
             features: ""
           # kameo_console crate (the TUI; no additional features)
           - package: "kameo_console"
+            features: ""
+          # kameo_remote crate (no additional features)
+          - package: "kameo_remote"
             features: ""
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "actors", "console", "macros"]
+members = [".", "actors", "console", "macros", "remote"]
 
 [workspace.dependencies]
 kameo = { path = ".", version = "0.22.1" }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -36,6 +36,13 @@ name = "kameo_console"
 git_tag_name = "console-v{{ version }}"
 git_release_name = "console-v{{ version }}"
 
+[[package]]
+name = "kameo_remote"
+git_tag_name = "remote-v{{ version }}"
+git_release_name = "remote-v{{ version }}"
+# Experimental; flip to true when ready to publish to crates.io.
+release = false
+
 [changelog]
 # Ported from the former cliff.toml. In release-plz the git-cliff commit parsing
 # keys live under [changelog] rather than a separate [git] table.

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "kameo_remote"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88.0"
+description = "Distributed actors for kameo via gossip clustering and TCP messaging"
+readme = "../README.md"
+repository = "https://github.com/tqwewe/kameo"
+license = "MIT OR Apache-2.0"
+keywords = ["actor", "tokio", "distributed", "gossip", "cluster"]
+categories = ["asynchronous", "concurrency", "network-programming"]
+include = ["/src"]
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+chitchat = "0.11"
+futures.workspace = true
+kameo.workspace = true
+rmp-serde = "1.3"
+serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
+serde_json = "1"
+thiserror = "2"
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+tracing = "0.1"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -28,5 +28,5 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/remote/examples/chat.rs
+++ b/remote/examples/chat.rs
@@ -1,0 +1,125 @@
+//! A peer-to-peer chat room with no central server.
+//!
+//! Every node registers its own user actor under the shared name `chat`. Sending a
+//! message looks up all providers and tells each one; presence comes from watching
+//! the provider set change as users join and leave.
+//!
+//! Run in two or more terminals:
+//!
+//! ```sh
+//! cargo run -p kameo_remote --example chat -- alice 127.0.0.1:7400 127.0.0.1:7401
+//! cargo run -p kameo_remote --example chat -- bob 127.0.0.1:7410 127.0.0.1:7411 127.0.0.1:7400
+//! ```
+//!
+//! Arguments: `<username> <gossip addr> <messaging addr> [seed gossip addr...]`
+//!
+//! Exit with ctrl-d to leave gracefully (peers see the departure immediately); a
+//! killed process is noticed by the failure detector after a few seconds.
+
+use std::{collections::HashSet, env, error::Error, pin::pin};
+
+use futures::StreamExt;
+use kameo::prelude::*;
+use kameo_remote::{
+    RemoteActor, RemoteActorId, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig,
+};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncBufReadExt;
+
+#[derive(Actor)]
+struct ChatUser;
+
+#[derive(Serialize, Deserialize)]
+struct ChatMessage {
+    from: String,
+    body: String,
+}
+
+impl Message<ChatMessage> for ChatUser {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ChatMessage, _: &mut Context<Self, Self::Reply>) {
+        println!("{}: {}", msg.from, msg.body);
+    }
+}
+
+impl RemoteMessage for ChatMessage {
+    const REMOTE_ID: &'static str = "chat::ChatMessage";
+}
+
+impl RemoteActor for ChatUser {
+    const REMOTE_ID: &'static str = "chat::ChatUser";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<ChatMessage>();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let username = args.next().expect("missing username");
+    let gossip_addr = args.next().expect("missing gossip addr").parse()?;
+    let messaging_addr = args.next().expect("missing messaging addr").parse()?;
+    let seed_nodes: Vec<String> = args.collect();
+
+    let node = RemoteNode::bootstrap(
+        RemoteNodeConfig::default()
+            .with_node_name(&username)
+            .with_gossip_addr(gossip_addr)
+            .with_messaging_addr(messaging_addr)
+            .with_seed_nodes(seed_nodes),
+    )
+    .await?;
+
+    let user = ChatUser::spawn(ChatUser);
+    node.register(&user, "chat").await?;
+
+    // Print join and leave notices from changes to the provider set.
+    let presence = node.watch::<ChatUser>("chat").await?;
+    let self_id = node.node_id().clone();
+    tokio::spawn(async move {
+        let mut presence = pin!(presence);
+        let mut previous: HashSet<RemoteActorId> = HashSet::new();
+        while let Some(providers) = presence.next().await {
+            let current: HashSet<RemoteActorId> =
+                providers.iter().map(|user| user.id().clone()).collect();
+            for joined in current.difference(&previous) {
+                if joined.node_id != self_id {
+                    println!("* {} joined", joined.node_id);
+                }
+            }
+            for left in previous.difference(&current) {
+                if left.node_id != self_id {
+                    println!("* {} left", left.node_id);
+                }
+            }
+            previous = current;
+        }
+    });
+
+    println!("joined the chat as {username}; type a message and press enter");
+
+    let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+    while let Some(line) = lines.next_line().await? {
+        let body = line.trim();
+        if body.is_empty() {
+            continue;
+        }
+        for peer in node.lookup_all::<ChatUser>("chat").await? {
+            if peer.node_id() == node.node_id() {
+                continue;
+            }
+            let message = ChatMessage {
+                from: username.clone(),
+                body: body.to_string(),
+            };
+            if let Err(err) = peer.tell(&message).await {
+                println!("* failed to reach {}: {err}", peer.node_id());
+            }
+        }
+    }
+
+    node.shutdown().await?;
+    Ok(())
+}

--- a/remote/examples/chat.rs
+++ b/remote/examples/chat.rs
@@ -4,19 +4,22 @@
 //! message looks up all providers and tells each one; presence comes from watching
 //! the provider set change as users join and leave.
 //!
-//! Run in two or more terminals:
+//! Run in two or more terminals. With no arguments, instances discover each other on
+//! localhost automatically: each one claims the first free gossip port in a well-known
+//! range and seeds the rest of the range.
 //!
 //! ```sh
-//! cargo run -p kameo_remote --example chat -- alice 127.0.0.1:7400 127.0.0.1:7401
-//! cargo run -p kameo_remote --example chat -- bob 127.0.0.1:7410 127.0.0.1:7411 127.0.0.1:7400
+//! cargo run -p kameo_remote --example chat
+//! cargo run -p kameo_remote --example chat -- alice
+//! cargo run -p kameo_remote --example chat -- alice 127.0.0.1:7400 127.0.0.1:7401 [seeds...]
 //! ```
 //!
-//! Arguments: `<username> <gossip addr> <messaging addr> [seed gossip addr...]`
+//! Arguments: `[username] [<gossip addr> <messaging addr> [seed gossip addr...]]`
 //!
 //! Exit with ctrl-d to leave gracefully (peers see the departure immediately); a
 //! killed process is noticed by the failure detector after a few seconds.
 
-use std::{collections::HashSet, env, error::Error, pin::pin};
+use std::{collections::HashSet, env, error::Error, net::SocketAddr, pin::pin};
 
 use futures::StreamExt;
 use kameo::prelude::*;
@@ -55,16 +58,45 @@ impl RemoteActor for ChatUser {
     }
 }
 
+/// The well-known localhost gossip ports used for zero-config discovery: an instance
+/// claims the first free one and seeds the others, so up to 10 instances find each
+/// other with no configuration.
+const AUTO_PORTS: std::ops::Range<u16> = 7400..7410;
+
+fn auto_network() -> Result<(SocketAddr, Vec<String>), Box<dyn Error>> {
+    for port in AUTO_PORTS {
+        // Best-effort availability check; bootstrap binds it for real right after.
+        if std::net::UdpSocket::bind(("127.0.0.1", port)).is_ok() {
+            let seeds = AUTO_PORTS
+                .filter(|seed_port| *seed_port != port)
+                .map(|seed_port| format!("127.0.0.1:{seed_port}"))
+                .collect();
+            return Ok((SocketAddr::from(([127, 0, 0, 1], port)), seeds));
+        }
+    }
+    Err(format!("no free gossip port in {AUTO_PORTS:?}; the chat room is full").into())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut args = env::args().skip(1);
-    let username = args.next().expect("missing username");
-    let gossip_addr = args.next().expect("missing gossip addr").parse()?;
-    let messaging_addr = args.next().expect("missing messaging addr").parse()?;
-    let seed_nodes: Vec<String> = args.collect();
+    let username = args
+        .next()
+        .unwrap_or_else(|| format!("user-{}", &uuid::Uuid::new_v4().simple().to_string()[..4]));
+    let (gossip_addr, messaging_addr, seed_nodes) = match args.next() {
+        Some(gossip_addr) => {
+            let messaging_addr = args.next().expect("missing messaging addr").parse()?;
+            (gossip_addr.parse()?, messaging_addr, args.collect())
+        }
+        None => {
+            let (gossip_addr, seeds) = auto_network()?;
+            (gossip_addr, "127.0.0.1:0".parse()?, seeds)
+        }
+    };
 
     let node = RemoteNode::bootstrap(
         RemoteNodeConfig::default()
+            .with_cluster_id("chat-example")
             .with_node_name(&username)
             .with_gossip_addr(gossip_addr)
             .with_messaging_addr(messaging_addr)

--- a/remote/examples/cluster.rs
+++ b/remote/examples/cluster.rs
@@ -1,0 +1,88 @@
+//! A two-node cluster where each node increments the other's counter.
+//!
+//! Run in two terminals:
+//!
+//! ```sh
+//! cargo run -p kameo_remote --example cluster -- 127.0.0.1:7400 127.0.0.1:7401
+//! cargo run -p kameo_remote --example cluster -- 127.0.0.1:7410 127.0.0.1:7411 127.0.0.1:7400
+//! ```
+//!
+//! Arguments: `<gossip addr> <messaging addr> [seed gossip addr...]`
+
+use std::{env, error::Error, time::Duration};
+
+use kameo::prelude::*;
+use kameo_remote::{RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Actor)]
+struct Incrementor {
+    count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inc {
+    amount: i64,
+    from: String,
+}
+
+impl Message<Inc> for Incrementor {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        println!("+{} from {} (count: {})", msg.amount, msg.from, self.count);
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "cluster::Inc";
+}
+
+impl RemoteActor for Incrementor {
+    const REMOTE_ID: &'static str = "cluster::Incrementor";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let gossip_addr = args.next().expect("missing gossip addr").parse()?;
+    let messaging_addr = args.next().expect("missing messaging addr").parse()?;
+    let seed_nodes: Vec<String> = args.collect();
+
+    let node = RemoteNode::bootstrap(
+        RemoteNodeConfig::default()
+            .with_gossip_addr(gossip_addr)
+            .with_messaging_addr(messaging_addr)
+            .with_seed_nodes(seed_nodes),
+    )
+    .await?;
+    println!("started {} on {gossip_addr}", node.node_id());
+
+    let incrementor = Incrementor::spawn(Incrementor { count: 0 });
+    node.register(&incrementor, "incrementor").await?;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        for remote in node.lookup_all::<Incrementor>("incrementor").await? {
+            if remote.node_id() == node.node_id() {
+                continue;
+            }
+            match remote
+                .ask(&Inc {
+                    amount: 1,
+                    from: node.node_id().to_string(),
+                })
+                .await
+            {
+                Ok(count) => println!("{} is now at {count}", remote.node_id()),
+                Err(err) => println!("failed to increment {}: {err}", remote.node_id()),
+            }
+        }
+    }
+}

--- a/remote/examples/watch.rs
+++ b/remote/examples/watch.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
     println!("watching from {}", node.node_id());
 
-    let mut providers = std::pin::pin!(node.watch::<Incrementor>("incrementor").await);
+    let mut providers = std::pin::pin!(node.watch::<Incrementor>("incrementor").await?);
     while let Some(providers) = providers.next().await {
         println!(
             "providers ({}): {:?}",

--- a/remote/examples/watch.rs
+++ b/remote/examples/watch.rs
@@ -1,0 +1,78 @@
+//! Watches the live providers of the `incrementor` name from the `cluster` example.
+//!
+//! Start one or more `cluster` example nodes, then:
+//!
+//! ```sh
+//! cargo run -p kameo_remote --example watch -- 127.0.0.1:7420 127.0.0.1:7421 127.0.0.1:7400
+//! ```
+//!
+//! Arguments: `<gossip addr> <messaging addr> [seed gossip addr...]`
+
+use std::{env, error::Error};
+
+use futures::StreamExt;
+use kameo::prelude::*;
+use kameo_remote::{RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Actor)]
+struct Incrementor {
+    count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inc {
+    amount: i64,
+    from: String,
+}
+
+impl Message<Inc> for Incrementor {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "cluster::Inc";
+}
+
+impl RemoteActor for Incrementor {
+    const REMOTE_ID: &'static str = "cluster::Incrementor";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let gossip_addr = args.next().expect("missing gossip addr").parse()?;
+    let messaging_addr = args.next().expect("missing messaging addr").parse()?;
+    let seed_nodes: Vec<String> = args.collect();
+
+    let node = RemoteNode::bootstrap(
+        RemoteNodeConfig::default()
+            .with_gossip_addr(gossip_addr)
+            .with_messaging_addr(messaging_addr)
+            .with_seed_nodes(seed_nodes),
+    )
+    .await?;
+    println!("watching from {}", node.node_id());
+
+    let mut providers = std::pin::pin!(node.watch::<Incrementor>("incrementor").await);
+    while let Some(providers) = providers.next().await {
+        println!(
+            "providers ({}): {:?}",
+            providers.len(),
+            providers
+                .iter()
+                .map(|provider| provider.id().to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}

--- a/remote/src/dispatch.rs
+++ b/remote/src/dispatch.rs
@@ -68,6 +68,12 @@ impl DispatchTable {
             .insert(name);
     }
 
+    /// Removes all entries, dropping the strong `ActorRef` clones held by the handlers
+    /// so registered actors are no longer kept alive by this node.
+    pub(crate) fn clear(&self) {
+        self.actors.write().unwrap().clear();
+    }
+
     pub(crate) fn remove_name(&self, sequence_id: u64, name: &str) {
         let mut actors = self.actors.write().unwrap();
         if let Some(entry) = actors.get_mut(&sequence_id) {

--- a/remote/src/dispatch.rs
+++ b/remote/src/dispatch.rs
@@ -26,8 +26,10 @@ pub(crate) type DynHandler = Arc<
 >;
 
 /// Registered actors on this node, keyed by their local sequence id.
-#[derive(Default)]
 pub(crate) struct DispatchTable {
+    /// This node incarnation's generation; requests targeting another generation are
+    /// stale references from before a restart and are rejected.
+    generation_id: u64,
     // Sync lock; the guard is never held across an await.
     actors: RwLock<HashMap<u64, ActorEntry>>,
 }
@@ -40,6 +42,13 @@ struct ActorEntry {
 }
 
 impl DispatchTable {
+    pub(crate) fn new(generation_id: u64) -> Self {
+        DispatchTable {
+            generation_id,
+            actors: RwLock::new(HashMap::new()),
+        }
+    }
+
     pub(crate) fn insert(
         &self,
         sequence_id: u64,
@@ -72,6 +81,10 @@ impl DispatchTable {
     /// Resolves a request to its handler. The handler is cloned out so the lock is
     /// released before it is invoked.
     pub(crate) fn resolve(&self, req: &RequestFrame) -> Result<DynHandler, WireError> {
+        if req.target_generation_id != self.generation_id {
+            // A stale reference into a previous incarnation of this node.
+            return Err(WireError::ActorNotRunning);
+        }
         let actors = self.actors.read().unwrap();
         let Some(entry) = actors.get(&req.target_sequence_id) else {
             // The actor was deregistered, stopped, or never existed on this node.

--- a/remote/src/dispatch.rs
+++ b/remote/src/dispatch.rs
@@ -1,0 +1,91 @@
+//! Per-node dispatch tables routing inbound requests to typed handlers.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use futures::future::BoxFuture;
+
+use crate::messaging::protocol::{RequestFrame, WireError};
+
+/// How an inbound request expects to be handled.
+pub(crate) enum InboundKind {
+    Ask { reply_timeout: Option<Duration> },
+    Tell,
+}
+
+/// A type-erased handler for one `(actor, message)` pair.
+///
+/// Returns `Ok(Some(reply_bytes))` for asks, `Ok(None)` for tells.
+pub(crate) type DynHandler = Arc<
+    dyn Fn(Vec<u8>, InboundKind) -> BoxFuture<'static, Result<Option<Vec<u8>>, WireError>>
+        + Send
+        + Sync,
+>;
+
+/// Registered actors on this node, keyed by their local sequence id.
+#[derive(Default)]
+pub(crate) struct DispatchTable {
+    // Sync lock; the guard is never held across an await.
+    actors: RwLock<HashMap<u64, ActorEntry>>,
+}
+
+struct ActorEntry {
+    actor_remote_id: &'static str,
+    handlers: Arc<HashMap<&'static str, DynHandler>>,
+    /// Names this actor is registered under; the entry is dropped with its last name.
+    names: HashSet<String>,
+}
+
+impl DispatchTable {
+    pub(crate) fn insert(
+        &self,
+        sequence_id: u64,
+        actor_remote_id: &'static str,
+        name: String,
+        handlers: HashMap<&'static str, DynHandler>,
+    ) {
+        let mut actors = self.actors.write().unwrap();
+        actors
+            .entry(sequence_id)
+            .or_insert_with(|| ActorEntry {
+                actor_remote_id,
+                handlers: Arc::new(handlers),
+                names: HashSet::new(),
+            })
+            .names
+            .insert(name);
+    }
+
+    pub(crate) fn remove_name(&self, sequence_id: u64, name: &str) {
+        let mut actors = self.actors.write().unwrap();
+        if let Some(entry) = actors.get_mut(&sequence_id) {
+            entry.names.remove(name);
+            if entry.names.is_empty() {
+                actors.remove(&sequence_id);
+            }
+        }
+    }
+
+    /// Resolves a request to its handler. The handler is cloned out so the lock is
+    /// released before it is invoked.
+    pub(crate) fn resolve(&self, req: &RequestFrame) -> Result<DynHandler, WireError> {
+        let actors = self.actors.read().unwrap();
+        let Some(entry) = actors.get(&req.target_sequence_id) else {
+            // The actor was deregistered, stopped, or never existed on this node.
+            return Err(WireError::ActorNotRunning);
+        };
+        if entry.actor_remote_id != req.actor_remote_id {
+            return Err(WireError::BadActorType);
+        }
+        match entry.handlers.get(req.message_remote_id.as_str()) {
+            Some(handler) => Ok(Arc::clone(handler)),
+            None => Err(WireError::UnknownMessage {
+                actor_remote_id: req.actor_remote_id.clone(),
+                message_remote_id: req.message_remote_id.clone(),
+            }),
+        }
+    }
+}

--- a/remote/src/dispatch.rs
+++ b/remote/src/dispatch.rs
@@ -99,11 +99,11 @@ impl DispatchTable {
         if entry.actor_remote_id != req.actor_remote_id {
             return Err(WireError::BadActorType);
         }
-        match entry.handlers.get(req.message_remote_id.as_str()) {
+        match entry.handlers.get(req.message_remote_id.as_ref()) {
             Some(handler) => Ok(Arc::clone(handler)),
             None => Err(WireError::UnknownMessage {
-                actor_remote_id: req.actor_remote_id.clone(),
-                message_remote_id: req.message_remote_id.clone(),
+                actor_remote_id: req.actor_remote_id.to_string(),
+                message_remote_id: req.message_remote_id.to_string(),
             }),
         }
     }

--- a/remote/src/error.rs
+++ b/remote/src/error.rs
@@ -27,6 +27,9 @@ pub enum RegistryError {
     /// The actor name is empty or contains a `:`.
     #[error("invalid actor name {0:?}: must be non-empty and must not contain ':'")]
     InvalidName(String),
+    /// The node has been shut down; its registry can no longer be used.
+    #[error("node has been shut down")]
+    NodeShutdown,
     /// The name is registered, but under a different actor type.
     #[error("actor registered as {name:?} is not of type {expected_remote_id:?}")]
     BadActorType {
@@ -46,12 +49,6 @@ pub enum RemoteSendError<E = Infallible> {
     /// The remote actor stopped before processing the message.
     #[error("actor stopped before reply")]
     ActorStopped,
-    /// The remote node has no registered actor with this remote id.
-    #[error("remote node has no actor with remote id {actor_remote_id:?}")]
-    UnknownActor {
-        /// The actor `REMOTE_ID` sent in the request.
-        actor_remote_id: String,
-    },
     /// The remote actor does not accept this message type remotely.
     #[error("actor {actor_remote_id:?} does not handle remote message {message_remote_id:?}")]
     UnknownMessage {
@@ -104,9 +101,6 @@ impl<E> RemoteSendError<E> {
         match self {
             RemoteSendError::ActorNotRunning => RemoteSendError::ActorNotRunning,
             RemoteSendError::ActorStopped => RemoteSendError::ActorStopped,
-            RemoteSendError::UnknownActor { actor_remote_id } => {
-                RemoteSendError::UnknownActor { actor_remote_id }
-            }
             RemoteSendError::UnknownMessage {
                 actor_remote_id,
                 message_remote_id,

--- a/remote/src/error.rs
+++ b/remote/src/error.rs
@@ -89,7 +89,7 @@ pub enum RemoteSendError<E = Infallible> {
     DeserializeHandlerError(String),
     /// Failed to connect to the remote node.
     #[error("failed to connect to remote node: {0}")]
-    Connect(io::Error),
+    Connect(#[source] io::Error),
     /// The connection closed before a reply was received.
     #[error("connection closed before a reply was received")]
     ConnectionClosed,

--- a/remote/src/error.rs
+++ b/remote/src/error.rs
@@ -1,0 +1,135 @@
+//! Error types for bootstrapping, the registry, and remote messaging.
+
+use std::{convert::Infallible, io};
+
+/// An error which can occur when bootstrapping a [`RemoteNode`](crate::RemoteNode).
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapError {
+    /// Failed to bind the gossip or messaging listener.
+    #[error("failed to bind listener: {0}")]
+    Bind(#[from] io::Error),
+    /// The gossip layer failed to start.
+    #[error("chitchat: {0}")]
+    Chitchat(anyhow::Error),
+}
+
+/// An error which can occur when shutting down a [`RemoteNode`](crate::RemoteNode).
+#[derive(Debug, thiserror::Error)]
+pub enum ShutdownError {
+    /// The gossip layer failed to shut down cleanly.
+    #[error("chitchat: {0}")]
+    Chitchat(anyhow::Error),
+}
+
+/// An error which can occur when registering or looking up actors.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RegistryError {
+    /// The actor name is empty or contains a `:`.
+    #[error("invalid actor name {0:?}: must be non-empty and must not contain ':'")]
+    InvalidName(String),
+    /// The name is registered, but under a different actor type.
+    #[error("actor registered as {name:?} is not of type {expected_remote_id:?}")]
+    BadActorType {
+        /// The name that was looked up.
+        name: String,
+        /// The `REMOTE_ID` of the actor type the lookup expected.
+        expected_remote_id: &'static str,
+    },
+}
+
+/// An error which can occur when sending a message to a remote actor.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoteSendError<E = Infallible> {
+    /// The remote actor is no longer running.
+    #[error("actor not running")]
+    ActorNotRunning,
+    /// The remote actor stopped before processing the message.
+    #[error("actor stopped before reply")]
+    ActorStopped,
+    /// The remote node has no registered actor with this remote id.
+    #[error("remote node has no actor with remote id {actor_remote_id:?}")]
+    UnknownActor {
+        /// The actor `REMOTE_ID` sent in the request.
+        actor_remote_id: String,
+    },
+    /// The remote actor does not accept this message type remotely.
+    #[error("actor {actor_remote_id:?} does not handle remote message {message_remote_id:?}")]
+    UnknownMessage {
+        /// The actor `REMOTE_ID` sent in the request.
+        actor_remote_id: String,
+        /// The message `REMOTE_ID` sent in the request.
+        message_remote_id: String,
+    },
+    /// The registered actor is of a different type than the request expected.
+    #[error("bad actor type")]
+    BadActorType,
+    /// The remote actor's mailbox is full.
+    #[error("mailbox full")]
+    MailboxFull,
+    /// Timed out waiting for a reply.
+    #[error("timed out waiting for reply")]
+    ReplyTimeout,
+    /// The remote actor's handler returned an error.
+    #[error("handler error: {0:?}")]
+    HandlerError(E),
+    /// Failed to serialize the outgoing message.
+    #[error("failed to serialize message: {0}")]
+    SerializeMessage(String),
+    /// The remote node failed to deserialize the message.
+    #[error("failed to deserialize message: {0}")]
+    DeserializeMessage(String),
+    /// The remote node failed to serialize the reply.
+    #[error("failed to serialize reply: {0}")]
+    SerializeReply(String),
+    /// Failed to deserialize the reply.
+    #[error("failed to deserialize reply: {0}")]
+    DeserializeReply(String),
+    /// The remote node failed to serialize the handler error.
+    #[error("failed to serialize handler error: {0}")]
+    SerializeHandlerError(String),
+    /// Failed to deserialize the handler error.
+    #[error("failed to deserialize handler error: {0}")]
+    DeserializeHandlerError(String),
+    /// Failed to connect to the remote node.
+    #[error("failed to connect to remote node: {0}")]
+    Connect(io::Error),
+    /// The connection closed before a reply was received.
+    #[error("connection closed before a reply was received")]
+    ConnectionClosed,
+}
+
+impl<E> RemoteSendError<E> {
+    /// Maps the handler error type.
+    pub fn map_err<F>(self, op: impl FnOnce(E) -> F) -> RemoteSendError<F> {
+        match self {
+            RemoteSendError::ActorNotRunning => RemoteSendError::ActorNotRunning,
+            RemoteSendError::ActorStopped => RemoteSendError::ActorStopped,
+            RemoteSendError::UnknownActor { actor_remote_id } => {
+                RemoteSendError::UnknownActor { actor_remote_id }
+            }
+            RemoteSendError::UnknownMessage {
+                actor_remote_id,
+                message_remote_id,
+            } => RemoteSendError::UnknownMessage {
+                actor_remote_id,
+                message_remote_id,
+            },
+            RemoteSendError::BadActorType => RemoteSendError::BadActorType,
+            RemoteSendError::MailboxFull => RemoteSendError::MailboxFull,
+            RemoteSendError::ReplyTimeout => RemoteSendError::ReplyTimeout,
+            RemoteSendError::HandlerError(err) => RemoteSendError::HandlerError(op(err)),
+            RemoteSendError::SerializeMessage(err) => RemoteSendError::SerializeMessage(err),
+            RemoteSendError::DeserializeMessage(err) => RemoteSendError::DeserializeMessage(err),
+            RemoteSendError::SerializeReply(err) => RemoteSendError::SerializeReply(err),
+            RemoteSendError::DeserializeReply(err) => RemoteSendError::DeserializeReply(err),
+            RemoteSendError::SerializeHandlerError(err) => {
+                RemoteSendError::SerializeHandlerError(err)
+            }
+            RemoteSendError::DeserializeHandlerError(err) => {
+                RemoteSendError::DeserializeHandlerError(err)
+            }
+            RemoteSendError::Connect(err) => RemoteSendError::Connect(err),
+            RemoteSendError::ConnectionClosed => RemoteSendError::ConnectionClosed,
+        }
+    }
+}

--- a/remote/src/error.rs
+++ b/remote/src/error.rs
@@ -93,6 +93,9 @@ pub enum RemoteSendError<E = Infallible> {
     /// The connection closed before a reply was received.
     #[error("connection closed before a reply was received")]
     ConnectionClosed,
+    /// The local node has been shut down; its remote refs can no longer send.
+    #[error("node has been shut down")]
+    NodeShutdown,
 }
 
 impl<E> RemoteSendError<E> {
@@ -124,6 +127,7 @@ impl<E> RemoteSendError<E> {
             }
             RemoteSendError::Connect(err) => RemoteSendError::Connect(err),
             RemoteSendError::ConnectionClosed => RemoteSendError::ConnectionClosed,
+            RemoteSendError::NodeShutdown => RemoteSendError::NodeShutdown,
         }
     }
 }

--- a/remote/src/id.rs
+++ b/remote/src/id.rs
@@ -1,0 +1,70 @@
+//! Identity types for nodes and remote actors.
+
+use std::{fmt, sync::Arc};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A cluster-unique node identity.
+///
+/// This is the gossip node id string, either configured via
+/// [`RemoteNodeConfig::node_name`](crate::RemoteNodeConfig) or generated at bootstrap.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeId(Arc<str>);
+
+impl NodeId {
+    /// Returns the node id as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for NodeId {
+    fn from(s: &str) -> Self {
+        NodeId(Arc::from(s))
+    }
+}
+
+impl From<String> for NodeId {
+    fn from(s: String) -> Self {
+        NodeId(Arc::from(s))
+    }
+}
+
+impl From<Arc<str>> for NodeId {
+    fn from(s: Arc<str>) -> Self {
+        NodeId(s)
+    }
+}
+
+impl Serialize for NodeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for NodeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer).map(NodeId::from)
+    }
+}
+
+/// The identity of a remote actor: the owning node plus the actor's local sequence id.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RemoteActorId {
+    /// The node the actor lives on.
+    pub node_id: NodeId,
+    /// The actor's locally-unique sequence id on that node.
+    pub sequence_id: u64,
+}
+
+impl fmt::Display for RemoteActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{}@{}", self.sequence_id, self.node_id)
+    }
+}

--- a/remote/src/id.rs
+++ b/remote/src/id.rs
@@ -54,11 +54,18 @@ impl<'de> Deserialize<'de> for NodeId {
     }
 }
 
-/// The identity of a remote actor: the owning node plus the actor's local sequence id.
+/// The identity of a remote actor: the owning node incarnation plus the actor's local
+/// sequence id.
+///
+/// The `generation_id` identifies the node's incarnation (it increases on restart), so a
+/// stale reference into a previous incarnation can never reach an unrelated actor that
+/// happens to reuse the same sequence id.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RemoteActorId {
     /// The node the actor lives on.
     pub node_id: NodeId,
+    /// The generation of the node's incarnation the actor was registered in.
+    pub generation_id: u64,
     /// The actor's locally-unique sequence id on that node.
     pub sequence_id: u64,
 }

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -1,0 +1,86 @@
+//! Distributed actors for kameo via gossip clustering and TCP messaging.
+//!
+//! This crate connects kameo actors across nodes without any external infrastructure:
+//!
+//! - **Registry**: actors register under a name and become visible to every node in the
+//!   cluster. Cluster membership and the registry are replicated with gossip
+//!   ([chitchat]), so lookups are local and instant, and a dead node's registrations
+//!   vanish automatically. Any number of actors may share a name (set semantics);
+//!   [`RemoteNode::lookup_all`] returns them all.
+//! - **Messaging**: [`RemoteActorRef::ask`] and [`RemoteActorRef::tell`] send messages
+//!   over plain TCP, with one pooled connection per node pair.
+//!
+//! Nodes join the cluster through seed nodes: a starting node contacts any configured
+//! seed and learns the rest of the membership through gossip.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use kameo::prelude::*;
+//! use kameo_remote::{RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Actor)]
+//! struct Counter {
+//!     count: i64,
+//! }
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Inc {
+//!     amount: i64,
+//! }
+//!
+//! impl Message<Inc> for Counter {
+//!     type Reply = i64;
+//!
+//!     async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+//!         self.count += msg.amount;
+//!         self.count
+//!     }
+//! }
+//!
+//! impl RemoteMessage for Inc {
+//!     const REMOTE_ID: &'static str = "example::Inc";
+//! }
+//!
+//! impl RemoteActor for Counter {
+//!     const REMOTE_ID: &'static str = "example::Counter";
+//!
+//!     fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+//!         handlers.add::<Inc>();
+//!     }
+//! }
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let node = RemoteNode::bootstrap(RemoteNodeConfig::default()).await?;
+//!
+//! let counter = Counter::spawn(Counter { count: 0 });
+//! node.register(&counter, "counter").await?;
+//!
+//! // On any node in the cluster:
+//! if let Some(counter) = node.lookup::<Counter>("counter").await? {
+//!     let count = counter.ask(&Inc { amount: 1 }).await?;
+//!     println!("count: {count}");
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [chitchat]: https://docs.rs/chitchat
+
+mod dispatch;
+mod error;
+mod id;
+mod messaging;
+mod node;
+mod registry;
+mod remote_actor;
+mod remote_ref;
+
+pub use chitchat::FailureDetectorConfig;
+
+pub use error::{BootstrapError, RegistryError, RemoteSendError, ShutdownError};
+pub use id::{NodeId, RemoteActorId};
+pub use node::{RemoteNode, RemoteNodeConfig};
+pub use remote_actor::{RemoteActor, RemoteMessage, RemoteMessages};
+pub use remote_ref::{RemoteActorRef, RemoteAskRequest, RemoteTellRequest};

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -8,7 +8,11 @@
 //!   vanish automatically. Any number of actors may share a name (set semantics);
 //!   [`RemoteNode::lookup_all`] returns them all.
 //! - **Messaging**: [`RemoteActorRef::ask`] and [`RemoteActorRef::tell`] send messages
-//!   over plain TCP, with one pooled connection per node pair.
+//!   over plain TCP, with one pooled connection per node pair. Tells are acknowledged
+//!   on mailbox delivery, matching local tell semantics (with
+//!   [`send_unacked`](RemoteTellRequest::send_unacked) as the fire-and-forget path),
+//!   and refs resolving to the local node dispatch in-process without touching the
+//!   network.
 //!
 //! Nodes join the cluster through seed nodes: a starting node contacts any configured
 //! seed and learns the rest of the membership through gossip.

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -9,11 +9,8 @@
 //!   [`RemoteNode::lookup_all`] returns them all.
 //! - **Messaging**: [`RemoteActorRef::ask`] and [`RemoteActorRef::tell`] send messages
 //!   over plain TCP, with one pooled connection per node pair. Tells are acknowledged
-//!   on mailbox delivery, matching local tell semantics (with
-//!   [`send_unacked`](RemoteTellRequest::send_unacked) as the fire-and-forget path),
-//!   and refs resolving to the local node dispatch in-process without touching the
-//!   network. Messages from one node to one target actor are delivered in send order
-//!   (per-pair FIFO ordering, as in Akka).
+//!   on mailbox delivery, refs resolving to the local node are dispatched in-process,
+//!   and messages from one node to one target actor are delivered in send order.
 //!
 //! Nodes join the cluster through seed nodes: a starting node contacts any configured
 //! seed and learns the rest of the membership through gossip.

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -12,7 +12,8 @@
 //!   on mailbox delivery, matching local tell semantics (with
 //!   [`send_unacked`](RemoteTellRequest::send_unacked) as the fire-and-forget path),
 //!   and refs resolving to the local node dispatch in-process without touching the
-//!   network.
+//!   network. Messages from one node to one target actor are delivered in send order
+//!   (per-pair FIFO ordering, as in Akka).
 //!
 //! Nodes join the cluster through seed nodes: a starting node contacts any configured
 //! seed and learns the rest of the membership through gossip.

--- a/remote/src/messaging/mod.rs
+++ b/remote/src/messaging/mod.rs
@@ -1,0 +1,4 @@
+//! TCP messaging between nodes.
+
+pub(crate) mod protocol;
+pub(crate) mod transport;

--- a/remote/src/messaging/protocol.rs
+++ b/remote/src/messaging/protocol.rs
@@ -56,9 +56,6 @@ pub(crate) enum WireError {
     BadActorType,
     MailboxFull,
     ReplyTimeout,
-    UnknownActor {
-        actor_remote_id: String,
-    },
     UnknownMessage {
         actor_remote_id: String,
         message_remote_id: String,
@@ -152,9 +149,6 @@ mod tests {
             WireError::BadActorType,
             WireError::MailboxFull,
             WireError::ReplyTimeout,
-            WireError::UnknownActor {
-                actor_remote_id: "a".to_string(),
-            },
             WireError::UnknownMessage {
                 actor_remote_id: "a".to_string(),
                 message_remote_id: "m".to_string(),

--- a/remote/src/messaging/protocol.rs
+++ b/remote/src/messaging/protocol.rs
@@ -1,0 +1,160 @@
+//! Wire protocol types exchanged between nodes over TCP.
+//!
+//! Frames are length-delimited (4 byte big-endian prefix) and encoded with MessagePack.
+
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+
+/// A single frame on the wire.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum Frame {
+    Request(RequestFrame),
+    Response(ResponseFrame),
+}
+
+/// A message sent to an actor on a remote node.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct RequestFrame {
+    /// `Some(id)` for asks (a response with this id is expected), `None` for tells.
+    pub request_id: Option<u64>,
+    /// The sequence id of the target actor on the receiving node.
+    pub target_sequence_id: u64,
+    /// The target actor type's `REMOTE_ID`.
+    pub actor_remote_id: String,
+    /// The message type's `REMOTE_ID`.
+    pub message_remote_id: String,
+    /// Reply timeout in milliseconds, asks only.
+    pub reply_timeout_ms: Option<u64>,
+    /// The MessagePack-encoded message.
+    pub payload: ByteBuf,
+}
+
+/// A reply to an ask request.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ResponseFrame {
+    pub request_id: u64,
+    /// The MessagePack-encoded reply, or the error that occurred.
+    pub result: Result<ByteBuf, WireError>,
+}
+
+/// The serializable error subset that crosses the wire.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) enum WireError {
+    ActorNotRunning,
+    ActorStopped,
+    BadActorType,
+    MailboxFull,
+    ReplyTimeout,
+    UnknownActor {
+        actor_remote_id: String,
+    },
+    UnknownMessage {
+        actor_remote_id: String,
+        message_remote_id: String,
+    },
+    /// The MessagePack-encoded handler error.
+    HandlerError(ByteBuf),
+    DeserializeMessage(String),
+    SerializeReply(String),
+    SerializeHandlerError(String),
+}
+
+pub(crate) fn encode(frame: &Frame) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    rmp_serde::to_vec_named(frame)
+}
+
+pub(crate) fn decode(bytes: &[u8]) -> Result<Frame, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(frame: Frame) -> Frame {
+        decode(&encode(&frame).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn request_frame_round_trip() {
+        let frame = round_trip(Frame::Request(RequestFrame {
+            request_id: Some(42),
+            target_sequence_id: 7,
+            actor_remote_id: "my_actor".to_string(),
+            message_remote_id: "my_msg".to_string(),
+            reply_timeout_ms: Some(30_000),
+            payload: ByteBuf::from(vec![1, 2, 3]),
+        }));
+        let Frame::Request(req) = frame else {
+            panic!("expected request frame");
+        };
+        assert_eq!(req.request_id, Some(42));
+        assert_eq!(req.target_sequence_id, 7);
+        assert_eq!(req.actor_remote_id, "my_actor");
+        assert_eq!(req.message_remote_id, "my_msg");
+        assert_eq!(req.reply_timeout_ms, Some(30_000));
+        assert_eq!(req.payload.as_ref(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn tell_frame_round_trip() {
+        let frame = round_trip(Frame::Request(RequestFrame {
+            request_id: None,
+            target_sequence_id: 1,
+            actor_remote_id: "a".to_string(),
+            message_remote_id: "m".to_string(),
+            reply_timeout_ms: None,
+            payload: ByteBuf::new(),
+        }));
+        let Frame::Request(req) = frame else {
+            panic!("expected request frame");
+        };
+        assert_eq!(req.request_id, None);
+        assert_eq!(req.reply_timeout_ms, None);
+    }
+
+    #[test]
+    fn response_ok_round_trip() {
+        let frame = round_trip(Frame::Response(ResponseFrame {
+            request_id: 9,
+            result: Ok(ByteBuf::from(vec![9, 9])),
+        }));
+        let Frame::Response(res) = frame else {
+            panic!("expected response frame");
+        };
+        assert_eq!(res.request_id, 9);
+        assert_eq!(res.result.unwrap().as_ref(), &[9, 9]);
+    }
+
+    #[test]
+    fn response_errors_round_trip() {
+        let errors = vec![
+            WireError::ActorNotRunning,
+            WireError::ActorStopped,
+            WireError::BadActorType,
+            WireError::MailboxFull,
+            WireError::ReplyTimeout,
+            WireError::UnknownActor {
+                actor_remote_id: "a".to_string(),
+            },
+            WireError::UnknownMessage {
+                actor_remote_id: "a".to_string(),
+                message_remote_id: "m".to_string(),
+            },
+            WireError::HandlerError(ByteBuf::from(vec![1])),
+            WireError::DeserializeMessage("bad".to_string()),
+            WireError::SerializeReply("bad".to_string()),
+            WireError::SerializeHandlerError("bad".to_string()),
+        ];
+        for err in errors {
+            let frame = round_trip(Frame::Response(ResponseFrame {
+                request_id: 1,
+                result: Err(err.clone()),
+            }));
+            let Frame::Response(res) = frame else {
+                panic!("expected response frame");
+            };
+            assert_eq!(res.result.unwrap_err(), err);
+        }
+    }
+}

--- a/remote/src/messaging/protocol.rs
+++ b/remote/src/messaging/protocol.rs
@@ -12,11 +12,20 @@ pub(crate) enum Frame {
     Response(ResponseFrame),
 }
 
+/// Whether a request expects a reply value (ask) or only a delivery ack (tell).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub(crate) enum RequestKind {
+    Ask,
+    Tell,
+}
+
 /// A message sent to an actor on a remote node.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct RequestFrame {
-    /// `Some(id)` for asks (a response with this id is expected), `None` for tells.
+    /// `Some(id)` when a response with this id is expected: the reply for asks, a
+    /// delivery ack for tells. `None` means fire-and-forget.
     pub request_id: Option<u64>,
+    pub kind: RequestKind,
     /// The generation of the node incarnation the target actor was registered in.
     pub target_generation_id: u64,
     /// The sequence id of the target actor on the receiving node.
@@ -81,6 +90,7 @@ mod tests {
     fn request_frame_round_trip() {
         let frame = round_trip(Frame::Request(RequestFrame {
             request_id: Some(42),
+            kind: RequestKind::Ask,
             target_generation_id: 3,
             target_sequence_id: 7,
             actor_remote_id: "my_actor".to_string(),
@@ -92,6 +102,7 @@ mod tests {
             panic!("expected request frame");
         };
         assert_eq!(req.request_id, Some(42));
+        assert_eq!(req.kind, RequestKind::Ask);
         assert_eq!(req.target_generation_id, 3);
         assert_eq!(req.target_sequence_id, 7);
         assert_eq!(req.actor_remote_id, "my_actor");
@@ -103,7 +114,8 @@ mod tests {
     #[test]
     fn tell_frame_round_trip() {
         let frame = round_trip(Frame::Request(RequestFrame {
-            request_id: None,
+            request_id: Some(43),
+            kind: RequestKind::Tell,
             target_generation_id: 0,
             target_sequence_id: 1,
             actor_remote_id: "a".to_string(),
@@ -114,7 +126,8 @@ mod tests {
         let Frame::Request(req) = frame else {
             panic!("expected request frame");
         };
-        assert_eq!(req.request_id, None);
+        assert_eq!(req.request_id, Some(43));
+        assert_eq!(req.kind, RequestKind::Tell);
         assert_eq!(req.reply_timeout_ms, None);
     }
 

--- a/remote/src/messaging/protocol.rs
+++ b/remote/src/messaging/protocol.rs
@@ -2,6 +2,8 @@
 //!
 //! Frames are length-delimited (4 byte big-endian prefix) and encoded with MessagePack.
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
@@ -30,10 +32,12 @@ pub(crate) struct RequestFrame {
     pub target_generation_id: u64,
     /// The sequence id of the target actor on the receiving node.
     pub target_sequence_id: u64,
-    /// The target actor type's `REMOTE_ID`.
-    pub actor_remote_id: String,
-    /// The message type's `REMOTE_ID`.
-    pub message_remote_id: String,
+    /// The target actor type's `REMOTE_ID`. Borrowed on the sending side, owned when
+    /// decoded on the receiving side.
+    pub actor_remote_id: Cow<'static, str>,
+    /// The message type's `REMOTE_ID`. Borrowed on the sending side, owned when
+    /// decoded on the receiving side.
+    pub message_remote_id: Cow<'static, str>,
     /// Reply timeout in milliseconds, asks only.
     pub reply_timeout_ms: Option<u64>,
     /// The MessagePack-encoded message.
@@ -90,8 +94,8 @@ mod tests {
             kind: RequestKind::Ask,
             target_generation_id: 3,
             target_sequence_id: 7,
-            actor_remote_id: "my_actor".to_string(),
-            message_remote_id: "my_msg".to_string(),
+            actor_remote_id: "my_actor".into(),
+            message_remote_id: "my_msg".into(),
             reply_timeout_ms: Some(30_000),
             payload: ByteBuf::from(vec![1, 2, 3]),
         }));
@@ -115,8 +119,8 @@ mod tests {
             kind: RequestKind::Tell,
             target_generation_id: 0,
             target_sequence_id: 1,
-            actor_remote_id: "a".to_string(),
-            message_remote_id: "m".to_string(),
+            actor_remote_id: "a".into(),
+            message_remote_id: "m".into(),
             reply_timeout_ms: None,
             payload: ByteBuf::new(),
         }));

--- a/remote/src/messaging/protocol.rs
+++ b/remote/src/messaging/protocol.rs
@@ -17,6 +17,8 @@ pub(crate) enum Frame {
 pub(crate) struct RequestFrame {
     /// `Some(id)` for asks (a response with this id is expected), `None` for tells.
     pub request_id: Option<u64>,
+    /// The generation of the node incarnation the target actor was registered in.
+    pub target_generation_id: u64,
     /// The sequence id of the target actor on the receiving node.
     pub target_sequence_id: u64,
     /// The target actor type's `REMOTE_ID`.
@@ -79,6 +81,7 @@ mod tests {
     fn request_frame_round_trip() {
         let frame = round_trip(Frame::Request(RequestFrame {
             request_id: Some(42),
+            target_generation_id: 3,
             target_sequence_id: 7,
             actor_remote_id: "my_actor".to_string(),
             message_remote_id: "my_msg".to_string(),
@@ -89,6 +92,7 @@ mod tests {
             panic!("expected request frame");
         };
         assert_eq!(req.request_id, Some(42));
+        assert_eq!(req.target_generation_id, 3);
         assert_eq!(req.target_sequence_id, 7);
         assert_eq!(req.actor_remote_id, "my_actor");
         assert_eq!(req.message_remote_id, "my_msg");
@@ -100,6 +104,7 @@ mod tests {
     fn tell_frame_round_trip() {
         let frame = round_trip(Frame::Request(RequestFrame {
             request_id: None,
+            target_generation_id: 0,
             target_sequence_id: 1,
             actor_remote_id: "a".to_string(),
             message_remote_id: "m".to_string(),

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -22,7 +22,7 @@ use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
 
 use crate::{
     dispatch::{DispatchTable, InboundKind},
-    messaging::protocol::{self, Frame, RequestFrame, ResponseFrame, WireError},
+    messaging::protocol::{self, Frame, RequestFrame, RequestKind, ResponseFrame, WireError},
 };
 
 /// An error which can occur when sending a request over the transport.
@@ -82,8 +82,9 @@ impl ConnectionPool {
         self.inner.default_reply_timeout
     }
 
-    /// Sends an ask request and waits for the correlated response.
-    pub(crate) async fn ask(
+    /// Sends a request and waits for the correlated response: the reply for asks, the
+    /// delivery ack for tells.
+    pub(crate) async fn request(
         &self,
         addr: SocketAddr,
         mut req: RequestFrame,
@@ -112,8 +113,8 @@ impl ConnectionPool {
         }
     }
 
-    /// Sends a tell request; returns once the frame is queued to the writer.
-    pub(crate) async fn tell(
+    /// Queues a request without expecting any response (fire-and-forget).
+    pub(crate) async fn enqueue(
         &self,
         addr: SocketAddr,
         mut req: RequestFrame,
@@ -337,11 +338,11 @@ async fn handle_request(
     _permit: OwnedSemaphorePermit,
 ) {
     let request_id = req.request_id;
-    let kind = match request_id {
-        Some(_) => InboundKind::Ask {
+    let kind = match req.kind {
+        RequestKind::Ask => InboundKind::Ask {
             reply_timeout: req.reply_timeout_ms.map(Duration::from_millis),
         },
-        None => InboundKind::Tell,
+        RequestKind::Tell => InboundKind::Tell,
     };
     let result = match dispatch.resolve(&req) {
         Ok(handler) => handler(req.payload.into_vec(), kind).await,

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -1,0 +1,334 @@
+//! TCP transport: client connection pool and server accept loop.
+
+use std::{
+    collections::HashMap,
+    io,
+    net::SocketAddr,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use serde_bytes::ByteBuf;
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::{mpsc, oneshot},
+};
+use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
+
+use crate::{
+    dispatch::{DispatchTable, InboundKind},
+    messaging::protocol::{self, Frame, RequestFrame, ResponseFrame, WireError},
+};
+
+/// An error which can occur when sending a request over the transport.
+#[derive(Debug)]
+pub(crate) enum TransportError {
+    Connect(io::Error),
+    ConnectionClosed,
+    ReplyTimeout,
+    Remote(WireError),
+}
+
+type PendingReplies = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<ByteBuf, WireError>>>>>;
+
+/// A pool of lazily-established connections, one per remote messaging address.
+#[derive(Clone)]
+pub(crate) struct ConnectionPool {
+    inner: Arc<PoolInner>,
+}
+
+struct PoolInner {
+    connections: tokio::sync::Mutex<HashMap<SocketAddr, Connection>>,
+    connect_timeout: Duration,
+    default_reply_timeout: Duration,
+    max_frame_len: usize,
+}
+
+#[derive(Clone)]
+struct Connection {
+    outbound: mpsc::Sender<Frame>,
+    pending: PendingReplies,
+    next_request_id: Arc<AtomicU64>,
+    closed: Arc<AtomicBool>,
+}
+
+impl ConnectionPool {
+    pub(crate) fn new(
+        connect_timeout: Duration,
+        default_reply_timeout: Duration,
+        max_frame_len: usize,
+    ) -> Self {
+        ConnectionPool {
+            inner: Arc::new(PoolInner {
+                connections: tokio::sync::Mutex::new(HashMap::new()),
+                connect_timeout,
+                default_reply_timeout,
+                max_frame_len,
+            }),
+        }
+    }
+
+    pub(crate) fn default_reply_timeout(&self) -> Duration {
+        self.inner.default_reply_timeout
+    }
+
+    /// Sends an ask request and waits for the correlated response.
+    pub(crate) async fn ask(
+        &self,
+        addr: SocketAddr,
+        mut req: RequestFrame,
+        timeout: Duration,
+    ) -> Result<ByteBuf, TransportError> {
+        let conn = self.get_or_connect(addr).await?;
+        let request_id = conn.next_request_id.fetch_add(1, Ordering::Relaxed) + 1;
+        req.request_id = Some(request_id);
+
+        let (tx, rx) = oneshot::channel();
+        conn.pending.lock().unwrap().insert(request_id, tx);
+
+        if conn.outbound.send(Frame::Request(req)).await.is_err() {
+            conn.pending.lock().unwrap().remove(&request_id);
+            return Err(TransportError::ConnectionClosed);
+        }
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(Ok(bytes))) => Ok(bytes),
+            Ok(Ok(Err(err))) => Err(TransportError::Remote(err)),
+            Ok(Err(_)) => Err(TransportError::ConnectionClosed),
+            Err(_) => {
+                conn.pending.lock().unwrap().remove(&request_id);
+                Err(TransportError::ReplyTimeout)
+            }
+        }
+    }
+
+    /// Sends a tell request; returns once the frame is queued to the writer.
+    pub(crate) async fn tell(
+        &self,
+        addr: SocketAddr,
+        mut req: RequestFrame,
+    ) -> Result<(), TransportError> {
+        let conn = self.get_or_connect(addr).await?;
+        req.request_id = None;
+        conn.outbound
+            .send(Frame::Request(req))
+            .await
+            .map_err(|_| TransportError::ConnectionClosed)
+    }
+
+    async fn get_or_connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
+        // The pool lock is held across connect, serialising new dials; acceptable for v1.
+        let mut connections = self.inner.connections.lock().await;
+        if let Some(conn) = connections.get(&addr) {
+            if !conn.closed.load(Ordering::Relaxed) {
+                return Ok(conn.clone());
+            }
+            connections.remove(&addr);
+        }
+
+        let stream = tokio::time::timeout(self.inner.connect_timeout, TcpStream::connect(addr))
+            .await
+            .map_err(|_| {
+                TransportError::Connect(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "connect timed out",
+                ))
+            })?
+            .map_err(TransportError::Connect)?;
+        stream.set_nodelay(true).map_err(TransportError::Connect)?;
+
+        let framed = LengthDelimitedCodec::builder()
+            .max_frame_length(self.inner.max_frame_len)
+            .new_framed(stream);
+        let (mut sink, mut stream) = framed.split();
+
+        let (outbound_tx, mut outbound_rx) = mpsc::channel::<Frame>(1024);
+        let pending: PendingReplies = Arc::new(Mutex::new(HashMap::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+
+        // Writer task: drain outbound frames into the socket.
+        let writer_closed = closed.clone();
+        tokio::spawn(async move {
+            while let Some(frame) = outbound_rx.recv().await {
+                let bytes = match protocol::encode(&frame) {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
+                        tracing::warn!("failed to encode frame: {err}");
+                        continue;
+                    }
+                };
+                if let Err(err) = sink.send(Bytes::from(bytes)).await {
+                    tracing::debug!("connection write failed: {err}");
+                    break;
+                }
+            }
+            writer_closed.store(true, Ordering::Relaxed);
+        });
+
+        // Reader task: route responses to their pending oneshot by request id.
+        let reader_pending = pending.clone();
+        let reader_closed = closed.clone();
+        tokio::spawn(async move {
+            while let Some(result) = stream.next().await {
+                let bytes = match result {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
+                        tracing::debug!("connection read failed: {err}");
+                        break;
+                    }
+                };
+                match protocol::decode(&bytes) {
+                    Ok(Frame::Response(res)) => {
+                        let tx = reader_pending.lock().unwrap().remove(&res.request_id);
+                        if let Some(tx) = tx {
+                            let _ = tx.send(res.result);
+                        }
+                    }
+                    Ok(Frame::Request(_)) => {
+                        tracing::warn!("unexpected request frame on client connection");
+                    }
+                    Err(err) => {
+                        tracing::warn!("failed to decode frame: {err}");
+                        break;
+                    }
+                }
+            }
+            reader_closed.store(true, Ordering::Relaxed);
+            // Fail all in-flight asks by dropping their reply senders; new requests
+            // will reconnect lazily.
+            reader_pending.lock().unwrap().clear();
+        });
+
+        let conn = Connection {
+            outbound: outbound_tx,
+            pending,
+            next_request_id: Arc::new(AtomicU64::new(0)),
+            closed,
+        };
+        connections.insert(addr, conn.clone());
+        Ok(conn)
+    }
+}
+
+/// Accepts inbound connections and dispatches their requests until cancelled.
+pub(crate) async fn run_server(
+    listener: TcpListener,
+    dispatch: Arc<DispatchTable>,
+    cancel: CancellationToken,
+    max_frame_len: usize,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            result = listener.accept() => match result {
+                Ok((stream, _)) => {
+                    tokio::spawn(handle_conn(
+                        stream,
+                        dispatch.clone(),
+                        cancel.child_token(),
+                        max_frame_len,
+                    ));
+                }
+                Err(err) => tracing::warn!("failed to accept connection: {err}"),
+            }
+        }
+    }
+}
+
+async fn handle_conn(
+    stream: TcpStream,
+    dispatch: Arc<DispatchTable>,
+    cancel: CancellationToken,
+    max_frame_len: usize,
+) {
+    if let Err(err) = stream.set_nodelay(true) {
+        tracing::debug!("failed to set nodelay: {err}");
+    }
+    let framed = LengthDelimitedCodec::builder()
+        .max_frame_length(max_frame_len)
+        .new_framed(stream);
+    let (mut sink, mut stream) = framed.split();
+
+    // Replies come from concurrently spawned request tasks, so they are funnelled
+    // through a channel to a single writer.
+    let (reply_tx, mut reply_rx) = mpsc::channel::<ResponseFrame>(1024);
+    tokio::spawn(async move {
+        while let Some(res) = reply_rx.recv().await {
+            let bytes = match protocol::encode(&Frame::Response(res)) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    tracing::warn!("failed to encode response frame: {err}");
+                    continue;
+                }
+            };
+            if let Err(err) = sink.send(Bytes::from(bytes)).await {
+                tracing::debug!("connection write failed: {err}");
+                break;
+            }
+        }
+    });
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            frame = stream.next() => {
+                let bytes = match frame {
+                    None => break,
+                    Some(Err(err)) => {
+                        tracing::warn!("connection read failed: {err}");
+                        break;
+                    }
+                    Some(Ok(bytes)) => bytes,
+                };
+                match protocol::decode(&bytes) {
+                    Ok(Frame::Request(req)) => {
+                        let dispatch = dispatch.clone();
+                        let reply_tx = reply_tx.clone();
+                        tokio::spawn(handle_request(req, dispatch, reply_tx));
+                    }
+                    Ok(Frame::Response(_)) => {
+                        tracing::warn!("unexpected response frame on server connection");
+                    }
+                    Err(err) => {
+                        tracing::warn!("failed to decode frame: {err}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_request(
+    req: RequestFrame,
+    dispatch: Arc<DispatchTable>,
+    reply_tx: mpsc::Sender<ResponseFrame>,
+) {
+    let request_id = req.request_id;
+    let kind = match request_id {
+        Some(_) => InboundKind::Ask {
+            reply_timeout: req.reply_timeout_ms.map(Duration::from_millis),
+        },
+        None => InboundKind::Tell,
+    };
+    let result = match dispatch.resolve(&req) {
+        Ok(handler) => handler(req.payload.into_vec(), kind).await,
+        Err(err) => Err(err),
+    };
+    match request_id {
+        Some(request_id) => {
+            let result = result.map(|reply| ByteBuf::from(reply.unwrap_or_default()));
+            let _ = reply_tx.send(ResponseFrame { request_id, result }).await;
+        }
+        None => {
+            if let Err(err) = result {
+                tracing::warn!("tell dispatch failed: {err:?}");
+            }
+        }
+    }
+}

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -312,12 +312,22 @@ async fn handle_conn(
 
     // One FIFO worker per target actor, so messages from this connection to a given
     // actor are delivered in arrival order, while different target actors are
-    // processed concurrently.
-    let mut workers: HashMap<u64, mpsc::Sender<WorkItem>> = HashMap::new();
+    // processed concurrently. Idle workers are swept periodically so a long-lived
+    // connection does not accumulate tasks for actors it no longer messages.
+    let mut workers: HashMap<u64, Worker> = HashMap::new();
+    let mut idle_sweep = tokio::time::interval(WORKER_IDLE_SWEEP_INTERVAL);
 
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
+            _ = idle_sweep.tick() => {
+                // Only fully drained workers are dropped: this loop is the sole
+                // sender, so processed == sent means nothing is queued or in flight
+                // and removal cannot reorder messages. The next request respawns one.
+                workers.retain(|_, worker| {
+                    worker.processed.load(Ordering::Relaxed) != worker.sent
+                });
+            }
             frame = stream.next() => {
                 let bytes = match frame {
                     None => break,
@@ -344,14 +354,18 @@ async fn handle_conn(
                             });
                             // Never blocks: queued items hold permits, so a worker
                             // queue can never exceed its capacity.
-                            if let Err(err) = worker.send((handler, req, permit)).await {
+                            if let Err(err) = worker.tx.send((handler, req, permit)).await {
                                 // The worker died (e.g. a serialize impl panicked in a
                                 // handler); replace it so the actor stays reachable.
                                 tracing::warn!("request worker exited unexpectedly; restarting it");
-                                let worker =
+                                let mut worker =
                                     spawn_worker(reply_tx.clone(), max_concurrent_requests);
-                                let _ = worker.send(err.0).await;
+                                if worker.tx.send(err.0).await.is_ok() {
+                                    worker.sent += 1;
+                                }
                                 workers.insert(sequence_id, worker);
+                            } else {
+                                worker.sent += 1;
                             }
                         }
                         Err(err) => match req.request_id {
@@ -382,15 +396,31 @@ async fn handle_conn(
 
 type WorkItem = (DynHandler, RequestFrame, OwnedSemaphorePermit);
 
-fn spawn_worker(reply_tx: mpsc::Sender<ResponseFrame>, capacity: usize) -> mpsc::Sender<WorkItem> {
+const WORKER_IDLE_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A per-target-actor FIFO worker, with counters tracking whether it is drained.
+struct Worker {
+    tx: mpsc::Sender<WorkItem>,
+    sent: u64,
+    processed: Arc<AtomicU64>,
+}
+
+fn spawn_worker(reply_tx: mpsc::Sender<ResponseFrame>, capacity: usize) -> Worker {
     let (tx, mut rx) = mpsc::channel::<WorkItem>(capacity);
+    let processed = Arc::new(AtomicU64::new(0));
+    let counter = processed.clone();
     tokio::spawn(async move {
         while let Some((handler, req, permit)) = rx.recv().await {
             handle_request(handler, req, &reply_tx).await;
             drop(permit);
+            counter.fetch_add(1, Ordering::Relaxed);
         }
     });
-    tx
+    Worker {
+        tx,
+        sent: 0,
+        processed,
+    }
 }
 
 async fn handle_request(

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -16,7 +16,7 @@ use futures::{SinkExt, StreamExt};
 use serde_bytes::ByteBuf;
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{mpsc, oneshot},
+    sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot},
 };
 use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
 
@@ -36,6 +36,10 @@ pub(crate) enum TransportError {
 
 type PendingReplies = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<ByteBuf, WireError>>>>>;
 
+/// One pooled connection slot per remote address. Dialing holds only this slot's lock,
+/// so an unreachable peer never stalls sends to other peers.
+type Slot = Arc<tokio::sync::Mutex<Option<Connection>>>;
+
 /// A pool of lazily-established connections, one per remote messaging address.
 #[derive(Clone)]
 pub(crate) struct ConnectionPool {
@@ -43,7 +47,8 @@ pub(crate) struct ConnectionPool {
 }
 
 struct PoolInner {
-    connections: tokio::sync::Mutex<HashMap<SocketAddr, Connection>>,
+    // Sync lock guarding the slot map only; never held across an await.
+    slots: Mutex<HashMap<SocketAddr, Slot>>,
     connect_timeout: Duration,
     default_reply_timeout: Duration,
     max_frame_len: usize,
@@ -65,7 +70,7 @@ impl ConnectionPool {
     ) -> Self {
         ConnectionPool {
             inner: Arc::new(PoolInner {
-                connections: tokio::sync::Mutex::new(HashMap::new()),
+                slots: Mutex::new(HashMap::new()),
                 connect_timeout,
                 default_reply_timeout,
                 max_frame_len,
@@ -122,15 +127,24 @@ impl ConnectionPool {
     }
 
     async fn get_or_connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
-        // The pool lock is held across connect, serialising new dials; acceptable for v1.
-        let mut connections = self.inner.connections.lock().await;
-        if let Some(conn) = connections.get(&addr) {
-            if !conn.closed.load(Ordering::Relaxed) {
-                return Ok(conn.clone());
-            }
-            connections.remove(&addr);
+        let slot = {
+            let mut slots = self.inner.slots.lock().unwrap();
+            slots.entry(addr).or_default().clone()
+        };
+        // Only this address's slot is locked across the dial; concurrent requests to the
+        // same address queue behind a single dial, other addresses are unaffected.
+        let mut guard = slot.lock().await;
+        if let Some(conn) = guard.as_ref()
+            && !conn.closed.load(Ordering::Relaxed)
+        {
+            return Ok(conn.clone());
         }
+        let conn = self.connect(addr).await?;
+        *guard = Some(conn.clone());
+        Ok(conn)
+    }
 
+    async fn connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
         let stream = tokio::time::timeout(self.inner.connect_timeout, TcpStream::connect(addr))
             .await
             .map_err(|_| {
@@ -204,14 +218,12 @@ impl ConnectionPool {
             reader_pending.lock().unwrap().clear();
         });
 
-        let conn = Connection {
+        Ok(Connection {
             outbound: outbound_tx,
             pending,
             next_request_id: Arc::new(AtomicU64::new(0)),
             closed,
-        };
-        connections.insert(addr, conn.clone());
-        Ok(conn)
+        })
     }
 }
 
@@ -221,6 +233,7 @@ pub(crate) async fn run_server(
     dispatch: Arc<DispatchTable>,
     cancel: CancellationToken,
     max_frame_len: usize,
+    max_concurrent_requests: usize,
 ) {
     loop {
         tokio::select! {
@@ -232,6 +245,7 @@ pub(crate) async fn run_server(
                         dispatch.clone(),
                         cancel.child_token(),
                         max_frame_len,
+                        max_concurrent_requests,
                     ));
                 }
                 Err(err) => tracing::warn!("failed to accept connection: {err}"),
@@ -245,6 +259,7 @@ async fn handle_conn(
     dispatch: Arc<DispatchTable>,
     cancel: CancellationToken,
     max_frame_len: usize,
+    max_concurrent_requests: usize,
 ) {
     if let Err(err) = stream.set_nodelay(true) {
         tracing::debug!("failed to set nodelay: {err}");
@@ -273,6 +288,11 @@ async fn handle_conn(
         }
     });
 
+    // Caps concurrently processed requests for this connection. The read loop stops
+    // pulling frames while no permits are available, so overload propagates as TCP
+    // backpressure to the sender instead of unbounded task spawning.
+    let semaphore = Arc::new(Semaphore::new(max_concurrent_requests));
+
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -287,9 +307,15 @@ async fn handle_conn(
                 };
                 match protocol::decode(&bytes) {
                     Ok(Frame::Request(req)) => {
+                        let permit = tokio::select! {
+                            _ = cancel.cancelled() => break,
+                            permit = semaphore.clone().acquire_owned() => {
+                                permit.expect("semaphore is never closed")
+                            }
+                        };
                         let dispatch = dispatch.clone();
                         let reply_tx = reply_tx.clone();
-                        tokio::spawn(handle_request(req, dispatch, reply_tx));
+                        tokio::spawn(handle_request(req, dispatch, reply_tx, permit));
                     }
                     Ok(Frame::Response(_)) => {
                         tracing::warn!("unexpected response frame on server connection");
@@ -308,6 +334,7 @@ async fn handle_request(
     req: RequestFrame,
     dispatch: Arc<DispatchTable>,
     reply_tx: mpsc::Sender<ResponseFrame>,
+    _permit: OwnedSemaphorePermit,
 ) {
     let request_id = req.request_id;
     let kind = match request_id {

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -30,6 +30,7 @@ use crate::{
 pub(crate) enum TransportError {
     Connect(io::Error),
     ConnectionClosed,
+    NodeShutdown,
     ReplyTimeout,
     Remote(WireError),
 }
@@ -49,6 +50,7 @@ pub(crate) struct ConnectionPool {
 struct PoolInner {
     // Sync lock guarding the slot map only; never held across an await.
     slots: Mutex<HashMap<SocketAddr, Slot>>,
+    closed: AtomicBool,
     connect_timeout: Duration,
     default_reply_timeout: Duration,
     max_frame_len: usize,
@@ -71,6 +73,7 @@ impl ConnectionPool {
         ConnectionPool {
             inner: Arc::new(PoolInner {
                 slots: Mutex::new(HashMap::new()),
+                closed: AtomicBool::new(false),
                 connect_timeout,
                 default_reply_timeout,
                 max_frame_len,
@@ -80,6 +83,15 @@ impl ConnectionPool {
 
     pub(crate) fn default_reply_timeout(&self) -> Duration {
         self.inner.default_reply_timeout
+    }
+
+    /// Closes the pool: connections are torn down and further requests fail.
+    ///
+    /// Dropping the pooled connections drops their outbound senders, which ends the
+    /// writer and reader tasks and closes the sockets.
+    pub(crate) fn shutdown(&self) {
+        self.inner.closed.store(true, Ordering::Relaxed);
+        self.inner.slots.lock().unwrap().clear();
     }
 
     /// Sends a request and waits for the correlated response: the reply for asks, the
@@ -128,6 +140,9 @@ impl ConnectionPool {
     }
 
     async fn get_or_connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
+        if self.inner.closed.load(Ordering::Relaxed) {
+            return Err(TransportError::NodeShutdown);
+        }
         let slot = {
             let mut slots = self.inner.slots.lock().unwrap();
             slots.entry(addr).or_default().clone()
@@ -295,8 +310,8 @@ async fn handle_conn(
     let semaphore = Arc::new(Semaphore::new(max_concurrent_requests));
 
     // One FIFO worker per target actor, so messages from this connection to a given
-    // actor are delivered in arrival order (per-pair FIFO ordering, as in Akka), while
-    // different target actors are processed concurrently.
+    // actor are delivered in arrival order, while different target actors are
+    // processed concurrently.
     let mut workers: HashMap<u64, mpsc::Sender<WorkItem>> = HashMap::new();
 
     loop {
@@ -322,15 +337,20 @@ async fn handle_conn(
                                     permit.expect("semaphore is never closed")
                                 }
                             };
-                            let worker = workers
-                                .entry(req.target_sequence_id)
-                                .or_insert_with(|| {
-                                    spawn_worker(reply_tx.clone(), max_concurrent_requests)
-                                });
+                            let sequence_id = req.target_sequence_id;
+                            let worker = workers.entry(sequence_id).or_insert_with(|| {
+                                spawn_worker(reply_tx.clone(), max_concurrent_requests)
+                            });
                             // Never blocks: queued items hold permits, so a worker
                             // queue can never exceed its capacity.
-                            if worker.send((handler, req, permit)).await.is_err() {
-                                tracing::warn!("request worker exited unexpectedly");
+                            if let Err(err) = worker.send((handler, req, permit)).await {
+                                // The worker died (e.g. a serialize impl panicked in a
+                                // handler); replace it so the actor stays reachable.
+                                tracing::warn!("request worker exited unexpectedly; restarting it");
+                                let worker =
+                                    spawn_worker(reply_tx.clone(), max_concurrent_requests);
+                                let _ = worker.send(err.0).await;
+                                workers.insert(sequence_id, worker);
                             }
                         }
                         Err(err) => match req.request_id {

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
 
 use crate::{
-    dispatch::{DispatchTable, InboundKind},
+    dispatch::{DispatchTable, DynHandler, InboundKind},
     messaging::protocol::{self, Frame, RequestFrame, RequestKind, ResponseFrame, WireError},
 };
 
@@ -294,6 +294,11 @@ async fn handle_conn(
     // backpressure to the sender instead of unbounded task spawning.
     let semaphore = Arc::new(Semaphore::new(max_concurrent_requests));
 
+    // One FIFO worker per target actor, so messages from this connection to a given
+    // actor are delivered in arrival order (per-pair FIFO ordering, as in Akka), while
+    // different target actors are processed concurrently.
+    let mut workers: HashMap<u64, mpsc::Sender<WorkItem>> = HashMap::new();
+
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -307,17 +312,39 @@ async fn handle_conn(
                     Some(Ok(bytes)) => bytes,
                 };
                 match protocol::decode(&bytes) {
-                    Ok(Frame::Request(req)) => {
-                        let permit = tokio::select! {
-                            _ = cancel.cancelled() => break,
-                            permit = semaphore.clone().acquire_owned() => {
-                                permit.expect("semaphore is never closed")
+                    // Resolved inline so dispatch errors reply immediately and workers
+                    // only ever exist for registered actors.
+                    Ok(Frame::Request(req)) => match dispatch.resolve(&req) {
+                        Ok(handler) => {
+                            let permit = tokio::select! {
+                                _ = cancel.cancelled() => break,
+                                permit = semaphore.clone().acquire_owned() => {
+                                    permit.expect("semaphore is never closed")
+                                }
+                            };
+                            let worker = workers
+                                .entry(req.target_sequence_id)
+                                .or_insert_with(|| {
+                                    spawn_worker(reply_tx.clone(), max_concurrent_requests)
+                                });
+                            // Never blocks: queued items hold permits, so a worker
+                            // queue can never exceed its capacity.
+                            if worker.send((handler, req, permit)).await.is_err() {
+                                tracing::warn!("request worker exited unexpectedly");
                             }
-                        };
-                        let dispatch = dispatch.clone();
-                        let reply_tx = reply_tx.clone();
-                        tokio::spawn(handle_request(req, dispatch, reply_tx, permit));
-                    }
+                        }
+                        Err(err) => match req.request_id {
+                            Some(request_id) => {
+                                let _ = reply_tx
+                                    .send(ResponseFrame {
+                                        request_id,
+                                        result: Err(err),
+                                    })
+                                    .await;
+                            }
+                            None => tracing::warn!("tell dispatch failed: {err:?}"),
+                        },
+                    },
                     Ok(Frame::Response(_)) => {
                         tracing::warn!("unexpected response frame on server connection");
                     }
@@ -329,13 +356,26 @@ async fn handle_conn(
             }
         }
     }
+    // Dropping the worker map ends the workers once their queues drain.
+}
+
+type WorkItem = (DynHandler, RequestFrame, OwnedSemaphorePermit);
+
+fn spawn_worker(reply_tx: mpsc::Sender<ResponseFrame>, capacity: usize) -> mpsc::Sender<WorkItem> {
+    let (tx, mut rx) = mpsc::channel::<WorkItem>(capacity);
+    tokio::spawn(async move {
+        while let Some((handler, req, permit)) = rx.recv().await {
+            handle_request(handler, req, &reply_tx).await;
+            drop(permit);
+        }
+    });
+    tx
 }
 
 async fn handle_request(
+    handler: DynHandler,
     req: RequestFrame,
-    dispatch: Arc<DispatchTable>,
-    reply_tx: mpsc::Sender<ResponseFrame>,
-    _permit: OwnedSemaphorePermit,
+    reply_tx: &mpsc::Sender<ResponseFrame>,
 ) {
     let request_id = req.request_id;
     let kind = match req.kind {
@@ -344,10 +384,7 @@ async fn handle_request(
         },
         RequestKind::Tell => InboundKind::Tell,
     };
-    let result = match dispatch.resolve(&req) {
-        Ok(handler) => handler(req.payload.into_vec(), kind).await,
-        Err(err) => Err(err),
-    };
+    let result = handler(req.payload.into_vec(), kind).await;
     match request_id {
         Some(request_id) => {
             let result = result.map(|reply| ByteBuf::from(reply.unwrap_or_default()));

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{SinkExt, StreamExt};
+use futures::{FutureExt, SinkExt, StreamExt};
 use serde_bytes::ByteBuf;
 use tokio::{
     net::{TcpListener, TcpStream},
@@ -286,8 +286,9 @@ async fn handle_conn(
     let (mut sink, mut stream) = framed.split();
 
     // Replies come from concurrently spawned request tasks, so they are funnelled
-    // through a channel to a single writer.
-    let (reply_tx, mut reply_rx) = mpsc::channel::<ResponseFrame>(1024);
+    // through a channel to a single writer. Sized to the request cap so replies never
+    // backpressure workers before the request semaphore does.
+    let (reply_tx, mut reply_rx) = mpsc::channel::<ResponseFrame>(max_concurrent_requests);
     tokio::spawn(async move {
         while let Some(res) = reply_rx.recv().await {
             let bytes = match protocol::encode(&Frame::Response(res)) {
@@ -404,7 +405,23 @@ async fn handle_request(
         },
         RequestKind::Tell => InboundKind::Tell,
     };
-    let result = handler(req.payload.into_vec(), kind).await;
+    // Contained so a panicking handler (e.g. in a user serialize impl) cannot kill
+    // the worker and drop the requests queued behind it.
+    let result = match std::panic::AssertUnwindSafe(handler(req.payload.into_vec(), kind))
+        .catch_unwind()
+        .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            tracing::error!(
+                "handler for {:?} on actor {:?} panicked",
+                req.message_remote_id,
+                req.actor_remote_id
+            );
+            // Panics are not part of the wire vocabulary; an asking caller times out.
+            return;
+        }
+    };
     match request_id {
         Some(request_id) => {
             let result = result.map(|reply| ByteBuf::from(reply.unwrap_or_default()));

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -197,6 +197,20 @@ impl RemoteNode {
             }
         });
 
+        // An unspecified advertise address is only usable by an isolated single node:
+        // peers would gossip back or connect to 0.0.0.0 and never reach this node.
+        if gossip_advertise_addr.ip().is_unspecified() {
+            tracing::warn!(
+                "gossip advertise address {gossip_advertise_addr} is unspecified; other nodes \
+                 cannot reach this node, set gossip_advertise_addr or a concrete listen address"
+            );
+        } else if messaging_advertise_addr.ip().is_unspecified() {
+            tracing::warn!(
+                "messaging advertise address {messaging_advertise_addr} is unspecified; other \
+                 nodes cannot message this node, set messaging_advertise_addr"
+            );
+        }
+
         let chitchat_config = ChitchatConfig {
             chitchat_id: ChitchatId::new(node_name.clone(), generation_id, gossip_advertise_addr),
             cluster_id,
@@ -362,6 +376,7 @@ impl RemoteNode {
             &self.inner.chitchat,
             self.inner.pool.clone(),
             self.inner.dispatch.clone(),
+            self.inner.cancel.child_token(),
             name.into(),
         )
         .await)
@@ -446,6 +461,9 @@ impl RemoteNode {
         // Release the registry's strong ActorRefs; local fast-path refs now resolve
         // to nothing, consistent with how remote peers observe the departure.
         self.inner.dispatch.clear();
+        // Tear down outbound connections; remote refs obtained through this node
+        // fail with NodeShutdown from here on.
+        self.inner.pool.shutdown();
         result
     }
 }
@@ -478,5 +496,8 @@ impl Drop for RemoteNodeInner {
         // Local fast-path refs may outlive the node's Arc; without this they would
         // keep dispatching (and keep registered actors alive) after the node is gone.
         self.dispatch.clear();
+        // Remote refs hold pool clones; without this their connections and tasks
+        // would outlive the node.
+        self.pool.shutdown();
     }
 }

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -1,0 +1,393 @@
+//! The remote node: gossip membership, the actor registry, and the messaging server.
+
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use chitchat::{
+    Chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, spawn_chitchat,
+    transport::UdpTransport,
+};
+use futures::Stream;
+use kameo::actor::ActorRef;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    dispatch::DispatchTable,
+    error::{BootstrapError, RegistryError, ShutdownError},
+    id::NodeId,
+    messaging::transport::{ConnectionPool, run_server},
+    registry::{self, RegistrationValue},
+    remote_actor::{RemoteActor, RemoteMessages},
+    remote_ref::RemoteActorRef,
+};
+
+/// Configuration for a [`RemoteNode`].
+pub struct RemoteNodeConfig {
+    /// Cluster name; nodes only gossip within the same cluster id. Default: `"kameo"`.
+    pub cluster_id: String,
+    /// Stable node name, unique across the cluster. Default: generated `node-<uuid>`.
+    pub node_name: Option<String>,
+    /// UDP gossip bind address. Default: `0.0.0.0:7400`. Port 0 binds an ephemeral port.
+    pub gossip_listen_addr: SocketAddr,
+    /// Address other nodes gossip to. Default: the resolved gossip listen address.
+    pub gossip_advertise_addr: Option<SocketAddr>,
+    /// TCP messaging bind address. Default: `0.0.0.0:7401`. Port 0 binds an ephemeral port.
+    pub messaging_listen_addr: SocketAddr,
+    /// Address other nodes connect to for messaging. Default: the messaging listen
+    /// address, with an unspecified IP replaced by the gossip advertise IP.
+    pub messaging_advertise_addr: Option<SocketAddr>,
+    /// Gossip addresses of seed nodes, as `"host:port"`. Hostnames are re-resolved
+    /// periodically, supporting DNS-based discovery. Default: empty.
+    pub seed_nodes: Vec<String>,
+    /// Gossip round interval. Default: 500ms.
+    pub gossip_interval: Duration,
+    /// Failure detector tuning. Default: [`FailureDetectorConfig::default`].
+    pub failure_detector_config: FailureDetectorConfig,
+    /// Grace period before deleted registry keys are garbage collected. Default: 1h.
+    pub marked_for_deletion_grace_period: Duration,
+    /// TCP connect timeout. Default: 10s.
+    pub connect_timeout: Duration,
+    /// Default ask reply timeout when not set per-request. Default: 30s.
+    pub default_reply_timeout: Duration,
+    /// Maximum TCP frame length. Default: 16 MiB.
+    pub max_frame_len: usize,
+}
+
+impl Default for RemoteNodeConfig {
+    fn default() -> Self {
+        RemoteNodeConfig {
+            cluster_id: "kameo".to_string(),
+            node_name: None,
+            gossip_listen_addr: ([0, 0, 0, 0], 7400).into(),
+            gossip_advertise_addr: None,
+            messaging_listen_addr: ([0, 0, 0, 0], 7401).into(),
+            messaging_advertise_addr: None,
+            seed_nodes: Vec::new(),
+            gossip_interval: Duration::from_millis(500),
+            failure_detector_config: FailureDetectorConfig::default(),
+            marked_for_deletion_grace_period: Duration::from_secs(3600),
+            connect_timeout: Duration::from_secs(10),
+            default_reply_timeout: Duration::from_secs(30),
+            max_frame_len: 16 * 1024 * 1024,
+        }
+    }
+}
+
+impl RemoteNodeConfig {
+    /// Sets the cluster id.
+    pub fn with_cluster_id(mut self, cluster_id: impl Into<String>) -> Self {
+        self.cluster_id = cluster_id.into();
+        self
+    }
+
+    /// Sets a stable node name.
+    pub fn with_node_name(mut self, node_name: impl Into<String>) -> Self {
+        self.node_name = Some(node_name.into());
+        self
+    }
+
+    /// Sets the UDP gossip bind address.
+    pub fn with_gossip_addr(mut self, addr: SocketAddr) -> Self {
+        self.gossip_listen_addr = addr;
+        self
+    }
+
+    /// Sets the TCP messaging bind address.
+    pub fn with_messaging_addr(mut self, addr: SocketAddr) -> Self {
+        self.messaging_listen_addr = addr;
+        self
+    }
+
+    /// Sets the seed node gossip addresses.
+    pub fn with_seed_nodes(
+        mut self,
+        seed_nodes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.seed_nodes = seed_nodes.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+/// A node in a kameo cluster.
+///
+/// Bootstrapping a node joins the gossip cluster (via seed nodes) and starts the TCP
+/// messaging server. The node is cheap to clone; all clones share the same state.
+///
+/// Call [`shutdown`](RemoteNode::shutdown) for a clean exit. Dropping the last clone
+/// aborts the background tasks without gossiping a clean departure.
+#[derive(Clone)]
+pub struct RemoteNode {
+    inner: Arc<RemoteNodeInner>,
+}
+
+pub(crate) struct RemoteNodeInner {
+    node_id: NodeId,
+    gossip_advertise_addr: SocketAddr,
+    messaging_advertise_addr: SocketAddr,
+    chitchat: Arc<tokio::sync::Mutex<Chitchat>>,
+    // Option because ChitchatHandle::shutdown consumes the handle.
+    chitchat_handle: tokio::sync::Mutex<Option<ChitchatHandle>>,
+    dispatch: Arc<DispatchTable>,
+    pool: ConnectionPool,
+    server_task: tokio::task::JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+impl RemoteNode {
+    /// Starts a node: binds the gossip and messaging listeners and joins the cluster.
+    pub async fn bootstrap(config: RemoteNodeConfig) -> Result<Self, BootstrapError> {
+        let RemoteNodeConfig {
+            cluster_id,
+            node_name,
+            gossip_listen_addr,
+            gossip_advertise_addr,
+            messaging_listen_addr,
+            messaging_advertise_addr,
+            seed_nodes,
+            gossip_interval,
+            failure_detector_config,
+            marked_for_deletion_grace_period,
+            connect_timeout,
+            default_reply_timeout,
+            max_frame_len,
+        } = config;
+
+        let node_name = node_name
+            .unwrap_or_else(|| format!("node-{}", uuid::Uuid::new_v4().simple()));
+        // Milliseconds so fast restarts still get a strictly higher generation.
+        let generation_id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time is before the unix epoch")
+            .as_millis() as u64;
+
+        // Chitchat needs the advertise address before it binds, so an ephemeral gossip
+        // port is allocated by binding and dropping a socket first. This is best-effort
+        // (another process could grab the port); prefer concrete ports in production.
+        let gossip_listen_addr = if gossip_listen_addr.port() == 0 {
+            let socket = std::net::UdpSocket::bind(gossip_listen_addr)?;
+            socket.local_addr()?
+        } else {
+            gossip_listen_addr
+        };
+        let gossip_advertise_addr = gossip_advertise_addr.unwrap_or(gossip_listen_addr);
+
+        let listener = TcpListener::bind(messaging_listen_addr).await?;
+        let local_addr = listener.local_addr()?;
+        let messaging_advertise_addr = messaging_advertise_addr.unwrap_or_else(|| {
+            if local_addr.ip().is_unspecified() {
+                SocketAddr::new(gossip_advertise_addr.ip(), local_addr.port())
+            } else {
+                local_addr
+            }
+        });
+
+        let chitchat_config = ChitchatConfig {
+            chitchat_id: ChitchatId::new(node_name.clone(), generation_id, gossip_advertise_addr),
+            cluster_id,
+            gossip_interval,
+            listen_addr: gossip_listen_addr,
+            seed_nodes,
+            failure_detector_config,
+            marked_for_deletion_grace_period,
+            catchup_callback: None,
+            extra_liveness_predicate: None,
+        };
+        let handle = spawn_chitchat(
+            chitchat_config,
+            vec![(
+                "kameo:messaging_addr".to_string(),
+                messaging_advertise_addr.to_string(),
+            )],
+            &UdpTransport,
+        )
+        .await
+        .map_err(BootstrapError::Chitchat)?;
+
+        let chitchat = handle.chitchat();
+        let dispatch = Arc::new(DispatchTable::default());
+        let pool = ConnectionPool::new(connect_timeout, default_reply_timeout, max_frame_len);
+        let cancel = CancellationToken::new();
+        let server_task = tokio::spawn(run_server(
+            listener,
+            dispatch.clone(),
+            cancel.child_token(),
+            max_frame_len,
+        ));
+
+        Ok(RemoteNode {
+            inner: Arc::new(RemoteNodeInner {
+                node_id: NodeId::from(node_name),
+                gossip_advertise_addr,
+                messaging_advertise_addr,
+                chitchat,
+                chitchat_handle: tokio::sync::Mutex::new(Some(handle)),
+                dispatch,
+                pool,
+                server_task,
+                cancel,
+            }),
+        })
+    }
+
+    /// Registers an actor under a name, making it visible to all nodes in the cluster.
+    ///
+    /// Multiple actors (on this or other nodes) may register the same name; lookups
+    /// return the whole set. The registration is removed when it is explicitly
+    /// deregistered, when the actor stops, or when this node is declared dead.
+    pub async fn register<A: RemoteActor>(
+        &self,
+        actor_ref: &ActorRef<A>,
+        name: impl Into<String>,
+    ) -> Result<(), RegistryError> {
+        let name = name.into();
+        registry::validate_name(&name)?;
+        let sequence_id = actor_ref.id().sequence_id();
+
+        let mut messages = RemoteMessages::new(actor_ref.clone());
+        A::remote_messages(&mut messages);
+        self.inner.dispatch.insert(
+            sequence_id,
+            A::REMOTE_ID,
+            name.clone(),
+            messages.into_handlers(),
+        );
+
+        let value = RegistrationValue {
+            actor_remote_id: A::REMOTE_ID.to_string(),
+            messaging_addr: self.inner.messaging_advertise_addr,
+        };
+        let value = serde_json::to_string(&value).expect("registration value serializes");
+        {
+            let mut chitchat = self.inner.chitchat.lock().await;
+            chitchat
+                .self_node_state()
+                .set(registry::actor_key(&name, sequence_id), value);
+        }
+
+        // Auto-deregister when the actor stops.
+        let weak_actor = actor_ref.downgrade();
+        let weak_inner = Arc::downgrade(&self.inner);
+        let cancel = self.inner.cancel.child_token();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = cancel.cancelled() => {}
+                _ = weak_actor.wait_for_shutdown() => {
+                    if let Some(inner) = weak_inner.upgrade() {
+                        inner.remove_registration(sequence_id, &name).await;
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Removes a registration. Idempotent; deregistering an unknown name is a no-op.
+    pub async fn deregister<A: RemoteActor>(
+        &self,
+        actor_ref: &ActorRef<A>,
+        name: &str,
+    ) -> Result<(), RegistryError> {
+        registry::validate_name(name)?;
+        self.inner
+            .remove_registration(actor_ref.id().sequence_id(), name)
+            .await;
+        Ok(())
+    }
+
+    /// Looks up an arbitrary live actor registered under `name`.
+    pub async fn lookup<A: RemoteActor>(
+        &self,
+        name: &str,
+    ) -> Result<Option<RemoteActorRef<A>>, RegistryError> {
+        let refs = self.lookup_all(name).await?;
+        Ok(refs.into_iter().next())
+    }
+
+    /// Looks up all live actors registered under `name`, across all nodes.
+    ///
+    /// The result includes actors registered on this node; messages to them loop
+    /// back over TCP.
+    pub async fn lookup_all<A: RemoteActor>(
+        &self,
+        name: &str,
+    ) -> Result<Vec<RemoteActorRef<A>>, RegistryError> {
+        registry::collect_providers(&self.inner.chitchat, &self.inner.pool, name).await
+    }
+
+    /// Watches the live provider set of `name`, yielding it on every change.
+    ///
+    /// The current set is yielded immediately. Changes include registrations,
+    /// deregistrations, and nodes joining or dying.
+    pub async fn watch<A: RemoteActor>(
+        &self,
+        name: impl Into<String>,
+    ) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
+        registry::watch_providers(&self.inner.chitchat, self.inner.pool.clone(), name.into()).await
+    }
+
+    /// Returns this node's id.
+    pub fn node_id(&self) -> &NodeId {
+        &self.inner.node_id
+    }
+
+    /// Returns this node's gossip advertise address.
+    pub fn gossip_addr(&self) -> SocketAddr {
+        self.inner.gossip_advertise_addr
+    }
+
+    /// Returns this node's TCP messaging advertise address.
+    pub fn messaging_addr(&self) -> SocketAddr {
+        self.inner.messaging_advertise_addr
+    }
+
+    /// Returns the ids of the nodes currently considered alive, including this node.
+    pub async fn live_nodes(&self) -> Vec<NodeId> {
+        let chitchat = self.inner.chitchat.lock().await;
+        chitchat
+            .live_nodes()
+            .map(|chitchat_id| NodeId::from(chitchat_id.node_id.clone()))
+            .collect()
+    }
+
+    /// Shuts the node down: stops the messaging server and leaves the gossip cluster.
+    ///
+    /// Idempotent; a second call is a no-op. Registrations are not explicitly removed,
+    /// since other nodes drop them when this node is declared dead.
+    pub async fn shutdown(&self) -> Result<(), ShutdownError> {
+        self.inner.cancel.cancel();
+        let handle = self.inner.chitchat_handle.lock().await.take();
+        if let Some(handle) = handle {
+            handle.shutdown().await.map_err(ShutdownError::Chitchat)?;
+        }
+        Ok(())
+    }
+}
+
+impl RemoteNodeInner {
+    pub(crate) async fn remove_registration(&self, sequence_id: u64, name: &str) {
+        {
+            let mut chitchat = self.chitchat.lock().await;
+            chitchat
+                .self_node_state()
+                .delete(&registry::actor_key(name, sequence_id));
+        }
+        self.dispatch.remove_name(sequence_id, name);
+    }
+}
+
+impl Drop for RemoteNodeInner {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.server_task.abort();
+        if let Ok(mut guard) = self.chitchat_handle.try_lock()
+            && let Some(handle) = guard.take()
+        {
+            handle.abort();
+        }
+    }
+}

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -164,8 +164,8 @@ impl RemoteNode {
             max_concurrent_requests,
         } = config;
 
-        let node_name = node_name
-            .unwrap_or_else(|| format!("node-{}", uuid::Uuid::new_v4().simple()));
+        let node_name =
+            node_name.unwrap_or_else(|| format!("node-{}", uuid::Uuid::new_v4().simple()));
         // Milliseconds so fast restarts still get a strictly higher generation.
         let generation_id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -321,13 +321,19 @@ impl RemoteNode {
 
     /// Looks up all live actors registered under `name`, across all nodes.
     ///
-    /// The result includes actors registered on this node; messages to them loop
-    /// back over TCP.
+    /// The result includes actors registered on this node; messages to them are
+    /// dispatched in-process without touching the network (though still serialized).
     pub async fn lookup_all<A: RemoteActor>(
         &self,
         name: &str,
     ) -> Result<Vec<RemoteActorRef<A>>, RegistryError> {
-        registry::collect_providers(&self.inner.chitchat, &self.inner.pool, name).await
+        registry::collect_providers(
+            &self.inner.chitchat,
+            &self.inner.pool,
+            &self.inner.dispatch,
+            name,
+        )
+        .await
     }
 
     /// Watches the live provider set of `name`, yielding it on every change.
@@ -338,7 +344,13 @@ impl RemoteNode {
         &self,
         name: impl Into<String>,
     ) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
-        registry::watch_providers(&self.inner.chitchat, self.inner.pool.clone(), name.into()).await
+        registry::watch_providers(
+            &self.inner.chitchat,
+            self.inner.pool.clone(),
+            self.inner.dispatch.clone(),
+            name.into(),
+        )
+        .await
     }
 
     /// Returns this node's id.

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -2,7 +2,10 @@
 
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -142,6 +145,7 @@ pub(crate) struct RemoteNodeInner {
     pool: ConnectionPool,
     server_task: tokio::task::JoinHandle<()>,
     cancel: CancellationToken,
+    shutdown: AtomicBool,
 }
 
 impl RemoteNode {
@@ -240,6 +244,7 @@ impl RemoteNode {
                 pool,
                 server_task,
                 cancel,
+                shutdown: AtomicBool::new(false),
             }),
         })
     }
@@ -248,12 +253,17 @@ impl RemoteNode {
     ///
     /// Multiple actors (on this or other nodes) may register the same name; lookups
     /// return the whole set. The registration is removed when it is explicitly
-    /// deregistered, when the actor stops, or when this node is declared dead.
+    /// deregistered, when the actor stops, or when this node shuts down or dies.
+    ///
+    /// The registry holds a strong reference to the actor, so a registered actor is
+    /// kept alive even if all other [`ActorRef`]s are dropped, until one of the above
+    /// removes the registration.
     pub async fn register<A: RemoteActor>(
         &self,
         actor_ref: &ActorRef<A>,
         name: impl Into<String>,
     ) -> Result<(), RegistryError> {
+        self.check_running()?;
         let name = name.into();
         registry::validate_name(&name)?;
         let sequence_id = actor_ref.id().sequence_id();
@@ -303,6 +313,7 @@ impl RemoteNode {
         actor_ref: &ActorRef<A>,
         name: &str,
     ) -> Result<(), RegistryError> {
+        self.check_running()?;
         registry::validate_name(name)?;
         self.inner
             .remove_registration(actor_ref.id().sequence_id(), name)
@@ -327,6 +338,7 @@ impl RemoteNode {
         &self,
         name: &str,
     ) -> Result<Vec<RemoteActorRef<A>>, RegistryError> {
+        self.check_running()?;
         registry::collect_providers(
             &self.inner.chitchat,
             &self.inner.pool,
@@ -339,18 +351,20 @@ impl RemoteNode {
     /// Watches the live provider set of `name`, yielding it on every change.
     ///
     /// The current set is yielded immediately. Changes include registrations,
-    /// deregistrations, and nodes joining or dying.
+    /// deregistrations, and nodes joining or dying. The stream ends when this node
+    /// shuts down.
     pub async fn watch<A: RemoteActor>(
         &self,
         name: impl Into<String>,
-    ) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
-        registry::watch_providers(
+    ) -> Result<impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static, RegistryError> {
+        self.check_running()?;
+        Ok(registry::watch_providers(
             &self.inner.chitchat,
             self.inner.pool.clone(),
             self.inner.dispatch.clone(),
             name.into(),
         )
-        .await
+        .await)
     }
 
     /// Returns this node's id.
@@ -373,7 +387,19 @@ impl RemoteNode {
         self.inner.messaging_advertise_addr
     }
 
+    fn check_running(&self) -> Result<(), RegistryError> {
+        if self.inner.shutdown.load(Ordering::Relaxed) {
+            // After shutdown, gossip is frozen: registrations would never propagate
+            // and lookups would reflect stale liveness, so all registry ops fail.
+            return Err(RegistryError::NodeShutdown);
+        }
+        Ok(())
+    }
+
     /// Returns the ids of the nodes currently considered alive, including this node.
+    ///
+    /// Reflects the last known gossip state; after [`shutdown`](RemoteNode::shutdown)
+    /// this is frozen.
     pub async fn live_nodes(&self) -> Vec<NodeId> {
         let chitchat = self.inner.chitchat.lock().await;
         chitchat
@@ -387,8 +413,11 @@ impl RemoteNode {
     ///
     /// The registrations are deleted and given a couple of gossip rounds to propagate,
     /// so peers observe a clean departure quickly instead of waiting for the failure
-    /// detector. Idempotent; a second call is a no-op.
+    /// detector. The registry's strong references to registered actors are released,
+    /// so actors kept alive only by their registration stop. Idempotent; a second call
+    /// is a no-op.
     pub async fn shutdown(&self) -> Result<(), ShutdownError> {
+        self.inner.shutdown.store(true, Ordering::Relaxed);
         let handle = self.inner.chitchat_handle.lock().await.take();
         let Some(handle) = handle else {
             self.inner.cancel.cancel();
@@ -413,18 +442,25 @@ impl RemoteNode {
         }
 
         self.inner.cancel.cancel();
-        handle.shutdown().await.map_err(ShutdownError::Chitchat)?;
-        Ok(())
+        let result = handle.shutdown().await.map_err(ShutdownError::Chitchat);
+        // Release the registry's strong ActorRefs; local fast-path refs now resolve
+        // to nothing, consistent with how remote peers observe the departure.
+        self.inner.dispatch.clear();
+        result
     }
 }
 
 impl RemoteNodeInner {
     pub(crate) async fn remove_registration(&self, sequence_id: u64, name: &str) {
+        let key = registry::actor_key(name, sequence_id);
         {
             let mut chitchat = self.chitchat.lock().await;
-            chitchat
-                .self_node_state()
-                .delete(&registry::actor_key(name, sequence_id));
+            let state = chitchat.self_node_state();
+            // Guarded so repeated deregistration stays silent and does not bump
+            // tombstone versions.
+            if state.get(&key).is_some() {
+                state.delete(&key);
+            }
         }
         self.dispatch.remove_name(sequence_id, name);
     }
@@ -439,5 +475,8 @@ impl Drop for RemoteNodeInner {
         {
             handle.abort();
         }
+        // Local fast-path refs may outlive the node's Arc; without this they would
+        // keep dispatching (and keep registered actors alive) after the node is gone.
+        self.dispatch.clear();
     }
 }

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -298,6 +298,14 @@ impl RemoteNode {
         let value = serde_json::to_string(&value).expect("registration value serializes");
         {
             let mut chitchat = self.inner.chitchat.lock().await;
+            // Re-checked under the lock: shutdown deletes registry keys under this
+            // lock after setting the flag, so a racing registration cannot slip in
+            // after the deletion sweep and gossip out from a shut-down node.
+            if self.inner.shutdown.load(Ordering::Relaxed) {
+                drop(chitchat);
+                self.inner.dispatch.remove_name(sequence_id, &name);
+                return Err(RegistryError::NodeShutdown);
+            }
             chitchat
                 .self_node_state()
                 .set(registry::actor_key(&name, sequence_id), value);
@@ -348,6 +356,11 @@ impl RemoteNode {
     ///
     /// The result includes actors registered on this node; messages to them are
     /// dispatched in-process without touching the network (though still serialized).
+    ///
+    /// Registrations under `name` whose actor type is not `A` are skipped. If the name
+    /// exists but only under other actor types, this fails with
+    /// [`RegistryError::BadActorType`]; a name with no registrations at all yields an
+    /// empty result.
     pub async fn lookup_all<A: RemoteActor>(
         &self,
         name: &str,

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -55,6 +55,10 @@ pub struct RemoteNodeConfig {
     pub default_reply_timeout: Duration,
     /// Maximum TCP frame length. Default: 16 MiB.
     pub max_frame_len: usize,
+    /// Maximum concurrently processed inbound requests per connection. When the limit
+    /// is reached, further frames are not read, propagating backpressure over TCP.
+    /// Default: 512.
+    pub max_concurrent_requests: usize,
 }
 
 impl Default for RemoteNodeConfig {
@@ -73,6 +77,7 @@ impl Default for RemoteNodeConfig {
             connect_timeout: Duration::from_secs(10),
             default_reply_timeout: Duration::from_secs(30),
             max_frame_len: 16 * 1024 * 1024,
+            max_concurrent_requests: 512,
         }
     }
 }
@@ -126,8 +131,10 @@ pub struct RemoteNode {
 
 pub(crate) struct RemoteNodeInner {
     node_id: NodeId,
+    generation_id: u64,
     gossip_advertise_addr: SocketAddr,
     messaging_advertise_addr: SocketAddr,
+    gossip_interval: Duration,
     chitchat: Arc<tokio::sync::Mutex<Chitchat>>,
     // Option because ChitchatHandle::shutdown consumes the handle.
     chitchat_handle: tokio::sync::Mutex<Option<ChitchatHandle>>,
@@ -154,6 +161,7 @@ impl RemoteNode {
             connect_timeout,
             default_reply_timeout,
             max_frame_len,
+            max_concurrent_requests,
         } = config;
 
         let node_name = node_name
@@ -208,7 +216,7 @@ impl RemoteNode {
         .map_err(BootstrapError::Chitchat)?;
 
         let chitchat = handle.chitchat();
-        let dispatch = Arc::new(DispatchTable::default());
+        let dispatch = Arc::new(DispatchTable::new(generation_id));
         let pool = ConnectionPool::new(connect_timeout, default_reply_timeout, max_frame_len);
         let cancel = CancellationToken::new();
         let server_task = tokio::spawn(run_server(
@@ -216,13 +224,16 @@ impl RemoteNode {
             dispatch.clone(),
             cancel.child_token(),
             max_frame_len,
+            max_concurrent_requests,
         ));
 
         Ok(RemoteNode {
             inner: Arc::new(RemoteNodeInner {
                 node_id: NodeId::from(node_name),
+                generation_id,
                 gossip_advertise_addr,
                 messaging_advertise_addr,
+                gossip_interval,
                 chitchat,
                 chitchat_handle: tokio::sync::Mutex::new(Some(handle)),
                 dispatch,
@@ -335,6 +346,11 @@ impl RemoteNode {
         &self.inner.node_id
     }
 
+    /// Returns this node incarnation's generation id, which increases on restart.
+    pub fn generation_id(&self) -> u64 {
+        self.inner.generation_id
+    }
+
     /// Returns this node's gossip advertise address.
     pub fn gossip_addr(&self) -> SocketAddr {
         self.inner.gossip_advertise_addr
@@ -354,16 +370,38 @@ impl RemoteNode {
             .collect()
     }
 
-    /// Shuts the node down: stops the messaging server and leaves the gossip cluster.
+    /// Shuts the node down: deregisters all registrations, stops the messaging server,
+    /// and leaves the gossip cluster.
     ///
-    /// Idempotent; a second call is a no-op. Registrations are not explicitly removed,
-    /// since other nodes drop them when this node is declared dead.
+    /// The registrations are deleted and given a couple of gossip rounds to propagate,
+    /// so peers observe a clean departure quickly instead of waiting for the failure
+    /// detector. Idempotent; a second call is a no-op.
     pub async fn shutdown(&self) -> Result<(), ShutdownError> {
-        self.inner.cancel.cancel();
         let handle = self.inner.chitchat_handle.lock().await.take();
-        if let Some(handle) = handle {
-            handle.shutdown().await.map_err(ShutdownError::Chitchat)?;
+        let Some(handle) = handle else {
+            self.inner.cancel.cancel();
+            return Ok(());
+        };
+
+        let had_registrations = {
+            let mut chitchat = self.inner.chitchat.lock().await;
+            let state = chitchat.self_node_state();
+            let keys: Vec<String> = state
+                .iter_prefix(registry::ACTOR_KEY_PREFIX)
+                .map(|(key, _)| key.to_string())
+                .collect();
+            for key in &keys {
+                state.delete(key);
+            }
+            !keys.is_empty()
+        };
+        if had_registrations {
+            // Give gossip a couple of rounds to propagate the deletions.
+            tokio::time::sleep(2 * self.inner.gossip_interval).await;
         }
+
+        self.inner.cancel.cancel();
+        handle.shutdown().await.map_err(ShutdownError::Chitchat)?;
         Ok(())
     }
 }

--- a/remote/src/registry.rs
+++ b/remote/src/registry.rs
@@ -1,0 +1,185 @@
+//! The actor registry, stored as key-values in each node's own gossip state.
+//!
+//! Keys have the form `actor:<name>:<sequence_id>`; values are JSON
+//! [`RegistrationValue`]s. Set-per-name semantics fall out of this schema: any
+//! number of actors, across any number of nodes, can register the same name.
+
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+
+use chitchat::{Chitchat, ChitchatId, NodeState};
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::{
+    error::RegistryError,
+    id::{NodeId, RemoteActorId},
+    messaging::transport::ConnectionPool,
+    remote_actor::RemoteActor,
+    remote_ref::RemoteActorRef,
+};
+
+pub(crate) const ACTOR_KEY_PREFIX: &str = "actor:";
+
+/// The JSON value stored in the gossip state for one registration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RegistrationValue {
+    /// The actor type's `REMOTE_ID`, checked at lookup.
+    pub actor_remote_id: String,
+    /// The TCP messaging advertise address of the owning node.
+    pub messaging_addr: SocketAddr,
+}
+
+pub(crate) fn validate_name(name: &str) -> Result<(), RegistryError> {
+    if name.is_empty() || name.contains(':') {
+        return Err(RegistryError::InvalidName(name.to_string()));
+    }
+    Ok(())
+}
+
+pub(crate) fn actor_key(name: &str, sequence_id: u64) -> String {
+    format!("{ACTOR_KEY_PREFIX}{name}:{sequence_id}")
+}
+
+fn parse_actor_key(key: &str) -> Option<(&str, u64)> {
+    let rest = key.strip_prefix(ACTOR_KEY_PREFIX)?;
+    let (name, sequence_id) = rest.rsplit_once(':')?;
+    Some((name, sequence_id.parse().ok()?))
+}
+
+/// Collects the providers of `name` from a set of live node states.
+fn providers_from_states<'a, A: RemoteActor>(
+    states: impl Iterator<Item = (&'a ChitchatId, &'a NodeState)>,
+    name: &str,
+    pool: &ConnectionPool,
+    saw_mismatch: &mut bool,
+) -> Vec<RemoteActorRef<A>> {
+    let prefix = format!("{ACTOR_KEY_PREFIX}{name}:");
+    let mut refs = Vec::new();
+    for (chitchat_id, state) in states {
+        for (key, versioned) in state.iter_prefix(&prefix) {
+            let Some((parsed_name, sequence_id)) = parse_actor_key(key) else {
+                continue;
+            };
+            if parsed_name != name {
+                continue;
+            }
+            let value: RegistrationValue = match serde_json::from_str(&versioned.value) {
+                Ok(value) => value,
+                Err(err) => {
+                    tracing::warn!("skipping malformed registration {key:?}: {err}");
+                    continue;
+                }
+            };
+            if value.actor_remote_id != A::REMOTE_ID {
+                *saw_mismatch = true;
+                continue;
+            }
+            refs.push(RemoteActorRef::new(
+                RemoteActorId {
+                    node_id: NodeId::from(chitchat_id.node_id.clone()),
+                    sequence_id,
+                },
+                value.messaging_addr,
+                pool.clone(),
+            ));
+        }
+    }
+    refs
+}
+
+/// Collects the current live providers of `name` across the cluster.
+pub(crate) async fn collect_providers<A: RemoteActor>(
+    chitchat: &Arc<Mutex<Chitchat>>,
+    pool: &ConnectionPool,
+    name: &str,
+) -> Result<Vec<RemoteActorRef<A>>, RegistryError> {
+    let mut saw_mismatch = false;
+    let refs = {
+        // Everything is copied out under the guard; it is never held across I/O.
+        let guard = chitchat.lock().await;
+        let live: HashSet<ChitchatId> = guard.live_nodes().cloned().collect();
+        let states = guard
+            .node_states()
+            .iter()
+            .filter(|(chitchat_id, _)| live.contains(chitchat_id));
+        providers_from_states::<A>(states, name, pool, &mut saw_mismatch)
+    };
+    if refs.is_empty() && saw_mismatch {
+        return Err(RegistryError::BadActorType {
+            name: name.to_string(),
+            expected_remote_id: A::REMOTE_ID,
+        });
+    }
+    Ok(refs)
+}
+
+/// Streams the live provider set of `name`, yielding on every change.
+///
+/// Built on the gossip live-nodes watcher rather than key listeners, so it observes
+/// registrations, deregistrations, and node death uniformly. The current provider
+/// set is yielded immediately.
+pub(crate) async fn watch_providers<A: RemoteActor>(
+    chitchat: &Arc<Mutex<Chitchat>>,
+    pool: ConnectionPool,
+    name: String,
+) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
+    let stream = chitchat.lock().await.live_nodes_watch_stream();
+    stream
+        .map(move |snapshot| {
+            let mut saw_mismatch = false;
+            providers_from_states::<A>(snapshot.iter(), &name, &pool, &mut saw_mismatch)
+        })
+        .scan(
+            None::<Vec<RemoteActorId>>,
+            |prev, refs: Vec<RemoteActorRef<A>>| {
+                let mut ids: Vec<RemoteActorId> =
+                    refs.iter().map(|actor_ref| actor_ref.id().clone()).collect();
+                ids.sort();
+                let item = if prev.as_ref() == Some(&ids) {
+                    // Deduplicate consecutive identical provider sets.
+                    None
+                } else {
+                    *prev = Some(ids);
+                    Some(refs)
+                };
+                futures::future::ready(Some(item))
+            },
+        )
+        .filter_map(futures::future::ready)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn actor_key_format() {
+        assert_eq!(actor_key("incrementor", 42), "actor:incrementor:42");
+    }
+
+    #[test]
+    fn parse_actor_key_round_trip() {
+        assert_eq!(
+            parse_actor_key("actor:incrementor:42"),
+            Some(("incrementor", 42))
+        );
+        assert_eq!(parse_actor_key("actor:incrementor:"), None);
+        assert_eq!(parse_actor_key("actor:incrementor"), None);
+        assert_eq!(parse_actor_key("other:incrementor:42"), None);
+        assert_eq!(parse_actor_key("actor:a:b:42"), Some(("a:b", 42)));
+    }
+
+    #[test]
+    fn validate_name_rejects_invalid() {
+        assert!(validate_name("incrementor").is_ok());
+        assert_eq!(
+            validate_name(""),
+            Err(RegistryError::InvalidName(String::new()))
+        );
+        assert_eq!(
+            validate_name("a:b"),
+            Err(RegistryError::InvalidName("a:b".to_string()))
+        );
+    }
+}

--- a/remote/src/registry.rs
+++ b/remote/src/registry.rs
@@ -10,6 +10,7 @@ use chitchat::{Chitchat, ChitchatId, NodeState};
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     dispatch::DispatchTable,
@@ -132,6 +133,7 @@ pub(crate) async fn watch_providers<A: RemoteActor>(
     chitchat: &Arc<Mutex<Chitchat>>,
     pool: ConnectionPool,
     dispatch: Arc<DispatchTable>,
+    cancel: CancellationToken,
     name: String,
 ) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
     let (stream, self_id) = {
@@ -172,6 +174,8 @@ pub(crate) async fn watch_providers<A: RemoteActor>(
             },
         )
         .filter_map(futures::future::ready)
+        // End the stream when the node shuts down; gossip is frozen from then on.
+        .take_until(cancel.cancelled_owned())
 }
 
 #[cfg(test)]

--- a/remote/src/registry.rs
+++ b/remote/src/registry.rs
@@ -78,6 +78,7 @@ fn providers_from_states<'a, A: RemoteActor>(
             refs.push(RemoteActorRef::new(
                 RemoteActorId {
                     node_id: NodeId::from(chitchat_id.node_id.clone()),
+                    generation_id: chitchat_id.generation_id,
                     sequence_id,
                 },
                 value.messaging_addr,

--- a/remote/src/registry.rs
+++ b/remote/src/registry.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use crate::{
+    dispatch::DispatchTable,
     error::RegistryError,
     id::{NodeId, RemoteActorId},
     messaging::transport::ConnectionPool,
@@ -52,6 +53,8 @@ fn providers_from_states<'a, A: RemoteActor>(
     states: impl Iterator<Item = (&'a ChitchatId, &'a NodeState)>,
     name: &str,
     pool: &ConnectionPool,
+    self_id: &ChitchatId,
+    dispatch: &Arc<DispatchTable>,
     saw_mismatch: &mut bool,
 ) -> Vec<RemoteActorRef<A>> {
     let prefix = format!("{ACTOR_KEY_PREFIX}{name}:");
@@ -75,6 +78,8 @@ fn providers_from_states<'a, A: RemoteActor>(
                 *saw_mismatch = true;
                 continue;
             }
+            // Actors on this node incarnation are dispatched in-process, skipping TCP.
+            let local_dispatch = (chitchat_id == self_id).then(|| dispatch.clone());
             refs.push(RemoteActorRef::new(
                 RemoteActorId {
                     node_id: NodeId::from(chitchat_id.node_id.clone()),
@@ -83,6 +88,7 @@ fn providers_from_states<'a, A: RemoteActor>(
                 },
                 value.messaging_addr,
                 pool.clone(),
+                local_dispatch,
             ));
         }
     }
@@ -93,18 +99,20 @@ fn providers_from_states<'a, A: RemoteActor>(
 pub(crate) async fn collect_providers<A: RemoteActor>(
     chitchat: &Arc<Mutex<Chitchat>>,
     pool: &ConnectionPool,
+    dispatch: &Arc<DispatchTable>,
     name: &str,
 ) -> Result<Vec<RemoteActorRef<A>>, RegistryError> {
     let mut saw_mismatch = false;
     let refs = {
         // Everything is copied out under the guard; it is never held across I/O.
         let guard = chitchat.lock().await;
+        let self_id = guard.self_chitchat_id().clone();
         let live: HashSet<ChitchatId> = guard.live_nodes().cloned().collect();
         let states = guard
             .node_states()
             .iter()
             .filter(|(chitchat_id, _)| live.contains(chitchat_id));
-        providers_from_states::<A>(states, name, pool, &mut saw_mismatch)
+        providers_from_states::<A>(states, name, pool, &self_id, dispatch, &mut saw_mismatch)
     };
     if refs.is_empty() && saw_mismatch {
         return Err(RegistryError::BadActorType {
@@ -123,19 +131,35 @@ pub(crate) async fn collect_providers<A: RemoteActor>(
 pub(crate) async fn watch_providers<A: RemoteActor>(
     chitchat: &Arc<Mutex<Chitchat>>,
     pool: ConnectionPool,
+    dispatch: Arc<DispatchTable>,
     name: String,
 ) -> impl Stream<Item = Vec<RemoteActorRef<A>>> + Send + 'static {
-    let stream = chitchat.lock().await.live_nodes_watch_stream();
+    let (stream, self_id) = {
+        let guard = chitchat.lock().await;
+        (
+            guard.live_nodes_watch_stream(),
+            guard.self_chitchat_id().clone(),
+        )
+    };
     stream
         .map(move |snapshot| {
             let mut saw_mismatch = false;
-            providers_from_states::<A>(snapshot.iter(), &name, &pool, &mut saw_mismatch)
+            providers_from_states::<A>(
+                snapshot.iter(),
+                &name,
+                &pool,
+                &self_id,
+                &dispatch,
+                &mut saw_mismatch,
+            )
         })
         .scan(
             None::<Vec<RemoteActorId>>,
             |prev, refs: Vec<RemoteActorRef<A>>| {
-                let mut ids: Vec<RemoteActorId> =
-                    refs.iter().map(|actor_ref| actor_ref.id().clone()).collect();
+                let mut ids: Vec<RemoteActorId> = refs
+                    .iter()
+                    .map(|actor_ref| actor_ref.id().clone())
+                    .collect();
                 ids.sort();
                 let item = if prev.as_ref() == Some(&ids) {
                     // Deduplicate consecutive identical provider sets.

--- a/remote/src/remote_actor.rs
+++ b/remote/src/remote_actor.rs
@@ -105,9 +105,11 @@ impl<A: Actor> RemoteMessages<A> {
                             None => actor_ref.ask(msg).send().await,
                         };
                         match result {
-                            Ok(ok) => Ok(Some(rmp_serde::to_vec_named(&ok).map_err(|err| {
-                                WireError::SerializeReply(err.to_string())
-                            })?)),
+                            Ok(ok) => {
+                                Ok(Some(rmp_serde::to_vec_named(&ok).map_err(|err| {
+                                    WireError::SerializeReply(err.to_string())
+                                })?))
+                            }
                             Err(SendError::HandlerError(err)) => {
                                 match rmp_serde::to_vec_named(&err) {
                                     Ok(bytes) => Err(WireError::HandlerError(ByteBuf::from(bytes))),

--- a/remote/src/remote_actor.rs
+++ b/remote/src/remote_actor.rs
@@ -1,0 +1,143 @@
+//! Traits declaring which actors and messages are available remotely.
+
+use std::collections::HashMap;
+
+use futures::FutureExt;
+use kameo::{Actor, Reply, actor::ActorRef, error::SendError, message::Message};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_bytes::ByteBuf;
+use std::sync::Arc;
+
+use crate::{
+    dispatch::{DynHandler, InboundKind},
+    messaging::protocol::WireError,
+};
+
+/// A message which can be sent to actors on other nodes.
+///
+/// The `REMOTE_ID` is the message's wire identifier and must be identical across all
+/// binaries in the cluster. Prefer a namespaced string such as `"my_crate::Inc"`.
+pub trait RemoteMessage: Serialize + DeserializeOwned + Send + Sync + 'static {
+    /// Stable wire identifier for this message type.
+    const REMOTE_ID: &'static str;
+}
+
+/// An actor which can be registered and messaged remotely.
+///
+/// Implementations declare the actor's wire identifier and the set of messages it
+/// accepts remotely:
+///
+/// ```
+/// # use kameo::prelude::*;
+/// # use kameo_remote::{RemoteActor, RemoteMessage, RemoteMessages};
+/// # use serde::{Serialize, Deserialize};
+/// # #[derive(Actor)]
+/// # struct MyActor { count: i64 }
+/// # #[derive(Serialize, Deserialize)]
+/// # struct Inc { amount: u32 }
+/// # impl Message<Inc> for MyActor {
+/// #     type Reply = i64;
+/// #     async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+/// #         self.count += msg.amount as i64;
+/// #         self.count
+/// #     }
+/// # }
+/// # impl RemoteMessage for Inc {
+/// #     const REMOTE_ID: &'static str = "example::Inc";
+/// # }
+/// impl RemoteActor for MyActor {
+///     const REMOTE_ID: &'static str = "example::MyActor";
+///
+///     fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+///         handlers.add::<Inc>();
+///     }
+/// }
+/// ```
+pub trait RemoteActor: Actor + Sized {
+    /// Stable wire identifier for this actor type.
+    const REMOTE_ID: &'static str;
+
+    /// Declares which messages this actor accepts remotely.
+    fn remote_messages(handlers: &mut RemoteMessages<Self>);
+}
+
+/// Collects the remote message handlers for an actor being registered.
+pub struct RemoteMessages<A: Actor> {
+    actor_ref: ActorRef<A>,
+    handlers: HashMap<&'static str, DynHandler>,
+}
+
+impl<A: Actor> RemoteMessages<A> {
+    pub(crate) fn new(actor_ref: ActorRef<A>) -> Self {
+        RemoteMessages {
+            actor_ref,
+            handlers: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn into_handlers(self) -> HashMap<&'static str, DynHandler> {
+        self.handlers
+    }
+
+    /// Makes the message type `M` remotely callable on this actor.
+    pub fn add<M>(&mut self)
+    where
+        A: Message<M>,
+        M: RemoteMessage,
+        <A::Reply as Reply>::Ok: Serialize,
+        <A::Reply as Reply>::Error: Serialize,
+    {
+        let actor_ref = self.actor_ref.clone();
+        let handler: DynHandler = Arc::new(move |payload: Vec<u8>, kind: InboundKind| {
+            let actor_ref = actor_ref.clone();
+            async move {
+                let msg: M = rmp_serde::from_slice(&payload)
+                    .map_err(|err| WireError::DeserializeMessage(err.to_string()))?;
+                match kind {
+                    InboundKind::Tell => match actor_ref.tell(msg).send().await {
+                        Ok(()) => Ok(None),
+                        Err(err) => Err(tell_error_to_wire(err)),
+                    },
+                    InboundKind::Ask { reply_timeout } => {
+                        // reply_timeout_opt is private in kameo, so branch on the typestate builder.
+                        let result = match reply_timeout {
+                            Some(timeout) => actor_ref.ask(msg).reply_timeout(timeout).send().await,
+                            None => actor_ref.ask(msg).send().await,
+                        };
+                        match result {
+                            Ok(ok) => Ok(Some(rmp_serde::to_vec_named(&ok).map_err(|err| {
+                                WireError::SerializeReply(err.to_string())
+                            })?)),
+                            Err(SendError::HandlerError(err)) => {
+                                match rmp_serde::to_vec_named(&err) {
+                                    Ok(bytes) => Err(WireError::HandlerError(ByteBuf::from(bytes))),
+                                    Err(err) => {
+                                        Err(WireError::SerializeHandlerError(err.to_string()))
+                                    }
+                                }
+                            }
+                            Err(SendError::ActorNotRunning(_) | SendError::ActorRestarting(_)) => {
+                                Err(WireError::ActorNotRunning)
+                            }
+                            Err(SendError::ActorStopped) => Err(WireError::ActorStopped),
+                            Err(SendError::MailboxFull(_)) => Err(WireError::MailboxFull),
+                            Err(SendError::Timeout(_)) => Err(WireError::ReplyTimeout),
+                        }
+                    }
+                }
+            }
+            .boxed()
+        });
+        self.handlers.insert(M::REMOTE_ID, handler);
+    }
+}
+
+fn tell_error_to_wire<M>(err: SendError<M>) -> WireError {
+    match err {
+        SendError::ActorNotRunning(_) | SendError::ActorRestarting(_) => WireError::ActorNotRunning,
+        SendError::ActorStopped => WireError::ActorStopped,
+        SendError::MailboxFull(_) => WireError::MailboxFull,
+        SendError::Timeout(_) => WireError::ReplyTimeout,
+        SendError::HandlerError(infallible) => match infallible {},
+    }
+}

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -1,6 +1,6 @@
 //! References to actors registered on other nodes.
 
-use std::{fmt, marker::PhantomData, net::SocketAddr, time::Duration};
+use std::{fmt, marker::PhantomData, net::SocketAddr, sync::Arc, time::Duration};
 
 use futures::future::BoxFuture;
 use kameo::{Reply, message::Message};
@@ -8,10 +8,11 @@ use serde::de::DeserializeOwned;
 use serde_bytes::ByteBuf;
 
 use crate::{
+    dispatch::{DispatchTable, InboundKind},
     error::RemoteSendError,
     id::{NodeId, RemoteActorId},
     messaging::{
-        protocol::{RequestFrame, WireError},
+        protocol::{RequestFrame, RequestKind, WireError},
         transport::{ConnectionPool, TransportError},
     },
     remote_actor::{RemoteActor, RemoteMessage},
@@ -22,17 +23,32 @@ pub struct RemoteActorRef<A: RemoteActor> {
     id: RemoteActorId,
     messaging_addr: SocketAddr,
     pool: ConnectionPool,
+    /// Set when the actor lives on this node; messages are dispatched in-process
+    /// (still serialized, but never touching the network).
+    local_dispatch: Option<Arc<DispatchTable>>,
     _marker: PhantomData<fn() -> A>,
 }
 
 impl<A: RemoteActor> RemoteActorRef<A> {
-    pub(crate) fn new(id: RemoteActorId, messaging_addr: SocketAddr, pool: ConnectionPool) -> Self {
+    pub(crate) fn new(
+        id: RemoteActorId,
+        messaging_addr: SocketAddr,
+        pool: ConnectionPool,
+        local_dispatch: Option<Arc<DispatchTable>>,
+    ) -> Self {
         RemoteActorRef {
             id,
             messaging_addr,
             pool,
+            local_dispatch,
             _marker: PhantomData,
         }
+    }
+
+    /// Returns whether the actor lives on the local node, in which case messages skip
+    /// the network and are dispatched in-process.
+    pub fn is_local(&self) -> bool {
+        self.local_dispatch.is_some()
     }
 
     /// Returns the remote actor's identity.
@@ -82,10 +98,12 @@ impl<A: RemoteActor> RemoteActorRef<A> {
     fn request_frame<M: RemoteMessage>(
         &self,
         msg: &M,
+        kind: RequestKind,
         reply_timeout_ms: Option<u64>,
     ) -> Result<RequestFrame, rmp_serde::encode::Error> {
         Ok(RequestFrame {
             request_id: None,
+            kind,
             target_generation_id: self.id.generation_id,
             target_sequence_id: self.id.sequence_id,
             actor_remote_id: A::REMOTE_ID.to_string(),
@@ -102,6 +120,7 @@ impl<A: RemoteActor> Clone for RemoteActorRef<A> {
             id: self.id.clone(),
             messaging_addr: self.messaging_addr,
             pool: self.pool.clone(),
+            local_dispatch: self.local_dispatch.clone(),
             _marker: PhantomData,
         }
     }
@@ -159,22 +178,40 @@ where
             .unwrap_or_else(|| self.actor_ref.pool.default_reply_timeout());
         let frame = self
             .actor_ref
-            .request_frame(self.msg, Some(timeout.as_millis() as u64))
+            .request_frame(self.msg, RequestKind::Ask, Some(timeout.as_millis() as u64))
             .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
+
+        if let Some(dispatch) = &self.actor_ref.local_dispatch {
+            let kind = InboundKind::Ask {
+                reply_timeout: Some(timeout),
+            };
+            let result = match dispatch.resolve(&frame) {
+                Ok(handler) => {
+                    match tokio::time::timeout(timeout, handler(frame.payload.into_vec(), kind))
+                        .await
+                    {
+                        Ok(result) => result,
+                        Err(_) => return Err(RemoteSendError::ReplyTimeout),
+                    }
+                }
+                Err(err) => Err(err),
+            };
+            return match result {
+                Ok(reply) => rmp_serde::from_slice(&reply.unwrap_or_default())
+                    .map_err(|err| RemoteSendError::DeserializeReply(err.to_string())),
+                Err(err) => Err(map_wire_error(err, decode_handler_error)),
+            };
+        }
+
         match self
             .actor_ref
             .pool
-            .ask(self.actor_ref.messaging_addr, frame, timeout)
+            .request(self.actor_ref.messaging_addr, frame, timeout)
             .await
         {
             Ok(bytes) => rmp_serde::from_slice(&bytes)
                 .map_err(|err| RemoteSendError::DeserializeReply(err.to_string())),
-            Err(err) => Err(map_transport_error(err, |payload| {
-                match rmp_serde::from_slice(&payload) {
-                    Ok(err) => RemoteSendError::HandlerError(err),
-                    Err(err) => RemoteSendError::DeserializeHandlerError(err.to_string()),
-                }
-            })),
+            Err(err) => Err(map_transport_error(err, decode_handler_error)),
         }
     }
 }
@@ -209,20 +246,79 @@ where
     A: RemoteActor + Message<M>,
     M: RemoteMessage,
 {
-    /// Sends the message, returning once it is queued to the connection.
+    /// Sends the message and waits for the receiving node to acknowledge delivery to
+    /// the actor's mailbox, matching the semantics of a local `tell(..).send()`.
+    ///
+    /// The acknowledgement confirms delivery, not processing. For fire-and-forget
+    /// semantics, use [`send_unacked`](RemoteTellRequest::send_unacked).
     pub async fn send(self) -> Result<(), RemoteSendError> {
+        let timeout = self.actor_ref.pool.default_reply_timeout();
         let frame = self
             .actor_ref
-            .request_frame(self.msg, None)
+            .request_frame(self.msg, RequestKind::Tell, None)
             .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
+
+        if let Some(dispatch) = &self.actor_ref.local_dispatch {
+            let result = match dispatch.resolve(&frame) {
+                Ok(handler) => {
+                    match tokio::time::timeout(
+                        timeout,
+                        handler(frame.payload.into_vec(), InboundKind::Tell),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_) => return Err(RemoteSendError::ReplyTimeout),
+                    }
+                }
+                Err(err) => Err(err),
+            };
+            return result
+                .map(|_| ())
+                .map_err(|err| map_wire_error(err, |_| RemoteSendError::ConnectionClosed));
+        }
+
         self.actor_ref
             .pool
-            .tell(self.actor_ref.messaging_addr, frame)
+            .request(self.actor_ref.messaging_addr, frame, timeout)
             .await
+            .map(|_| ())
             .map_err(|err| {
-                // Tells receive no response, so remote errors cannot occur here.
+                // The tell path never produces a handler error.
                 map_transport_error(err, |_| RemoteSendError::ConnectionClosed)
             })
+    }
+
+    /// Sends the message without waiting for any acknowledgement (at-most-once).
+    ///
+    /// Returns once the message is queued to the connection; delivery failures are
+    /// only logged on the receiving node.
+    pub async fn send_unacked(self) -> Result<(), RemoteSendError> {
+        let frame = self
+            .actor_ref
+            .request_frame(self.msg, RequestKind::Tell, None)
+            .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
+
+        if let Some(dispatch) = &self.actor_ref.local_dispatch {
+            match dispatch.resolve(&frame) {
+                Ok(handler) => {
+                    tokio::spawn(async move {
+                        if let Err(err) = handler(frame.payload.into_vec(), InboundKind::Tell).await
+                        {
+                            tracing::warn!("tell dispatch failed: {err:?}");
+                        }
+                    });
+                }
+                Err(err) => tracing::warn!("tell dispatch failed: {err:?}"),
+            }
+            return Ok(());
+        }
+
+        self.actor_ref
+            .pool
+            .enqueue(self.actor_ref.messaging_addr, frame)
+            .await
+            .map_err(|err| map_transport_error(err, |_| RemoteSendError::ConnectionClosed))
     }
 }
 
@@ -239,6 +335,13 @@ where
     }
 }
 
+fn decode_handler_error<E: DeserializeOwned>(payload: ByteBuf) -> RemoteSendError<E> {
+    match rmp_serde::from_slice(&payload) {
+        Ok(err) => RemoteSendError::HandlerError(err),
+        Err(err) => RemoteSendError::DeserializeHandlerError(err.to_string()),
+    }
+}
+
 fn map_transport_error<E>(
     err: TransportError,
     decode_handler_error: impl FnOnce(ByteBuf) -> RemoteSendError<E>,
@@ -247,26 +350,33 @@ fn map_transport_error<E>(
         TransportError::Connect(err) => RemoteSendError::Connect(err),
         TransportError::ConnectionClosed => RemoteSendError::ConnectionClosed,
         TransportError::ReplyTimeout => RemoteSendError::ReplyTimeout,
-        TransportError::Remote(err) => match err {
-            WireError::ActorNotRunning => RemoteSendError::ActorNotRunning,
-            WireError::ActorStopped => RemoteSendError::ActorStopped,
-            WireError::BadActorType => RemoteSendError::BadActorType,
-            WireError::MailboxFull => RemoteSendError::MailboxFull,
-            WireError::ReplyTimeout => RemoteSendError::ReplyTimeout,
-            WireError::UnknownActor { actor_remote_id } => {
-                RemoteSendError::UnknownActor { actor_remote_id }
-            }
-            WireError::UnknownMessage {
-                actor_remote_id,
-                message_remote_id,
-            } => RemoteSendError::UnknownMessage {
-                actor_remote_id,
-                message_remote_id,
-            },
-            WireError::HandlerError(payload) => decode_handler_error(payload),
-            WireError::DeserializeMessage(err) => RemoteSendError::DeserializeMessage(err),
-            WireError::SerializeReply(err) => RemoteSendError::SerializeReply(err),
-            WireError::SerializeHandlerError(err) => RemoteSendError::SerializeHandlerError(err),
+        TransportError::Remote(err) => map_wire_error(err, decode_handler_error),
+    }
+}
+
+fn map_wire_error<E>(
+    err: WireError,
+    decode_handler_error: impl FnOnce(ByteBuf) -> RemoteSendError<E>,
+) -> RemoteSendError<E> {
+    match err {
+        WireError::ActorNotRunning => RemoteSendError::ActorNotRunning,
+        WireError::ActorStopped => RemoteSendError::ActorStopped,
+        WireError::BadActorType => RemoteSendError::BadActorType,
+        WireError::MailboxFull => RemoteSendError::MailboxFull,
+        WireError::ReplyTimeout => RemoteSendError::ReplyTimeout,
+        WireError::UnknownActor { actor_remote_id } => {
+            RemoteSendError::UnknownActor { actor_remote_id }
+        }
+        WireError::UnknownMessage {
+            actor_remote_id,
+            message_remote_id,
+        } => RemoteSendError::UnknownMessage {
+            actor_remote_id,
+            message_remote_id,
         },
+        WireError::HandlerError(payload) => decode_handler_error(payload),
+        WireError::DeserializeMessage(err) => RemoteSendError::DeserializeMessage(err),
+        WireError::SerializeReply(err) => RemoteSendError::SerializeReply(err),
+        WireError::SerializeHandlerError(err) => RemoteSendError::SerializeHandlerError(err),
     }
 }

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -19,6 +19,14 @@ use crate::{
 };
 
 /// A reference to an actor registered on a remote node, obtained via lookup.
+///
+/// # Ordering
+///
+/// Messages sent sequentially from one node to one target actor are delivered to the
+/// actor's mailbox in send order (per-pair FIFO ordering, as in Akka). Requests to the
+/// same target actor are processed one at a time per sending node, so an ask delays
+/// subsequent messages to that actor from this node until its reply is sent; requests
+/// to different actors or from different nodes are unaffected.
 pub struct RemoteActorRef<A: RemoteActor> {
     id: RemoteActorId,
     messaging_addr: SocketAddr,
@@ -291,8 +299,8 @@ where
 
     /// Sends the message without waiting for any acknowledgement (at-most-once).
     ///
-    /// Returns once the message is queued to the connection; delivery failures are
-    /// only logged on the receiving node.
+    /// Returns once the message is queued to the connection (or, for local actors,
+    /// delivered to the mailbox); the delivery outcome is only logged, never reported.
     pub async fn send_unacked(self) -> Result<(), RemoteSendError> {
         let frame = self
             .actor_ref
@@ -300,14 +308,13 @@ where
             .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
 
         if let Some(dispatch) = &self.actor_ref.local_dispatch {
+            // Awaited rather than spawned so sequential unacked tells keep their order;
+            // the outcome is only logged, matching the fire-and-forget contract.
             match dispatch.resolve(&frame) {
                 Ok(handler) => {
-                    tokio::spawn(async move {
-                        if let Err(err) = handler(frame.payload.into_vec(), InboundKind::Tell).await
-                        {
-                            tracing::warn!("tell dispatch failed: {err:?}");
-                        }
-                    });
+                    if let Err(err) = handler(frame.payload.into_vec(), InboundKind::Tell).await {
+                        tracing::warn!("tell dispatch failed: {err:?}");
+                    }
                 }
                 Err(err) => tracing::warn!("tell dispatch failed: {err:?}"),
             }

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -371,9 +371,6 @@ fn map_wire_error<E>(
         WireError::BadActorType => RemoteSendError::BadActorType,
         WireError::MailboxFull => RemoteSendError::MailboxFull,
         WireError::ReplyTimeout => RemoteSendError::ReplyTimeout,
-        WireError::UnknownActor { actor_remote_id } => {
-            RemoteSendError::UnknownActor { actor_remote_id }
-        }
         WireError::UnknownMessage {
             actor_remote_id,
             message_remote_id,

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -1,6 +1,6 @@
 //! References to actors registered on other nodes.
 
-use std::{fmt, marker::PhantomData, net::SocketAddr, sync::Arc, time::Duration};
+use std::{borrow::Cow, fmt, marker::PhantomData, net::SocketAddr, sync::Arc, time::Duration};
 
 use futures::future::BoxFuture;
 use kameo::{Reply, message::Message};
@@ -119,8 +119,8 @@ impl<A: RemoteActor> RemoteActorRef<A> {
             kind,
             target_generation_id: self.id.generation_id,
             target_sequence_id: self.id.sequence_id,
-            actor_remote_id: A::REMOTE_ID.to_string(),
-            message_remote_id: M::REMOTE_ID.to_string(),
+            actor_remote_id: Cow::Borrowed(A::REMOTE_ID),
+            message_remote_id: Cow::Borrowed(M::REMOTE_ID),
             reply_timeout_ms,
             payload: ByteBuf::from(rmp_serde::to_vec_named(msg)?),
         })
@@ -205,18 +205,7 @@ where
             let kind = InboundKind::Ask {
                 reply_timeout: Some(timeout),
             };
-            let result = match dispatch.resolve(&frame) {
-                Ok(handler) => {
-                    match tokio::time::timeout(timeout, handler(frame.payload.into_vec(), kind))
-                        .await
-                    {
-                        Ok(result) => result,
-                        Err(_) => return Err(RemoteSendError::ReplyTimeout),
-                    }
-                }
-                Err(err) => Err(err),
-            };
-            return match result {
+            return match dispatch_local(dispatch, frame, kind, Some(timeout)).await {
                 Ok(reply) => rmp_serde::from_slice(&reply.unwrap_or_default())
                     .map_err(|err| RemoteSendError::DeserializeReply(err.to_string())),
                 Err(err) => Err(map_wire_error(err, decode_handler_error)),
@@ -278,21 +267,8 @@ where
             .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
 
         if let Some(dispatch) = &self.actor_ref.local_dispatch {
-            let result = match dispatch.resolve(&frame) {
-                Ok(handler) => {
-                    match tokio::time::timeout(
-                        timeout,
-                        handler(frame.payload.into_vec(), InboundKind::Tell),
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(_) => return Err(RemoteSendError::ReplyTimeout),
-                    }
-                }
-                Err(err) => Err(err),
-            };
-            return result
+            return dispatch_local(dispatch, frame, InboundKind::Tell, Some(timeout))
+                .await
                 .map(|_| ())
                 .map_err(|err| map_wire_error(err, |_| RemoteSendError::ConnectionClosed));
         }
@@ -320,14 +296,10 @@ where
 
         if let Some(dispatch) = &self.actor_ref.local_dispatch {
             // Awaited rather than spawned so sequential unacked tells keep their order;
-            // the outcome is only logged, matching the fire-and-forget contract.
-            match dispatch.resolve(&frame) {
-                Ok(handler) => {
-                    if let Err(err) = handler(frame.payload.into_vec(), InboundKind::Tell).await {
-                        tracing::warn!("tell dispatch failed: {err:?}");
-                    }
-                }
-                Err(err) => tracing::warn!("tell dispatch failed: {err:?}"),
+            // no timeout and the outcome only logged, matching the fire-and-forget
+            // contract of the remote path.
+            if let Err(err) = dispatch_local(dispatch, frame, InboundKind::Tell, None).await {
+                tracing::warn!("tell dispatch failed: {err:?}");
             }
             return Ok(());
         }
@@ -350,6 +322,24 @@ where
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
+    }
+}
+
+/// Dispatches a frame to an actor on this node, mirroring what the remote server
+/// would do with it.
+async fn dispatch_local(
+    dispatch: &Arc<DispatchTable>,
+    frame: RequestFrame,
+    kind: InboundKind,
+    timeout: Option<Duration>,
+) -> Result<Option<Vec<u8>>, WireError> {
+    let handler = dispatch.resolve(&frame)?;
+    let fut = handler(frame.payload.into_vec(), kind);
+    match timeout {
+        Some(timeout) => tokio::time::timeout(timeout, fut)
+            .await
+            .unwrap_or(Err(WireError::ReplyTimeout)),
+        None => fut.await,
     }
 }
 

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -20,13 +20,18 @@ use crate::{
 
 /// A reference to an actor registered on a remote node, obtained via lookup.
 ///
+/// Holding a reference does not affect the actor's lifetime; if the actor stops, sends
+/// fail with an error.
+///
 /// # Ordering
 ///
 /// Messages sent sequentially from one node to one target actor are delivered to the
-/// actor's mailbox in send order (per-pair FIFO ordering, as in Akka). Requests to the
-/// same target actor are processed one at a time per sending node, so an ask delays
-/// subsequent messages to that actor from this node until its reply is sent; requests
-/// to different actors or from different nodes are unaffected.
+/// actor's mailbox in send order. Requests to the same target actor are processed one
+/// at a time per sending node, so an ask delays subsequent messages to that actor from
+/// this node until its reply is sent; requests to different actors or from different
+/// nodes are unaffected. Ordering holds within one connection: if the connection fails
+/// and is re-established, messages already in flight may interleave with newly sent
+/// ones.
 pub struct RemoteActorRef<A: RemoteActor> {
     id: RemoteActorId,
     messaging_addr: SocketAddr,
@@ -257,8 +262,7 @@ where
     /// Sends the message and waits for the receiving node to acknowledge delivery to
     /// the actor's mailbox, matching the semantics of a local `tell(..).send()`.
     ///
-    /// The acknowledgement confirms delivery, not processing. For fire-and-forget
-    /// semantics, use [`send_unacked`](RemoteTellRequest::send_unacked).
+    /// The acknowledgement confirms delivery, not processing.
     pub async fn send(self) -> Result<(), RemoteSendError> {
         let timeout = self.actor_ref.pool.default_reply_timeout();
         let frame = self
@@ -356,6 +360,7 @@ fn map_transport_error<E>(
     match err {
         TransportError::Connect(err) => RemoteSendError::Connect(err),
         TransportError::ConnectionClosed => RemoteSendError::ConnectionClosed,
+        TransportError::NodeShutdown => RemoteSendError::NodeShutdown,
         TransportError::ReplyTimeout => RemoteSendError::ReplyTimeout,
         TransportError::Remote(err) => map_wire_error(err, decode_handler_error),
     }

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -156,6 +156,13 @@ impl<A: RemoteActor> PartialEq for RemoteActorRef<A> {
 
 impl<A: RemoteActor> Eq for RemoteActorRef<A> {}
 
+impl<A: RemoteActor> std::hash::Hash for RemoteActorRef<A> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.messaging_addr.hash(state);
+    }
+}
+
 /// A pending ask request to a remote actor.
 pub struct RemoteAskRequest<'a, A, M>
 where

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -86,6 +86,7 @@ impl<A: RemoteActor> RemoteActorRef<A> {
     ) -> Result<RequestFrame, rmp_serde::encode::Error> {
         Ok(RequestFrame {
             request_id: None,
+            target_generation_id: self.id.generation_id,
             target_sequence_id: self.id.sequence_id,
             actor_remote_id: A::REMOTE_ID.to_string(),
             message_remote_id: M::REMOTE_ID.to_string(),

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -1,0 +1,271 @@
+//! References to actors registered on other nodes.
+
+use std::{fmt, marker::PhantomData, net::SocketAddr, time::Duration};
+
+use futures::future::BoxFuture;
+use kameo::{Reply, message::Message};
+use serde::de::DeserializeOwned;
+use serde_bytes::ByteBuf;
+
+use crate::{
+    error::RemoteSendError,
+    id::{NodeId, RemoteActorId},
+    messaging::{
+        protocol::{RequestFrame, WireError},
+        transport::{ConnectionPool, TransportError},
+    },
+    remote_actor::{RemoteActor, RemoteMessage},
+};
+
+/// A reference to an actor registered on a remote node, obtained via lookup.
+pub struct RemoteActorRef<A: RemoteActor> {
+    id: RemoteActorId,
+    messaging_addr: SocketAddr,
+    pool: ConnectionPool,
+    _marker: PhantomData<fn() -> A>,
+}
+
+impl<A: RemoteActor> RemoteActorRef<A> {
+    pub(crate) fn new(id: RemoteActorId, messaging_addr: SocketAddr, pool: ConnectionPool) -> Self {
+        RemoteActorRef {
+            id,
+            messaging_addr,
+            pool,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the remote actor's identity.
+    pub fn id(&self) -> &RemoteActorId {
+        &self.id
+    }
+
+    /// Returns the id of the node the actor lives on.
+    pub fn node_id(&self) -> &NodeId {
+        &self.id.node_id
+    }
+
+    /// Returns the TCP messaging address of the node the actor lives on.
+    pub fn messaging_addr(&self) -> SocketAddr {
+        self.messaging_addr
+    }
+
+    /// Sends a message and waits for a reply.
+    ///
+    /// The message is taken by reference since it is serialized, never consumed.
+    pub fn ask<'a, M>(&'a self, msg: &'a M) -> RemoteAskRequest<'a, A, M>
+    where
+        A: Message<M>,
+        M: RemoteMessage,
+    {
+        RemoteAskRequest {
+            actor_ref: self,
+            msg,
+            reply_timeout: None,
+        }
+    }
+
+    /// Sends a message without waiting for a reply.
+    ///
+    /// The message is taken by reference since it is serialized, never consumed.
+    pub fn tell<'a, M>(&'a self, msg: &'a M) -> RemoteTellRequest<'a, A, M>
+    where
+        A: Message<M>,
+        M: RemoteMessage,
+    {
+        RemoteTellRequest {
+            actor_ref: self,
+            msg,
+        }
+    }
+
+    fn request_frame<M: RemoteMessage>(
+        &self,
+        msg: &M,
+        reply_timeout_ms: Option<u64>,
+    ) -> Result<RequestFrame, rmp_serde::encode::Error> {
+        Ok(RequestFrame {
+            request_id: None,
+            target_sequence_id: self.id.sequence_id,
+            actor_remote_id: A::REMOTE_ID.to_string(),
+            message_remote_id: M::REMOTE_ID.to_string(),
+            reply_timeout_ms,
+            payload: ByteBuf::from(rmp_serde::to_vec_named(msg)?),
+        })
+    }
+}
+
+impl<A: RemoteActor> Clone for RemoteActorRef<A> {
+    fn clone(&self) -> Self {
+        RemoteActorRef {
+            id: self.id.clone(),
+            messaging_addr: self.messaging_addr,
+            pool: self.pool.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<A: RemoteActor> fmt::Debug for RemoteActorRef<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RemoteActorRef")
+            .field("id", &self.id)
+            .field("messaging_addr", &self.messaging_addr)
+            .finish()
+    }
+}
+
+impl<A: RemoteActor> PartialEq for RemoteActorRef<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.messaging_addr == other.messaging_addr
+    }
+}
+
+impl<A: RemoteActor> Eq for RemoteActorRef<A> {}
+
+/// A pending ask request to a remote actor.
+pub struct RemoteAskRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+{
+    actor_ref: &'a RemoteActorRef<A>,
+    msg: &'a M,
+    reply_timeout: Option<Duration>,
+}
+
+impl<'a, A, M> RemoteAskRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+{
+    /// Sets the reply timeout, overriding the node's default.
+    pub fn reply_timeout(mut self, duration: Duration) -> Self {
+        self.reply_timeout = Some(duration);
+        self
+    }
+
+    /// Sends the message and waits for the reply.
+    pub async fn send(
+        self,
+    ) -> Result<<A::Reply as Reply>::Ok, RemoteSendError<<A::Reply as Reply>::Error>>
+    where
+        <A::Reply as Reply>::Ok: DeserializeOwned,
+        <A::Reply as Reply>::Error: DeserializeOwned,
+    {
+        let timeout = self
+            .reply_timeout
+            .unwrap_or_else(|| self.actor_ref.pool.default_reply_timeout());
+        let frame = self
+            .actor_ref
+            .request_frame(self.msg, Some(timeout.as_millis() as u64))
+            .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
+        match self
+            .actor_ref
+            .pool
+            .ask(self.actor_ref.messaging_addr, frame, timeout)
+            .await
+        {
+            Ok(bytes) => rmp_serde::from_slice(&bytes)
+                .map_err(|err| RemoteSendError::DeserializeReply(err.to_string())),
+            Err(err) => Err(map_transport_error(err, |payload| {
+                match rmp_serde::from_slice(&payload) {
+                    Ok(err) => RemoteSendError::HandlerError(err),
+                    Err(err) => RemoteSendError::DeserializeHandlerError(err.to_string()),
+                }
+            })),
+        }
+    }
+}
+
+impl<'a, A, M> IntoFuture for RemoteAskRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+    <A::Reply as Reply>::Ok: DeserializeOwned,
+    <A::Reply as Reply>::Error: DeserializeOwned,
+{
+    type Output = Result<<A::Reply as Reply>::Ok, RemoteSendError<<A::Reply as Reply>::Error>>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.send())
+    }
+}
+
+/// A pending tell request to a remote actor.
+pub struct RemoteTellRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+{
+    actor_ref: &'a RemoteActorRef<A>,
+    msg: &'a M,
+}
+
+impl<'a, A, M> RemoteTellRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+{
+    /// Sends the message, returning once it is queued to the connection.
+    pub async fn send(self) -> Result<(), RemoteSendError> {
+        let frame = self
+            .actor_ref
+            .request_frame(self.msg, None)
+            .map_err(|err| RemoteSendError::SerializeMessage(err.to_string()))?;
+        self.actor_ref
+            .pool
+            .tell(self.actor_ref.messaging_addr, frame)
+            .await
+            .map_err(|err| {
+                // Tells receive no response, so remote errors cannot occur here.
+                map_transport_error(err, |_| RemoteSendError::ConnectionClosed)
+            })
+    }
+}
+
+impl<'a, A, M> IntoFuture for RemoteTellRequest<'a, A, M>
+where
+    A: RemoteActor + Message<M>,
+    M: RemoteMessage,
+{
+    type Output = Result<(), RemoteSendError>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.send())
+    }
+}
+
+fn map_transport_error<E>(
+    err: TransportError,
+    decode_handler_error: impl FnOnce(ByteBuf) -> RemoteSendError<E>,
+) -> RemoteSendError<E> {
+    match err {
+        TransportError::Connect(err) => RemoteSendError::Connect(err),
+        TransportError::ConnectionClosed => RemoteSendError::ConnectionClosed,
+        TransportError::ReplyTimeout => RemoteSendError::ReplyTimeout,
+        TransportError::Remote(err) => match err {
+            WireError::ActorNotRunning => RemoteSendError::ActorNotRunning,
+            WireError::ActorStopped => RemoteSendError::ActorStopped,
+            WireError::BadActorType => RemoteSendError::BadActorType,
+            WireError::MailboxFull => RemoteSendError::MailboxFull,
+            WireError::ReplyTimeout => RemoteSendError::ReplyTimeout,
+            WireError::UnknownActor { actor_remote_id } => {
+                RemoteSendError::UnknownActor { actor_remote_id }
+            }
+            WireError::UnknownMessage {
+                actor_remote_id,
+                message_remote_id,
+            } => RemoteSendError::UnknownMessage {
+                actor_remote_id,
+                message_remote_id,
+            },
+            WireError::HandlerError(payload) => decode_handler_error(payload),
+            WireError::DeserializeMessage(err) => RemoteSendError::DeserializeMessage(err),
+            WireError::SerializeReply(err) => RemoteSendError::SerializeReply(err),
+            WireError::SerializeHandlerError(err) => RemoteSendError::SerializeHandlerError(err),
+        },
+    }
+}

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -101,8 +101,8 @@ impl RemoteActor for OtherActor {
     fn remote_messages(_: &mut RemoteMessages<Self>) {}
 }
 
-async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
-    let config = RemoteNodeConfig {
+fn test_config(seed_nodes: Vec<String>) -> RemoteNodeConfig {
+    RemoteNodeConfig {
         cluster_id: "kameo-test".to_string(),
         gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
         messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
@@ -116,8 +116,11 @@ async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
             dead_node_grace_period: Duration::from_secs(20),
         },
         ..Default::default()
-    };
-    RemoteNode::bootstrap(config).await.unwrap()
+    }
+}
+
+async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
+    RemoteNode::bootstrap(test_config(seed_nodes)).await.unwrap()
 }
 
 /// Spawns two nodes, with the second seeded off the first.
@@ -327,7 +330,9 @@ async fn node_death_removes_registrations() {
     })
     .await;
 
-    node_b.shutdown().await.unwrap();
+    // Dropping the node aborts its gossip and messaging tasks without a clean
+    // departure, simulating a crash.
+    drop(node_b);
 
     // The failure detector on node a must declare node b dead.
     eventually(DEATH_DEADLINE, || async {
@@ -339,6 +344,85 @@ async fn node_death_removes_registrations() {
             .then_some(())
     })
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clean_shutdown_deregisters_quickly() {
+    // A slow failure detector, so fast removal can only come from the gossiped
+    // deletions performed by shutdown, not from failure detection.
+    let mut config_a = test_config(vec![]);
+    config_a.failure_detector_config = FailureDetectorConfig::default();
+    let node_a = RemoteNode::bootstrap(config_a).await.unwrap();
+    let mut config_b = test_config(vec![node_a.gossip_addr().to_string()]);
+    config_b.failure_detector_config = FailureDetectorConfig::default();
+    let node_b = RemoteNode::bootstrap(config_b).await.unwrap();
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_b.register(&counter, "counter").await.unwrap();
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_a.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    node_b.shutdown().await.unwrap();
+
+    eventually(Duration::from_secs(3), || async {
+        node_a
+            .lookup::<Counter>("counter")
+            .await
+            .unwrap()
+            .is_none()
+            .then_some(())
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_ref_rejected_after_restart() {
+    let node_a = spawn_test_node(vec![]).await;
+
+    // Node b has a fixed name so its restarted incarnation is the "same node".
+    let mut config = test_config(vec![node_a.gossip_addr().to_string()]);
+    config.node_name = Some("fixed-node".to_string());
+    let node_b = RemoteNode::bootstrap(config).await.unwrap();
+    let messaging_addr = node_b.messaging_addr();
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_b.register(&counter, "counter").await.unwrap();
+
+    let stale = eventually(GOSSIP_DEADLINE, || async {
+        node_a.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    node_b.shutdown().await.unwrap();
+
+    // Restart with the same name and messaging address, and re-register the same
+    // actor so the stale reference's sequence id is valid on the new incarnation.
+    let mut config = test_config(vec![node_a.gossip_addr().to_string()]);
+    config.node_name = Some("fixed-node".to_string());
+    config.messaging_listen_addr = messaging_addr;
+    let node_b2 = RemoteNode::bootstrap(config).await.unwrap();
+    assert_ne!(node_b2.generation_id(), stale.id().generation_id);
+    node_b2.register(&counter, "counter").await.unwrap();
+
+    // A fresh lookup targets the new incarnation and works.
+    let fresh = eventually(GOSSIP_DEADLINE, || async {
+        let remote = node_a.lookup::<Counter>("counter").await.unwrap()?;
+        (remote.id().generation_id == node_b2.generation_id()).then_some(remote)
+    })
+    .await;
+    assert_eq!(fresh.ask(&Get).await.unwrap(), 0);
+
+    // The stale reference carries the old generation and must be rejected, even
+    // though its sequence id matches a registered actor.
+    assert_eq!(stale.id().sequence_id, fresh.id().sequence_id);
+    let err = stale.ask(&Get).await.unwrap_err();
+    assert!(
+        matches!(err, RemoteSendError::ActorNotRunning),
+        "expected ActorNotRunning, got {err:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -547,7 +547,7 @@ async fn stale_ref_rejected_after_restart() {
 async fn watch_stream() {
     let (node_a, node_b) = spawn_test_cluster().await;
 
-    let mut watch = Box::pin(node_b.watch::<Counter>("watched").await);
+    let mut watch = Box::pin(node_b.watch::<Counter>("watched").await.unwrap());
 
     let counter = Counter::spawn(Counter { count: 0 });
     node_a.register(&counter, "watched").await.unwrap();
@@ -578,6 +578,62 @@ async fn watch_stream() {
     })
     .await
     .expect("timed out waiting for deregistration");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn registration_keeps_actor_alive_until_shutdown() {
+    let node = spawn_test_node(vec![]).await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node.register(&counter, "counter").await.unwrap();
+
+    // The registry holds a strong ref, so the actor survives dropping ours.
+    let weak = counter.downgrade();
+    drop(counter);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        weak.upgrade().is_some(),
+        "registered actor should be kept alive by the registry"
+    );
+
+    // Shutdown releases the registry's refs, letting the actor stop.
+    node.shutdown().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(5), weak.wait_for_shutdown())
+        .await
+        .expect("actor should stop once its registration is released");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn registry_ops_fail_after_shutdown() {
+    let node = spawn_test_node(vec![]).await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node.register(&counter, "counter").await.unwrap();
+    let local = node.lookup::<Counter>("counter").await.unwrap().unwrap();
+
+    node.shutdown().await.unwrap();
+
+    assert_eq!(
+        node.register(&counter, "counter").await.unwrap_err(),
+        RegistryError::NodeShutdown
+    );
+    assert_eq!(
+        node.deregister(&counter, "counter").await.unwrap_err(),
+        RegistryError::NodeShutdown
+    );
+    assert_eq!(
+        node.lookup::<Counter>("counter").await.unwrap_err(),
+        RegistryError::NodeShutdown
+    );
+    assert!(node.watch::<Counter>("counter").await.is_err());
+
+    // Local fast-path refs held from before the shutdown resolve to nothing, like
+    // remote peers observing the departure.
+    let err = local.ask(&Get).await.unwrap_err();
+    assert!(
+        matches!(err, RemoteSendError::ActorNotRunning),
+        "expected ActorNotRunning, got {err:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -120,7 +120,9 @@ fn test_config(seed_nodes: Vec<String>) -> RemoteNodeConfig {
 }
 
 async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
-    RemoteNode::bootstrap(test_config(seed_nodes)).await.unwrap()
+    RemoteNode::bootstrap(test_config(seed_nodes))
+        .await
+        .unwrap()
 }
 
 /// Spawns two nodes, with the second seeded off the first.
@@ -268,6 +270,57 @@ async fn unknown_message() {
     };
     assert_eq!(actor_remote_id, "test::Counter");
     assert_eq!(message_remote_id, "test::Undeclared");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn acked_tell_surfaces_errors() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    // The delivery ack carries dispatch errors back to the sender.
+    let err = remote.tell(&Undeclared).await.unwrap_err();
+    assert!(
+        matches!(err, RemoteSendError::UnknownMessage { .. }),
+        "expected UnknownMessage, got {err:?}"
+    );
+
+    // Fire-and-forget only reports local failures; the remote error is not observed.
+    remote.tell(&Undeclared).send_unacked().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn same_node_fast_path() {
+    // A bogus messaging advertise address: if any message touched TCP, it would fail
+    // to connect. Local refs must work anyway, proving in-process dispatch.
+    let mut config = test_config(vec![]);
+    config.messaging_advertise_addr = Some("127.0.0.1:1".parse().unwrap());
+    let node = RemoteNode::bootstrap(config).await.unwrap();
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node.register(&counter, "counter").await.unwrap();
+
+    let local = eventually(GOSSIP_DEADLINE, || async {
+        node.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+    assert!(local.is_local());
+
+    assert_eq!(local.ask(&Inc { amount: 4 }).await.unwrap(), 4);
+    local.tell(&Inc { amount: 1 }).await.unwrap();
+    assert_eq!(local.ask(&Get).await.unwrap(), 5);
+
+    // Errors flow through the same dispatch path locally.
+    let err = local.ask(&Fail).await.unwrap_err();
+    assert!(matches!(err, RemoteSendError::HandlerError(_)));
+    let err = local.tell(&Undeclared).await.unwrap_err();
+    assert!(matches!(err, RemoteSendError::UnknownMessage { .. }));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -1,0 +1,405 @@
+use std::time::{Duration, Instant};
+
+use futures::{Future, StreamExt};
+use kameo::prelude::*;
+use kameo_remote::{
+    FailureDetectorConfig, RegistryError, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode,
+    RemoteNodeConfig, RemoteSendError,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Actor)]
+struct Counter {
+    count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inc {
+    amount: i64,
+}
+
+impl Message<Inc> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "test::Inc";
+}
+
+#[derive(Serialize, Deserialize)]
+struct Get;
+
+impl Message<Get> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, _: Get, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count
+    }
+}
+
+impl RemoteMessage for Get {
+    const REMOTE_ID: &'static str = "test::Get";
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct TestError(String);
+
+#[derive(Serialize, Deserialize)]
+struct Fail;
+
+impl Message<Fail> for Counter {
+    type Reply = Result<i64, TestError>;
+
+    async fn handle(
+        &mut self,
+        _: Fail,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Result<i64, TestError> {
+        Err(TestError("boom".to_string()))
+    }
+}
+
+impl RemoteMessage for Fail {
+    const REMOTE_ID: &'static str = "test::Fail";
+}
+
+/// Handled by `Counter`, but deliberately not declared in `remote_messages`.
+#[derive(Serialize, Deserialize)]
+struct Undeclared;
+
+impl Message<Undeclared> for Counter {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Undeclared, _: &mut Context<Self, Self::Reply>) {}
+}
+
+impl RemoteMessage for Undeclared {
+    const REMOTE_ID: &'static str = "test::Undeclared";
+}
+
+impl RemoteActor for Counter {
+    const REMOTE_ID: &'static str = "test::Counter";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+        handlers.add::<Get>();
+        handlers.add::<Fail>();
+    }
+}
+
+#[derive(Actor)]
+struct OtherActor;
+
+impl RemoteActor for OtherActor {
+    const REMOTE_ID: &'static str = "test::OtherActor";
+
+    fn remote_messages(_: &mut RemoteMessages<Self>) {}
+}
+
+async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
+    let config = RemoteNodeConfig {
+        cluster_id: "kameo-test".to_string(),
+        gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        seed_nodes,
+        gossip_interval: Duration::from_millis(50),
+        failure_detector_config: FailureDetectorConfig {
+            phi_threshold: 8.0,
+            sampling_window_size: 1000,
+            max_interval: Duration::from_millis(500),
+            initial_interval: Duration::from_millis(100),
+            dead_node_grace_period: Duration::from_secs(20),
+        },
+        ..Default::default()
+    };
+    RemoteNode::bootstrap(config).await.unwrap()
+}
+
+/// Spawns two nodes, with the second seeded off the first.
+async fn spawn_test_cluster() -> (RemoteNode, RemoteNode) {
+    let node_a = spawn_test_node(vec![]).await;
+    let node_b = spawn_test_node(vec![node_a.gossip_addr().to_string()]).await;
+    (node_a, node_b)
+}
+
+async fn eventually<T, F, Fut>(deadline: Duration, mut condition: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let start = Instant::now();
+    loop {
+        if let Some(value) = condition().await {
+            return value;
+        }
+        if start.elapsed() > deadline {
+            panic!("condition not met within {deadline:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+const GOSSIP_DEADLINE: Duration = Duration::from_secs(10);
+const DEATH_DEADLINE: Duration = Duration::from_secs(30);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn register_and_lookup() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    assert_eq!(remote.node_id(), node_a.node_id());
+    assert_eq!(remote.id().sequence_id, counter.id().sequence_id());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_all_set_semantics() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter_1 = Counter::spawn(Counter { count: 0 });
+    let counter_2 = Counter::spawn(Counter { count: 0 });
+    let counter_3 = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter_1, "workers").await.unwrap();
+    node_a.register(&counter_2, "workers").await.unwrap();
+    node_b.register(&counter_3, "workers").await.unwrap();
+
+    let refs = eventually(GOSSIP_DEADLINE, || async {
+        let refs = node_b.lookup_all::<Counter>("workers").await.unwrap();
+        (refs.len() == 3).then_some(refs)
+    })
+    .await;
+
+    let mut ids: Vec<_> = refs.iter().map(|remote| remote.id().clone()).collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), 3, "provider ids should be distinct");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ask_round_trip() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    assert_eq!(remote.ask(&Inc { amount: 5 }).await.unwrap(), 5);
+    assert_eq!(remote.ask(&Inc { amount: 2 }).await.unwrap(), 7);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ask_handler_error() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    let err = remote.ask(&Fail).await.unwrap_err();
+    let RemoteSendError::HandlerError(err) = err else {
+        panic!("expected HandlerError, got {err:?}");
+    };
+    assert_eq!(err, TestError("boom".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tell_then_observe() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    remote.tell(&Inc { amount: 3 }).await.unwrap();
+
+    let count = eventually(GOSSIP_DEADLINE, || async {
+        let count = remote.ask(&Get).await.unwrap();
+        (count == 3).then_some(count)
+    })
+    .await;
+    assert_eq!(count, 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_message() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    let err = remote.ask(&Undeclared).await.unwrap_err();
+    let RemoteSendError::UnknownMessage {
+        actor_remote_id,
+        message_remote_id,
+    } = err
+    else {
+        panic!("expected UnknownMessage, got {err:?}");
+    };
+    assert_eq!(actor_remote_id, "test::Counter");
+    assert_eq!(message_remote_id, "test::Undeclared");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bad_actor_type() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let other = OtherActor::spawn(OtherActor);
+    node_a.register(&other, "conflict").await.unwrap();
+
+    // Wait until node b sees the registration under its true type.
+    eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<OtherActor>("conflict").await.unwrap()
+    })
+    .await;
+
+    let err = node_b.lookup::<Counter>("conflict").await.unwrap_err();
+    assert_eq!(
+        err,
+        RegistryError::BadActorType {
+            name: "conflict".to_string(),
+            expected_remote_id: "test::Counter",
+        }
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deregister_removes() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    node_a.deregister(&counter, "counter").await.unwrap();
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_b
+            .lookup::<Counter>("counter")
+            .await
+            .unwrap()
+            .is_none()
+            .then_some(())
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn node_death_removes_registrations() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_b.register(&counter, "counter").await.unwrap();
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_a.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    node_b.shutdown().await.unwrap();
+
+    // The failure detector on node a must declare node b dead.
+    eventually(DEATH_DEADLINE, || async {
+        node_a
+            .lookup::<Counter>("counter")
+            .await
+            .unwrap()
+            .is_none()
+            .then_some(())
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watch_stream() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let mut watch = Box::pin(node_b.watch::<Counter>("watched").await);
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "watched").await.unwrap();
+
+    // The stream yields provider sets on change; await one containing the registration.
+    let providers = tokio::time::timeout(GOSSIP_DEADLINE, async {
+        loop {
+            let providers = watch.next().await.expect("watch stream ended");
+            if !providers.is_empty() {
+                break providers;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for provider");
+    assert_eq!(providers.len(), 1);
+    assert_eq!(providers[0].node_id(), node_a.node_id());
+
+    node_a.deregister(&counter, "watched").await.unwrap();
+
+    tokio::time::timeout(GOSSIP_DEADLINE, async {
+        loop {
+            let providers = watch.next().await.expect("watch stream ended");
+            if providers.is_empty() {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for deregistration");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn actor_shutdown_auto_deregisters() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+
+    counter.stop_gracefully().await.unwrap();
+    counter.wait_for_shutdown().await;
+
+    eventually(GOSSIP_DEADLINE, || async {
+        node_b
+            .lookup::<Counter>("counter")
+            .await
+            .unwrap()
+            .is_none()
+            .then_some(())
+    })
+    .await;
+}

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -637,6 +637,43 @@ async fn registry_ops_fail_after_shutdown() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn remote_refs_and_watches_end_after_node_shutdown() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+    assert_eq!(remote.ask(&Inc { amount: 1 }).await.unwrap(), 1);
+
+    let mut watch = Box::pin(node_b.watch::<Counter>("counter").await.unwrap());
+
+    // Shutting down node b (the sender) invalidates the refs and watches it handed out.
+    node_b.shutdown().await.unwrap();
+
+    let err = remote.ask(&Inc { amount: 1 }).await.unwrap_err();
+    assert!(
+        matches!(err, RemoteSendError::NodeShutdown),
+        "expected NodeShutdown, got {err:?}"
+    );
+    let err = remote.tell(&Inc { amount: 1 }).await.unwrap_err();
+    assert!(
+        matches!(err, RemoteSendError::NodeShutdown),
+        "expected NodeShutdown, got {err:?}"
+    );
+
+    // The watch stream ends rather than freezing on stale state.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while watch.next().await.is_some() {}
+    })
+    .await
+    .expect("watch stream should end after shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn actor_shutdown_auto_deregisters() {
     let (node_a, node_b) = spawn_test_cluster().await;
 

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -358,7 +358,8 @@ async fn same_node_fast_path() {
 
     assert_eq!(local.ask(&Inc { amount: 4 }).await.unwrap(), 4);
     local.tell(&Inc { amount: 1 }).await.unwrap();
-    assert_eq!(local.ask(&Get).await.unwrap(), 5);
+    local.tell(&Inc { amount: 1 }).send_unacked().await.unwrap();
+    assert_eq!(local.ask(&Get).await.unwrap(), 6);
 
     // Errors flow through the same dispatch path locally.
     let err = local.ask(&Fail).await.unwrap_err();

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -101,6 +101,50 @@ impl RemoteActor for OtherActor {
     fn remote_messages(_: &mut RemoteMessages<Self>) {}
 }
 
+#[derive(Actor)]
+struct Sequencer {
+    values: Vec<u32>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Push(u32);
+
+impl Message<Push> for Sequencer {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Push, _: &mut Context<Self, Self::Reply>) {
+        self.values.push(msg.0);
+    }
+}
+
+impl RemoteMessage for Push {
+    const REMOTE_ID: &'static str = "test::Push";
+}
+
+#[derive(Serialize, Deserialize)]
+struct GetAll;
+
+impl Message<GetAll> for Sequencer {
+    type Reply = Vec<u32>;
+
+    async fn handle(&mut self, _: GetAll, _: &mut Context<Self, Self::Reply>) -> Vec<u32> {
+        self.values.clone()
+    }
+}
+
+impl RemoteMessage for GetAll {
+    const REMOTE_ID: &'static str = "test::GetAll";
+}
+
+impl RemoteActor for Sequencer {
+    const REMOTE_ID: &'static str = "test::Sequencer";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Push>();
+        handlers.add::<GetAll>();
+    }
+}
+
 fn test_config(seed_nodes: Vec<String>) -> RemoteNodeConfig {
     RemoteNodeConfig {
         cluster_id: "kameo-test".to_string(),
@@ -321,6 +365,27 @@ async fn same_node_fast_path() {
     assert!(matches!(err, RemoteSendError::HandlerError(_)));
     let err = local.tell(&Undeclared).await.unwrap_err();
     assert!(matches!(err, RemoteSendError::UnknownMessage { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn per_pair_ordering() {
+    let (node_a, node_b) = spawn_test_cluster().await;
+
+    let sequencer = Sequencer::spawn(Sequencer { values: Vec::new() });
+    node_a.register(&sequencer, "sequencer").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Sequencer>("sequencer").await.unwrap()
+    })
+    .await;
+
+    // Pipelined unacked tells must be delivered in send order, and the final ask
+    // must be ordered after all of them.
+    for i in 0..200 {
+        remote.tell(&Push(i)).send_unacked().await.unwrap();
+    }
+    let values = remote.ask(&GetAll).await.unwrap();
+    assert_eq!(values, (0..200).collect::<Vec<u32>>());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This adds `kameo_remote`, a new workspace crate that connects kameo actors across nodes without libp2p. It is a from-scratch replacement for the core `remote` feature, built on plain TCP for messaging and [chitchat](https://github.com/quickwit-oss/chitchat) (gossip with scuttlebutt reconciliation, from Quickwit) for cluster membership and the actor registry.

Core kameo is untouched. Stripping the old `remote` feature out of the core crate will be a separate PR, so the two implementations coexist until then. The crate is marked `release = false` in release-plz while it is experimental.

## Why

The libp2p based remote support is heavy and opaque: a kademlia DHT for what is ultimately a small registry, multi-hop lookups, and a large dependency tree that is hard to reason about when something goes wrong. This design trades that for a model suited to the cluster sizes kameo targets (tens of nodes, comfortable into the hundreds):

- Every node holds the full registry, replicated by gossip. Lookups are local and instant.
- Each node is the sole writer of its own registrations, so there are no write conflicts to resolve.
- Liveness comes from the gossip failure detector: when a node dies, its registrations vanish everywhere automatically.
- Messaging is a length-prefixed MessagePack protocol over pooled TCP connections, one per node pair. It can be inspected with tcpdump.

## Usage

```rust
use kameo::prelude::*;
use kameo_remote::{RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig};

impl RemoteMessage for Inc {
    const REMOTE_ID: &'static str = "example::Inc";
}

impl RemoteActor for Counter {
    const REMOTE_ID: &'static str = "example::Counter";

    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
        handlers.add::<Inc>();
    }
}

let node = RemoteNode::bootstrap(
    RemoteNodeConfig::default().with_seed_nodes(["10.0.0.1:7400"]),
).await?;

let counter = Counter::spawn(Counter { count: 0 });
node.register(&counter, "counter").await?;

// From any node in the cluster:
if let Some(counter) = node.lookup::<Counter>("counter").await? {
    let count = counter.ask(&Inc { amount: 1 }).await?;
}
```

Dispatch is declared on the actor type through the `RemoteActor` trait, with no macros and no linkme: registration builds per-node dispatch tables from `remote_messages`. Message and actor wire ids are explicit strings, since `type_name` is not stable across builds. A derive macro can be layered on later as sugar.

## Semantics

- **Registry**: set semantics per name. Any number of actors, across any number of nodes, can register the same name; `lookup_all` returns them all and `watch` streams the provider set as it changes. Lookups are type checked against the actor's `REMOTE_ID`. The registry holds a strong ref to registered actors, matching the local in-process registry, so a registered actor lives until it is deregistered, stopped, or its node shuts down.
- **Asks** carry typed replies and typed handler errors over the wire, with per-request reply timeouts.
- **Tells** are acknowledged on mailbox delivery, matching the semantics of a local `tell(..).send()`: the sender sees `ActorNotRunning`, `MailboxFull`, or `UnknownMessage` instead of silence. `send_unacked()` is the fire-and-forget alternative.
- **Ordering**: messages from one node to one target actor are delivered to its mailbox in send order. The server processes requests through one FIFO worker per (connection, target actor), so different actors and different senders stay concurrent.
- **Stale refs are rejected**: actor identity includes the node incarnation's generation, so a ref from before a node restart can never reach an unrelated actor that reuses the same sequence id.
- **Same-node refs** skip TCP and dispatch in-process (still serialized, identical behavior).
- **Clean shutdown** deregisters everything and gives gossip a couple of rounds to propagate, so peers converge immediately instead of waiting for failure detection. Shutdown also releases registered actors, tears down the connection pool, ends watch streams, and fails all further registry ops on that node.

## Not in scope for this PR

- [ ] TLS and authentication: anyone who can reach the ports can join and send. Use trusted networks only. This is the main gap before serious use (#380).
- [ ] Derive macro sugar for `RemoteActor` and `RemoteMessage`.
- [ ] Metrics.
- [ ] Removing the core `remote` feature (#376).

## Testing

- 19 multi-node integration tests covering registration, lookup, set semantics, ask and tell round trips, error propagation, unknown message and wrong type errors, deregistration, watch streams, auto deregistration on actor stop, node death via failure detection, clean shutdown convergence, stale ref rejection after restart, per-pair ordering (validated to fail against the previous racy dispatch), and lifecycle edge cases around shutdown.
- 7 unit tests for the wire protocol and registry key schema, plus doctests.
- Verified end to end with separate OS processes: two `cluster` example nodes plus a `watch` example node, including a kill -9 crash (failure detector removes the dead node's registrations) and a rejoin.

CI runs the new crate in the existing build, test, and clippy matrices, and release-plz is configured with the `remote-v{{ version }}` tag pattern.
