### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2](https://github.com/tqwewe/kameo/compare/v0.22.1...v0.22.2) - 2026-07-17
+
+### <!-- 3 -->Fixed
+
+- Make `actor.handle_message` a root span linked to `actor.lifecycle` ([#382](https://github.com/tqwewe/kameo/pull/382)) [</>](https://github.com/tqwewe/kameo/commit/1315c811994d6ded956c4f821438a8e5f63e3556)
+
+### <!-- 4 -->Documentation
+
+- Clarify `ActorStopReason::Panicked` covers hook errors, add `PanicError::is_panic` ([#375](https://github.com/tqwewe/kameo/pull/375)) [</>](https://github.com/tqwewe/kameo/commit/0dff64a050d59738422b1fec43866cc57df7f923)
+
+
 ## [0.22.1](https://github.com/tqwewe/kameo/compare/v0.22.0...v0.22.1) - 2026-07-07
 
 ### <!-- 5 -->Misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "actors", "console", "macros"]
 
 [workspace.dependencies]
-kameo = { path = ".", version = "0.22.1" }
+kameo = { path = ".", version = "0.22.2" }
 
 futures = "0.3"
 tokio = "1.47"
@@ -18,7 +18,7 @@ all-features = true
 
 [package]
 name = "kameo"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Fault-tolerant Async Actors Built on Tokio"

--- a/actors/CHANGELOG.md
+++ b/actors/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1](https://github.com/tqwewe/kameo/compare/actors-v0.8.0...actors-v0.8.1) - 2026-07-17
+
+### <!-- 0 -->Added
+
+- Add FutureActor for running futures as actors ([#372](https://github.com/tqwewe/kameo/pull/372)) [</>](https://github.com/tqwewe/kameo/commit/1c66bf9d16f80cd374283616fdbbebd49a4df61b)
+
+
 ## [0.8.0](https://github.com/tqwewe/kameo/compare/actors-v0.7.0...actors-v0.8.0) - 2026-07-07
 
 ### <!-- 3 -->Fixed

--- a/actors/Cargo.toml
+++ b/actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_actors"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Utility actors for kameo"

--- a/console/CHANGELOG.md
+++ b/console/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4](https://github.com/tqwewe/kameo/compare/console-v0.1.3...console-v0.1.4) - 2026-07-17
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.1.3](https://github.com/tqwewe/kameo/compare/console-v0.1.2...console-v0.1.3) - 2026-07-07
 
 ### <!-- 5 -->Misc

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_console"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal UI for monitoring a running kameo actor system"


### PR DESCRIPTION



## 🤖 New release

* `kameo`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `kameo_actors`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `kameo_console`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `kameo`

<blockquote>

## [0.22.2](https://github.com/tqwewe/kameo/compare/v0.22.1...v0.22.2) - 2026-07-17

### <!-- 3 -->Fixed

- Make `actor.handle_message` a root span linked to `actor.lifecycle` ([#382](https://github.com/tqwewe/kameo/pull/382)) [</>](https://github.com/tqwewe/kameo/commit/1315c811994d6ded956c4f821438a8e5f63e3556)

### <!-- 4 -->Documentation

- Clarify `ActorStopReason::Panicked` covers hook errors, add `PanicError::is_panic` ([#375](https://github.com/tqwewe/kameo/pull/375)) [</>](https://github.com/tqwewe/kameo/commit/0dff64a050d59738422b1fec43866cc57df7f923)
</blockquote>

## `kameo_actors`

<blockquote>

## [0.8.1](https://github.com/tqwewe/kameo/compare/actors-v0.8.0...actors-v0.8.1) - 2026-07-17

### <!-- 0 -->Added

- Add FutureActor for running futures as actors ([#372](https://github.com/tqwewe/kameo/pull/372)) [</>](https://github.com/tqwewe/kameo/commit/1c66bf9d16f80cd374283616fdbbebd49a4df61b)
</blockquote>

## `kameo_console`

<blockquote>

## [0.1.4](https://github.com/tqwewe/kameo/compare/console-v0.1.3...console-v0.1.4) - 2026-07-17

### <!-- 5 -->Misc

- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).