### PR TITLE
fix(supervision)!: keep actor refs stable across restarts

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -301,9 +301,9 @@ pub trait Actor: Sized + Send + 'static {
     ) -> impl Future<Output = Result<ControlFlow<ActorStopReason>, Self::Error>> + Send {
         async move {
             match &reason {
-                ActorStopReason::Normal | ActorStopReason::SupervisorRestart => {
-                    Ok(ControlFlow::Continue(()))
-                }
+                ActorStopReason::Normal
+                | ActorStopReason::Shutdown
+                | ActorStopReason::SupervisorRestart => Ok(ControlFlow::Continue(())),
                 ActorStopReason::Killed
                 | ActorStopReason::Panicked(_)
                 | ActorStopReason::LinkDied { .. } => {

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -65,9 +65,9 @@ struct ActorRefInner<A: Actor> {
 }
 
 pub(crate) struct ActorLifecycle {
-    pub(crate) abort_handle: RwLock<AbortHandle>,
-    pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
-    pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+    abort_handle: RwLock<AbortHandle>,
+    startup_result: Arc<SetOnce<Result<(), PanicError>>>,
+    shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
 }
 
 impl ActorLifecycle {
@@ -77,6 +77,26 @@ impl ActorLifecycle {
             startup_result: Arc::new(SetOnce::new()),
             shutdown_result: Arc::new(SetOnce::new()),
         }
+    }
+
+    #[inline]
+    pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
+        *self.abort_handle.write().unwrap() = abort_handle;
+    }
+
+    #[inline]
+    pub(crate) fn abort(&self) {
+        self.abort_handle.read().unwrap().abort();
+    }
+
+    #[inline]
+    pub(crate) fn startup_result(&self) -> &Arc<SetOnce<Result<(), PanicError>>> {
+        &self.startup_result
+    }
+
+    #[inline]
+    pub(crate) fn shutdown_result(&self) -> &SetOnce<Result<ActorStopReason, PanicError>> {
+        &self.shutdown_result
     }
 }
 
@@ -104,7 +124,7 @@ where
 
     #[inline]
     pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
-        *self.inner.lifecycle.abort_handle.write().unwrap() = abort_handle;
+        self.inner.lifecycle.replace_abort_handle(abort_handle);
     }
 
     /// Returns a reference to the actor's links.
@@ -317,7 +337,7 @@ where
     /// Note: If the actor is in the middle of processing a message, it will abort processing of that message.
     #[inline]
     pub fn kill(&self) {
-        self.inner.lifecycle.abort_handle.read().unwrap().abort()
+        self.inner.lifecycle.abort()
     }
 
     /// Returns the startup result if the actor has finished starting up, or `None` if startup
@@ -363,7 +383,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.startup_result.get()? {
+        match self.inner.lifecycle.startup_result().get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -416,7 +436,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.startup_result.get()? {
+        match self.inner.lifecycle.startup_result().get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -469,7 +489,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.shutdown_result.get()? {
+        match self.inner.lifecycle.shutdown_result().get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -525,7 +545,7 @@ where
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.shutdown_result.get()? {
+        match self.inner.lifecycle.shutdown_result().get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -569,7 +589,7 @@ where
     /// ```
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.inner.lifecycle.startup_result.wait().await;
+        self.inner.lifecycle.startup_result().wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -609,7 +629,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.startup_result.wait().await {
+        match self.inner.lifecycle.startup_result().wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -656,7 +676,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.startup_result.wait().await {
+        match self.inner.lifecycle.startup_result().wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -746,7 +766,7 @@ where
         A::Error: Clone,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.lifecycle.shutdown_result.wait().await {
+        match self.inner.lifecycle.shutdown_result().wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -827,7 +847,7 @@ where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.lifecycle.shutdown_result.wait().await {
+        match self.inner.lifecycle.shutdown_result().wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2180,10 +2200,15 @@ pub struct WeakActorRef<A: Actor> {
     mailbox_sender: WeakMailboxSender<A>,
     default_reply_timeout: Option<Duration>,
     pub(crate) links: Links,
-    pub(crate) lifecycle: Arc<ActorLifecycle>,
+    lifecycle: Arc<ActorLifecycle>,
 }
 
 impl<A: Actor> WeakActorRef<A> {
+    #[inline]
+    pub(crate) fn shutdown_result(&self) -> &SetOnce<Result<ActorStopReason, PanicError>> {
+        self.lifecycle.shutdown_result()
+    }
+
     /// Returns the actor identifier.
     pub fn id(&self) -> ActorId {
         self.id
@@ -2192,7 +2217,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// Returns whether the actor is currently alive.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        !self.lifecycle.shutdown_result.initialized()
+        !self.lifecycle.shutdown_result().initialized()
     }
 
     /// Tries to convert a `WeakActorRef` into a [`ActorRef`]. This will return `Some`
@@ -2236,7 +2261,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::kill`] for full details on behavior.
     #[inline]
     pub fn kill(&self) {
-        self.lifecycle.abort_handle.read().unwrap().abort()
+        self.lifecycle.abort()
     }
 
     /// Waits for the actor to finish startup and become ready to process messages.
@@ -2244,7 +2269,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_startup`] for full details and examples.
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.lifecycle.startup_result.wait().await;
+        self.lifecycle.startup_result().wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -2254,7 +2279,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.startup_result.wait().await {
+        match self.lifecycle.startup_result().wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2269,7 +2294,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.startup_result.wait().await {
+        match self.lifecycle.startup_result().wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2283,7 +2308,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.startup_result.get()? {
+        match self.lifecycle.startup_result().get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2299,7 +2324,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.startup_result.get()? {
+        match self.lifecycle.startup_result().get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -2310,7 +2335,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_shutdown`] for full details and examples.
     #[inline]
     pub async fn wait_for_shutdown(&self) {
-        self.lifecycle.shutdown_result.wait().await;
+        self.lifecycle.shutdown_result().wait().await;
     }
 
     /// Waits for the actor to finish shutdown, returning the shutdown result with a clone of the error.
@@ -2320,7 +2345,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.shutdown_result.wait().await {
+        match self.lifecycle.shutdown_result().wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2335,7 +2360,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.shutdown_result.wait().await {
+        match self.lifecycle.shutdown_result().wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2349,7 +2374,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.shutdown_result.get()? {
+        match self.lifecycle.shutdown_result().get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2365,7 +2390,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.shutdown_result.get()? {
+        match self.lifecycle.shutdown_result().get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -2,7 +2,7 @@ use std::{
     cell::Cell,
     cmp, fmt,
     hash::{Hash, Hasher},
-    sync::{Arc, RwLock, Weak},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 
@@ -65,7 +65,7 @@ struct ActorRefInner<A: Actor> {
 }
 
 pub(crate) struct ActorLifecycle {
-    abort_handle: RwLock<AbortHandle>,
+    abort_handle: Mutex<AbortHandle>,
     startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
 }
@@ -73,7 +73,7 @@ pub(crate) struct ActorLifecycle {
 impl ActorLifecycle {
     pub(crate) fn new(abort_handle: AbortHandle) -> Self {
         ActorLifecycle {
-            abort_handle: RwLock::new(abort_handle),
+            abort_handle: Mutex::new(abort_handle),
             startup_result: Arc::new(SetOnce::new()),
             shutdown_result: Arc::new(SetOnce::new()),
         }
@@ -81,12 +81,12 @@ impl ActorLifecycle {
 
     #[inline]
     pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
-        *self.abort_handle.write().unwrap() = abort_handle;
+        *self.abort_handle.lock().unwrap() = abort_handle;
     }
 
     #[inline]
     pub(crate) fn abort(&self) {
-        self.abort_handle.read().unwrap().abort();
+        self.abort_handle.lock().unwrap().abort();
     }
 
     #[inline]

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -7,7 +7,11 @@ use std::{
 };
 
 use dyn_clone::DynClone;
-use futures::{FutureExt, Stream, StreamExt, TryFutureExt, future::BoxFuture, stream::AbortHandle};
+use futures::{
+    FutureExt, Stream, StreamExt, TryFutureExt,
+    future::BoxFuture,
+    stream::{AbortHandle, AbortRegistration},
+};
 use tokio::{sync::SetOnce, task::JoinHandle, task_local};
 
 #[cfg(feature = "remote")]
@@ -64,14 +68,14 @@ struct ActorRefInner<A: Actor> {
     lifecycle: Arc<ActorLifecycle>,
 }
 
-pub(crate) struct ActorLifecycle {
+struct ActorLifecycle {
     abort_handle: Mutex<AbortHandle>,
     startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
 }
 
 impl ActorLifecycle {
-    pub(crate) fn new(abort_handle: AbortHandle) -> Self {
+    fn new(abort_handle: AbortHandle) -> Self {
         ActorLifecycle {
             abort_handle: Mutex::new(abort_handle),
             startup_result: Arc::new(SetOnce::new()),
@@ -80,23 +84,15 @@ impl ActorLifecycle {
     }
 
     #[inline]
-    pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
+    fn reset_abort_handle(&self) -> AbortRegistration {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
         *self.abort_handle.lock().unwrap() = abort_handle;
+        abort_registration
     }
 
     #[inline]
-    pub(crate) fn abort(&self) {
+    fn abort(&self) {
         self.abort_handle.lock().unwrap().abort();
-    }
-
-    #[inline]
-    pub(crate) fn startup_result(&self) -> &Arc<SetOnce<Result<(), PanicError>>> {
-        &self.startup_result
-    }
-
-    #[inline]
-    pub(crate) fn shutdown_result(&self) -> &SetOnce<Result<ActorStopReason, PanicError>> {
-        &self.shutdown_result
     }
 }
 
@@ -109,22 +105,27 @@ where
         id: ActorId,
         mailbox: MailboxSender<A>,
         links: Links,
-        lifecycle: Arc<ActorLifecycle>,
+        abort_handle: AbortHandle,
     ) -> Self {
         ActorRef {
             inner: Arc::new(ActorRefInner {
                 id,
                 mailbox_sender: mailbox,
                 links,
-                lifecycle,
+                lifecycle: Arc::new(ActorLifecycle::new(abort_handle)),
             }),
             default_reply_timeout: None,
         }
     }
 
     #[inline]
-    pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
-        self.inner.lifecycle.replace_abort_handle(abort_handle);
+    pub(crate) fn startup_result(&self) -> Arc<SetOnce<Result<(), PanicError>>> {
+        Arc::clone(&self.inner.lifecycle.startup_result)
+    }
+
+    #[inline]
+    pub(crate) fn reset_abort_handle(&self) -> AbortRegistration {
+        self.inner.lifecycle.reset_abort_handle()
     }
 
     /// Returns a reference to the actor's links.
@@ -383,7 +384,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.startup_result().get()? {
+        match self.inner.lifecycle.startup_result.get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -436,7 +437,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.startup_result().get()? {
+        match self.inner.lifecycle.startup_result.get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -489,7 +490,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.shutdown_result().get()? {
+        match self.inner.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -545,7 +546,7 @@ where
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.shutdown_result().get()? {
+        match self.inner.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -589,7 +590,7 @@ where
     /// ```
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.inner.lifecycle.startup_result().wait().await;
+        self.inner.lifecycle.startup_result.wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -629,7 +630,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.lifecycle.startup_result().wait().await {
+        match self.inner.lifecycle.startup_result.wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -676,7 +677,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.lifecycle.startup_result().wait().await {
+        match self.inner.lifecycle.startup_result.wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -766,7 +767,7 @@ where
         A::Error: Clone,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.lifecycle.shutdown_result().wait().await {
+        match self.inner.lifecycle.shutdown_result.wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -847,7 +848,7 @@ where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.lifecycle.shutdown_result().wait().await {
+        match self.inner.lifecycle.shutdown_result.wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2206,7 +2207,7 @@ pub struct WeakActorRef<A: Actor> {
 impl<A: Actor> WeakActorRef<A> {
     #[inline]
     pub(crate) fn shutdown_result(&self) -> &SetOnce<Result<ActorStopReason, PanicError>> {
-        self.lifecycle.shutdown_result()
+        &self.lifecycle.shutdown_result
     }
 
     /// Returns the actor identifier.
@@ -2217,7 +2218,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// Returns whether the actor is currently alive.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        !self.lifecycle.shutdown_result().initialized()
+        !self.lifecycle.shutdown_result.initialized()
     }
 
     /// Tries to convert a `WeakActorRef` into a [`ActorRef`]. This will return `Some`
@@ -2269,7 +2270,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_startup`] for full details and examples.
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.lifecycle.startup_result().wait().await;
+        self.lifecycle.startup_result.wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -2279,7 +2280,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.startup_result().wait().await {
+        match self.lifecycle.startup_result.wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2294,7 +2295,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.startup_result().wait().await {
+        match self.lifecycle.startup_result.wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2308,7 +2309,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.startup_result().get()? {
+        match self.lifecycle.startup_result.get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2324,7 +2325,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.startup_result().get()? {
+        match self.lifecycle.startup_result.get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -2335,7 +2336,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_shutdown`] for full details and examples.
     #[inline]
     pub async fn wait_for_shutdown(&self) {
-        self.lifecycle.shutdown_result().wait().await;
+        self.lifecycle.shutdown_result.wait().await;
     }
 
     /// Waits for the actor to finish shutdown, returning the shutdown result with a clone of the error.
@@ -2345,7 +2346,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.shutdown_result().wait().await {
+        match self.lifecycle.shutdown_result.wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2360,7 +2361,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.shutdown_result().wait().await {
+        match self.lifecycle.shutdown_result.wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2374,7 +2375,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.lifecycle.shutdown_result().get()? {
+        match self.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2390,7 +2391,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.lifecycle.shutdown_result().get()? {
+        match self.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }

--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -2,7 +2,7 @@ use std::{
     cell::Cell,
     cmp, fmt,
     hash::{Hash, Hasher},
-    sync::{Arc, Weak},
+    sync::{Arc, RwLock, Weak},
     time::Duration,
 };
 
@@ -60,10 +60,24 @@ pub struct ActorRef<A: Actor> {
 struct ActorRefInner<A: Actor> {
     id: ActorId,
     mailbox_sender: MailboxSender<A>,
-    abort_handle: AbortHandle,
     links: Links,
-    startup_result: Arc<SetOnce<Result<(), PanicError>>>,
-    shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+    lifecycle: Arc<ActorLifecycle>,
+}
+
+pub(crate) struct ActorLifecycle {
+    pub(crate) abort_handle: RwLock<AbortHandle>,
+    pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
+    pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+}
+
+impl ActorLifecycle {
+    pub(crate) fn new(abort_handle: AbortHandle) -> Self {
+        ActorLifecycle {
+            abort_handle: RwLock::new(abort_handle),
+            startup_result: Arc::new(SetOnce::new()),
+            shutdown_result: Arc::new(SetOnce::new()),
+        }
+    }
 }
 
 impl<A> ActorRef<A>
@@ -74,22 +88,23 @@ where
     pub(crate) fn new(
         id: ActorId,
         mailbox: MailboxSender<A>,
-        abort_handle: AbortHandle,
         links: Links,
-        startup_result: Arc<SetOnce<Result<(), PanicError>>>,
-        shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+        lifecycle: Arc<ActorLifecycle>,
     ) -> Self {
         ActorRef {
             inner: Arc::new(ActorRefInner {
                 id,
                 mailbox_sender: mailbox,
-                abort_handle,
                 links,
-                startup_result,
-                shutdown_result,
+                lifecycle,
             }),
             default_reply_timeout: None,
         }
+    }
+
+    #[inline]
+    pub(crate) fn replace_abort_handle(&self, abort_handle: AbortHandle) {
+        *self.inner.lifecycle.abort_handle.write().unwrap() = abort_handle;
     }
 
     /// Returns a reference to the actor's links.
@@ -238,11 +253,9 @@ where
             id: self.inner.id,
             inner: Arc::downgrade(&self.inner),
             mailbox_sender: self.inner.mailbox_sender.downgrade(),
-            abort_handle: self.inner.abort_handle.clone(),
             default_reply_timeout: self.default_reply_timeout,
             links: self.inner.links.clone(),
-            startup_result: self.inner.startup_result.clone(),
-            shutdown_result: self.inner.shutdown_result.clone(),
+            lifecycle: self.inner.lifecycle.clone(),
         }
     }
 
@@ -304,7 +317,7 @@ where
     /// Note: If the actor is in the middle of processing a message, it will abort processing of that message.
     #[inline]
     pub fn kill(&self) {
-        self.inner.abort_handle.abort()
+        self.inner.lifecycle.abort_handle.read().unwrap().abort()
     }
 
     /// Returns the startup result if the actor has finished starting up, or `None` if startup
@@ -350,7 +363,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.startup_result.get()? {
+        match self.inner.lifecycle.startup_result.get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -403,7 +416,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.startup_result.get()? {
+        match self.inner.lifecycle.startup_result.get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -456,7 +469,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.shutdown_result.get()? {
+        match self.inner.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -512,7 +525,7 @@ where
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.inner.shutdown_result.get()? {
+        match self.inner.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -556,7 +569,7 @@ where
     /// ```
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.inner.startup_result.wait().await;
+        self.inner.lifecycle.startup_result.wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -596,7 +609,7 @@ where
     where
         A::Error: Clone,
     {
-        match self.inner.startup_result.wait().await {
+        match self.inner.lifecycle.startup_result.wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -643,7 +656,7 @@ where
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.inner.startup_result.wait().await {
+        match self.inner.lifecycle.startup_result.wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -733,7 +746,7 @@ where
         A::Error: Clone,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.shutdown_result.wait().await {
+        match self.inner.lifecycle.shutdown_result.wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -814,7 +827,7 @@ where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
         self.inner.mailbox_sender.closed().await;
-        match self.inner.shutdown_result.wait().await {
+        match self.inner.lifecycle.shutdown_result.wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2165,11 +2178,9 @@ pub struct WeakActorRef<A: Actor> {
     /// own lifecycle task holds a `WeakActorRef` and still needs them during teardown, after
     /// the last strong handle may already be gone.
     mailbox_sender: WeakMailboxSender<A>,
-    abort_handle: AbortHandle,
     default_reply_timeout: Option<Duration>,
     pub(crate) links: Links,
-    pub(crate) startup_result: Arc<SetOnce<Result<(), PanicError>>>,
-    pub(crate) shutdown_result: Arc<SetOnce<Result<ActorStopReason, PanicError>>>,
+    pub(crate) lifecycle: Arc<ActorLifecycle>,
 }
 
 impl<A: Actor> WeakActorRef<A> {
@@ -2181,7 +2192,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// Returns whether the actor is currently alive.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        !self.shutdown_result.initialized()
+        !self.lifecycle.shutdown_result.initialized()
     }
 
     /// Tries to convert a `WeakActorRef` into a [`ActorRef`]. This will return `Some`
@@ -2225,7 +2236,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::kill`] for full details on behavior.
     #[inline]
     pub fn kill(&self) {
-        self.abort_handle.abort()
+        self.lifecycle.abort_handle.read().unwrap().abort()
     }
 
     /// Waits for the actor to finish startup and become ready to process messages.
@@ -2233,7 +2244,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_startup`] for full details and examples.
     #[inline]
     pub async fn wait_for_startup(&self) {
-        self.startup_result.wait().await;
+        self.lifecycle.startup_result.wait().await;
     }
 
     /// Waits for the actor to finish startup, returning the startup result with a clone of the error.
@@ -2243,7 +2254,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.startup_result.wait().await {
+        match self.lifecycle.startup_result.wait().await {
             Ok(()) => Ok(()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2258,7 +2269,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.startup_result.wait().await {
+        match self.lifecycle.startup_result.wait().await {
             Ok(()) => f(Ok(())),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2272,7 +2283,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.startup_result.get()? {
+        match self.lifecycle.startup_result.get()? {
             Ok(()) => Some(Ok(())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2288,7 +2299,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<(), HookError<&A::Error>>) -> R,
     {
-        match self.startup_result.get()? {
+        match self.lifecycle.startup_result.get()? {
             Ok(()) => Some(f(Ok(()))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -2299,7 +2310,7 @@ impl<A: Actor> WeakActorRef<A> {
     /// See [`ActorRef::wait_for_shutdown`] for full details and examples.
     #[inline]
     pub async fn wait_for_shutdown(&self) {
-        self.shutdown_result.wait().await;
+        self.lifecycle.shutdown_result.wait().await;
     }
 
     /// Waits for the actor to finish shutdown, returning the shutdown result with a clone of the error.
@@ -2309,7 +2320,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.shutdown_result.wait().await {
+        match self.lifecycle.shutdown_result.wait().await {
             Ok(reason) => Ok(reason.clone()),
             Err(err) => Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2324,7 +2335,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.shutdown_result.wait().await {
+        match self.lifecycle.shutdown_result.wait().await {
             Ok(reason) => f(Ok(reason)),
             Err(err) => handle_hook_panic(f, err),
         }
@@ -2338,7 +2349,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         A::Error: Clone,
     {
-        match self.shutdown_result.get()? {
+        match self.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(Ok(reason.clone())),
             Err(err) => Some(Err(err
                 .with_downcast_ref(|err: &A::Error| HookError::Error(err.clone()))
@@ -2354,7 +2365,7 @@ impl<A: Actor> WeakActorRef<A> {
     where
         F: FnOnce(Result<&ActorStopReason, HookError<&A::Error>>) -> R,
     {
-        match self.shutdown_result.get()? {
+        match self.lifecycle.shutdown_result.get()? {
             Ok(reason) => Some(f(Ok(reason))),
             Err(err) => Some(handle_hook_panic(f, err)),
         }
@@ -2481,11 +2492,9 @@ impl<A: Actor> Clone for WeakActorRef<A> {
             id: self.id,
             inner: self.inner.clone(),
             mailbox_sender: self.mailbox_sender.clone(),
-            abort_handle: self.abort_handle.clone(),
             default_reply_timeout: self.default_reply_timeout,
             links: self.links.clone(),
-            startup_result: self.startup_result.clone(),
-            shutdown_result: self.shutdown_result.clone(),
+            lifecycle: self.lifecycle.clone(),
         }
     }
 }

--- a/src/actor/kind.rs
+++ b/src/actor/kind.rs
@@ -232,7 +232,7 @@ where
         dead_actor_sibblings: Option<HashMap<ActorId, Link>>,
     ) -> ControlFlow<ActorStopReason> {
         {
-            let links = self.actor_ref.links.lock().await;
+            let mut links = self.actor_ref.links.lock().await;
 
             // Check if we're already coordinating a restart
             if let CoordinationState::Coordinating {
@@ -339,6 +339,15 @@ where
                     ControlFlow::Break(no_restart_reason) => {
                         #[cfg(feature = "tracing")]
                         match no_restart_reason {
+                            crate::links::NoRestartReason::Shutdown => {
+                                tracing::debug!(
+                                    %id,
+                                    name = A::name(),
+                                    ?reason,
+                                    decision = %no_restart_reason,
+                                    "actor not restarted"
+                                );
+                            }
                             crate::links::NoRestartReason::NormalExitUnderTransientPolicy => {
                                 tracing::debug!(
                                     %id,
@@ -380,6 +389,7 @@ where
                                 while let Some(()) = notify_futs.next().await {}
                             });
                         }
+                        links.children.remove(&id);
                     }
                 }
             }
@@ -405,10 +415,13 @@ where
         }
     }
 
-    pub(crate) async fn handle_stop(&mut self) -> ControlFlow<ActorStopReason> {
+    pub(crate) async fn handle_stop(
+        &mut self,
+        reason: ActorStopReason,
+    ) -> ControlFlow<ActorStopReason> {
         self.actor_ref.links.set_children_parent_shutdown().await;
         match self.handle_startup_finished().await {
-            ControlFlow::Continue(_) => ControlFlow::Break(ActorStopReason::Normal),
+            ControlFlow::Continue(_) => ControlFlow::Break(reason),
             ControlFlow::Break(reason) => ControlFlow::Break(reason),
         }
     }
@@ -419,6 +432,7 @@ where
     ) -> ControlFlow<ActorStopReason> {
         match reason {
             ActorStopReason::Normal => ControlFlow::Break(ActorStopReason::Normal),
+            ActorStopReason::Shutdown => ControlFlow::Break(ActorStopReason::Shutdown),
             ActorStopReason::SupervisorRestart => {
                 ControlFlow::Break(ActorStopReason::SupervisorRestart)
             }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -19,7 +19,7 @@ use tracing::{Instrument, error, trace};
 use crate::remote;
 
 use crate::{
-    actor::{Actor, ActorLifecycle, ActorRef, CURRENT_ACTOR_ID, kind::ActorBehaviour},
+    actor::{Actor, ActorRef, CURRENT_ACTOR_ID, kind::ActorBehaviour},
     error::{ActorStopReason, PanicError, PanicReason, SendError, invoke_actor_error_hook},
     links::Links,
     mailbox::{MailboxReceiver, MailboxSender, Signal},
@@ -66,9 +66,8 @@ impl<A: Actor> PreparedActor<A> {
         links: Links,
     ) -> Self {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        let lifecycle = Arc::new(ActorLifecycle::new(abort_handle));
-        let startup_result = lifecycle.startup_result().clone();
-        let actor_ref = ActorRef::new(actor_id, mailbox_tx, links, lifecycle);
+        let actor_ref = ActorRef::new(actor_id, mailbox_tx, links, abort_handle);
+        let startup_result = actor_ref.startup_result();
 
         #[cfg(feature = "console")]
         let monitor = crate::console::registry::register_or_get(&actor_ref);
@@ -84,8 +83,7 @@ impl<A: Actor> PreparedActor<A> {
     }
 
     pub(crate) fn restart(actor_ref: ActorRef<A>, mailbox_rx: MailboxReceiver<A>) -> Self {
-        let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        actor_ref.replace_abort_handle(abort_handle);
+        let abort_registration = actor_ref.reset_abort_handle();
         let startup_result = Arc::new(SetOnce::new());
 
         #[cfg(feature = "console")]

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -67,7 +67,7 @@ impl<A: Actor> PreparedActor<A> {
     ) -> Self {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         let lifecycle = Arc::new(ActorLifecycle::new(abort_handle));
-        let startup_result = lifecycle.startup_result.clone();
+        let startup_result = lifecycle.startup_result().clone();
         let actor_ref = ActorRef::new(actor_id, mailbox_tx, links, lifecycle);
 
         #[cfg(feature = "console")]
@@ -329,8 +329,7 @@ where
                     Ok(()) => {
                         if !is_restarting {
                             actor_ref
-                                .lifecycle
-                                .shutdown_result
+                                .shutdown_result()
                                 .set(Ok(reason.clone()))
                                 .expect("nothing else should set the shutdown result");
                         }
@@ -340,8 +339,7 @@ where
 
                         if !is_restarting {
                             actor_ref
-                                .lifecycle
-                                .shutdown_result
+                                .shutdown_result()
                                 .set(Err(err))
                                 .expect("nothing else should set the shutdown result");
                         }
@@ -383,8 +381,7 @@ where
 
                 if !is_restarting {
                     actor_ref
-                        .lifecycle
-                        .shutdown_result
+                        .shutdown_result()
                         .set(Err(err.clone()))
                         .expect("nothing should set the shutdown result");
                 }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -19,7 +19,7 @@ use tracing::{Instrument, error, trace};
 use crate::remote;
 
 use crate::{
-    actor::{Actor, ActorRef, CURRENT_ACTOR_ID, kind::ActorBehaviour},
+    actor::{Actor, ActorLifecycle, ActorRef, CURRENT_ACTOR_ID, kind::ActorBehaviour},
     error::{ActorStopReason, PanicError, PanicReason, SendError, invoke_actor_error_hook},
     links::Links,
     mailbox::{MailboxReceiver, MailboxSender, Signal},
@@ -40,6 +40,7 @@ pub struct PreparedActor<A: Actor> {
     actor_ref: ActorRef<A>,
     mailbox_rx: MailboxReceiver<A>,
     abort_registration: AbortRegistration,
+    startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     #[cfg(feature = "console")]
     monitor: Arc<crate::console::registry::ActorMonitor>,
 }
@@ -65,16 +66,9 @@ impl<A: Actor> PreparedActor<A> {
         links: Links,
     ) -> Self {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        let startup_result = Arc::new(SetOnce::new());
-        let shutdown_result = Arc::new(SetOnce::new());
-        let actor_ref = ActorRef::new(
-            actor_id,
-            mailbox_tx,
-            abort_handle,
-            links,
-            startup_result,
-            shutdown_result,
-        );
+        let lifecycle = Arc::new(ActorLifecycle::new(abort_handle));
+        let startup_result = lifecycle.startup_result.clone();
+        let actor_ref = ActorRef::new(actor_id, mailbox_tx, links, lifecycle);
 
         #[cfg(feature = "console")]
         let monitor = crate::console::registry::register_or_get(&actor_ref);
@@ -83,6 +77,25 @@ impl<A: Actor> PreparedActor<A> {
             actor_ref,
             mailbox_rx,
             abort_registration,
+            startup_result,
+            #[cfg(feature = "console")]
+            monitor,
+        }
+    }
+
+    pub(crate) fn restart(actor_ref: ActorRef<A>, mailbox_rx: MailboxReceiver<A>) -> Self {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        actor_ref.replace_abort_handle(abort_handle);
+        let startup_result = Arc::new(SetOnce::new());
+
+        #[cfg(feature = "console")]
+        let monitor = crate::console::registry::register_or_get(&actor_ref);
+
+        PreparedActor {
+            actor_ref,
+            mailbox_rx,
+            abort_registration,
+            startup_result,
             #[cfg(feature = "console")]
             monitor,
         }
@@ -150,6 +163,7 @@ impl<A: Actor> PreparedActor<A> {
             self.actor_ref,
             self.mailbox_rx,
             self.abort_registration,
+            self.startup_result,
             #[cfg(feature = "console")]
             self.monitor,
         )
@@ -201,6 +215,7 @@ async fn run_actor_lifecycle<A>(
     actor_ref: ActorRef<A>,
     mut mailbox_rx: MailboxReceiver<A>,
     abort_registration: AbortRegistration,
+    startup_result: Arc<SetOnce<Result<(), PanicError>>>,
     #[cfg(feature = "console")] monitor: Arc<crate::console::registry::ActorMonitor>,
 ) -> Result<(A, ActorStopReason), PanicError>
 where
@@ -241,7 +256,7 @@ where
                     abortable_actor_loop(
                         &mut state,
                         &mut mailbox_rx,
-                        &actor_ref.startup_result,
+                        &startup_result,
                         startup_finished,
                         #[cfg(feature = "console")]
                         &monitor,
@@ -259,6 +274,7 @@ where
                 actor_ref.links.send_children_shutdown().await;
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
+                actor_ref.links.lock().await.children.clear();
 
                 // On a terminal stop (not a restart, where the mailbox is reused by the next
                 // incarnation) hand any leftover tells to `on_undelivered` before `notify_links`
@@ -305,30 +321,37 @@ where
                 #[cfg(feature = "console")]
                 monitor.set_stopped(&reason);
 
-                unregister_actor(&id).await;
+                if !is_restarting {
+                    unregister_actor(&id).await;
+                }
 
                 match on_stop_res {
                     Ok(()) => {
-                        actor_ref
-                            .shutdown_result
-                            .set(Ok(reason.clone()))
-                            .expect("nothing else should set the shutdown result");
+                        if !is_restarting {
+                            actor_ref
+                                .lifecycle
+                                .shutdown_result
+                                .set(Ok(reason.clone()))
+                                .expect("nothing else should set the shutdown result");
+                        }
                     }
                     Err(err) => {
                         invoke_actor_error_hook(&err);
 
-                        actor_ref
-                            .shutdown_result
-                            .set(Err(err))
-                            .expect("nothing else should set the shutdown result");
+                        if !is_restarting {
+                            actor_ref
+                                .lifecycle
+                                .shutdown_result
+                                .set(Err(err))
+                                .expect("nothing else should set the shutdown result");
+                        }
                     }
                 }
 
                 Ok((actor, reason))
             }
             Err(err) => {
-                actor_ref
-                    .startup_result
+                startup_result
                     .set(Err(err.clone()))
                     .expect("nothing should set the startup result");
 
@@ -340,6 +363,7 @@ where
                 // startup failed; the supervisor may still restart us per policy
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
+                actor_ref.links.lock().await.children.clear();
                 actor_ref
                     .links
                     .lock()
@@ -349,16 +373,21 @@ where
                 #[cfg(feature = "console")]
                 monitor.set_stopped(&reason);
 
-                unregister_actor(&id).await;
+                if !is_restarting {
+                    unregister_actor(&id).await;
+                }
 
                 let ActorStopReason::Panicked(err) = reason else {
                     unreachable!()
                 };
 
-                actor_ref
-                    .shutdown_result
-                    .set(Err(err.clone()))
-                    .expect("nothing should set the startup result");
+                if !is_restarting {
+                    actor_ref
+                        .lifecycle
+                        .shutdown_result
+                        .set(Err(err.clone()))
+                        .expect("nothing should set the shutdown result");
+                }
 
                 Err(err)
             }
@@ -551,8 +580,17 @@ where
                     return reason;
                 }
             }
-            ControlFlow::Continue(Signal::Stop | Signal::SupervisorRestart) => {
-                if let ControlFlow::Break(reason) = state.handle_stop().await {
+            ControlFlow::Continue(Signal::Stop) => {
+                if let ControlFlow::Break(reason) =
+                    state.handle_stop(ActorStopReason::Shutdown).await
+                {
+                    return reason;
+                }
+            }
+            ControlFlow::Continue(Signal::SupervisorRestart) => {
+                if let ControlFlow::Break(reason) =
+                    state.handle_stop(ActorStopReason::SupervisorRestart).await
+                {
                     return reason;
                 }
             }
@@ -591,6 +629,7 @@ async fn unregister_actor(id: &ActorId) {
 fn log_actor_stop_reason(id: ActorId, name: &str, reason: &ActorStopReason) {
     match reason {
         reason @ (ActorStopReason::Normal
+        | ActorStopReason::Shutdown
         | ActorStopReason::SupervisorRestart
         | ActorStopReason::Killed
         | ActorStopReason::LinkDied { .. }) => {

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -274,7 +274,7 @@ where
                 actor_ref.links.send_children_shutdown().await;
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
-                actor_ref.links.lock().await.children.clear();
+                actor_ref.links.clear_children().await;
 
                 // On a terminal stop (not a restart, where the mailbox is reused by the next
                 // incarnation) hand any leftover tells to `on_undelivered` before `notify_links`
@@ -361,7 +361,7 @@ where
                 // startup failed; the supervisor may still restart us per policy
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
-                actor_ref.links.lock().await.children.clear();
+                actor_ref.links.clear_children().await;
                 actor_ref
                     .links
                     .lock()

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -149,7 +149,7 @@ pub(crate) struct ActorMonitor {
     mailbox_kind: wire::MailboxKind,
     mailbox_capacity: Option<usize>,
     links: Links,
-    /// Refreshed on restart so the monitor keeps a weak handle to the stable logical actor ref.
+    /// Weak handle to the stable logical actor ref; valid across supervised restarts.
     probe: Mutex<Box<dyn LiveProbe>>,
     status: AtomicU8,
     stopped: Mutex<Option<Stopped>>,
@@ -380,8 +380,6 @@ pub(crate) fn register_or_get<A: Actor>(actor_ref: &ActorRef<A>) -> Arc<ActorMon
         // handler here — otherwise the restarted actor would show as forever handling the old
         // message (an ever-growing "Stuck" elapsed).
         *monitor.current_handler.lock().unwrap() = None;
-        // Refresh the weak probe for the restarted logical actor.
-        *monitor.probe.lock().unwrap() = Box::new(actor_ref.downgrade());
         monitor.status.store(RESTARTING, Ordering::Relaxed);
         return Arc::clone(monitor);
     }

--- a/src/console/registry.rs
+++ b/src/console/registry.rs
@@ -149,8 +149,7 @@ pub(crate) struct ActorMonitor {
     mailbox_kind: wire::MailboxKind,
     mailbox_capacity: Option<usize>,
     links: Links,
-    /// Swapped out on restart: each incarnation has its own `ActorRef` allocation, so the
-    /// probe must track the latest one for its handle counts to stay meaningful.
+    /// Refreshed on restart so the monitor keeps a weak handle to the stable logical actor ref.
     probe: Mutex<Box<dyn LiveProbe>>,
     status: AtomicU8,
     stopped: Mutex<Option<Stopped>>,
@@ -381,7 +380,7 @@ pub(crate) fn register_or_get<A: Actor>(actor_ref: &ActorRef<A>) -> Arc<ActorMon
         // handler here — otherwise the restarted actor would show as forever handling the old
         // message (an ever-growing "Stuck" elapsed).
         *monitor.current_handler.lock().unwrap() = None;
-        // The new incarnation is a new allocation; repoint the probe so handle counts track it.
+        // Refresh the weak probe for the restarted logical actor.
         *monitor.probe.lock().unwrap() = Box::new(actor_ref.downgrade());
         monitor.status.store(RESTARTING, Ordering::Relaxed);
         return Arc::clone(monitor);

--- a/src/error.rs
+++ b/src/error.rs
@@ -373,6 +373,8 @@ where
 pub enum ActorStopReason {
     /// Actor stopped normally.
     Normal,
+    /// Actor was gracefully shut down through its actor reference.
+    Shutdown,
     /// Supervisor restarted.
     SupervisorRestart,
     /// Actor was killed.
@@ -403,7 +405,7 @@ impl ActorStopReason {
     /// Returns true if the actor's stop reason is normal and not caused by an error.
     pub fn is_normal(&self) -> bool {
         match self {
-            ActorStopReason::Normal => true,
+            ActorStopReason::Normal | ActorStopReason::Shutdown => true,
             ActorStopReason::SupervisorRestart
             | ActorStopReason::Killed
             | ActorStopReason::Panicked(_)
@@ -418,6 +420,7 @@ impl fmt::Debug for ActorStopReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ActorStopReason::Normal => write!(f, "Normal"),
+            ActorStopReason::Shutdown => write!(f, "Shutdown"),
             ActorStopReason::SupervisorRestart => write!(f, "SupervisorRestart"),
             ActorStopReason::Killed => write!(f, "Killed"),
             ActorStopReason::Panicked(err) => {
@@ -442,6 +445,7 @@ impl fmt::Display for ActorStopReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ActorStopReason::Normal => write!(f, "actor stopped normally"),
+            ActorStopReason::Shutdown => write!(f, "actor shut down gracefully"),
             ActorStopReason::SupervisorRestart => write!(f, "actor restarted by supervisor"),
             ActorStopReason::Killed => write!(f, "actor was killed"),
             ActorStopReason::Panicked(err) => err.fmt(f),

--- a/src/links.rs
+++ b/src/links.rs
@@ -25,9 +25,7 @@ use crate::{
 };
 
 pub type BoxMailboxReceiver = Box<dyn Any + Send>;
-pub type BoxActorRef = Box<dyn Any + Send>;
-pub type SpawnFactory =
-    Box<dyn Fn(BoxMailboxReceiver) -> BoxFuture<'static, BoxActorRef> + Send + Sync>;
+pub type SpawnFactory = Box<dyn Fn(BoxMailboxReceiver) -> BoxFuture<'static, ()> + Send + Sync>;
 pub type ShutdownFn = Box<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>;
 
 /// A collection of links to other actors that are notified when the actor dies.
@@ -139,6 +137,9 @@ impl LinksInner {
         };
         if self.parent_shutdown.load(Ordering::Acquire) {
             return false; // our supervisor is going away too
+        }
+        if matches!(reason, ActorStopReason::Shutdown) {
+            return false; // explicit graceful shutdown is terminal
         }
         match policy {
             RestartPolicy::Never => false,
@@ -291,6 +292,10 @@ impl ErasedChildSpec {
             return ControlFlow::Break(NoRestartReason::NeverPolicy);
         }
 
+        if matches!(reason, ActorStopReason::Shutdown) {
+            return ControlFlow::Break(NoRestartReason::Shutdown);
+        }
+
         // Always restart if supervisor initiated the shutdown for coordination
         if matches!(reason, ActorStopReason::SupervisorRestart) {
             return ControlFlow::Continue(());
@@ -396,6 +401,8 @@ impl RestartTracker {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NoRestartReason {
+    /// Explicit graceful shutdown is terminal
+    Shutdown,
     /// Transient policy but stop was normal
     NormalExitUnderTransientPolicy,
     /// Restart intensity threshold exceeded
@@ -410,6 +417,7 @@ pub enum NoRestartReason {
 impl fmt::Display for NoRestartReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            NoRestartReason::Shutdown => write!(f, "graceful shutdown"),
             NoRestartReason::NormalExitUnderTransientPolicy => {
                 write!(f, "normal exit under transient policy")
             }

--- a/src/links.rs
+++ b/src/links.rs
@@ -92,6 +92,10 @@ impl Links {
 
         join_all(mailboxes.iter().map(|m| m.closed())).await;
     }
+
+    pub(crate) async fn clear_children(&self) {
+        self.lock().await.children.clear();
+    }
 }
 
 #[derive(Default)]

--- a/src/supervision.rs
+++ b/src/supervision.rs
@@ -88,7 +88,7 @@ use futures::{FutureExt, future::BoxFuture};
 
 use crate::{
     actor::{Actor, ActorId, ActorRef, DEFAULT_MAILBOX_CAPACITY, PreparedActor},
-    links::{BoxActorRef, ErasedChildSpec, Links, RestartTracker, ShutdownFn, SpawnFactory},
+    links::{ErasedChildSpec, Links, RestartTracker, ShutdownFn, SpawnFactory},
     mailbox::{self, MailboxReceiver, MailboxSender, Signal},
 };
 
@@ -647,9 +647,12 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
             restart_tracker.clone(),
             parent_shutdown.clone(),
         );
+        let prepared =
+            PreparedActor::new_with(actor_id, (mailbox_tx.clone(), mailbox_rx), links.clone());
+        let actor_ref = prepared.actor_ref().clone();
+        let args = self.args_factory.get();
         let factory = Arc::new(new_factory(
-            actor_id,
-            mailbox_tx.clone(),
+            actor_ref.clone(),
             links.clone(),
             self.args_factory,
             in_thread,
@@ -675,20 +678,24 @@ impl<'a, S: Actor, C: Actor> SupervisedActorBuilder<'a, S, C> {
             restart_tracker,
         };
         self.supervisor_ref.link_child(actor_id, &links, spec).await;
-        *(*factory)(Box::new(mailbox_rx)).await.downcast().unwrap()
+        if in_thread {
+            prepared.spawn_in_thread(args);
+        } else {
+            prepared.spawn(args);
+        }
+        actor_ref
     }
 }
 
 fn new_factory<C: Actor>(
-    actor_id: ActorId,
-    mailbox_tx: MailboxSender<C>,
+    actor_ref: ActorRef<C>,
     links: Links,
     args_factory: SupervisorFactory<C::Args>,
     in_thread: bool,
 ) -> SpawnFactory {
     Box::new(move |rx: Box<dyn Any + Send>| {
         let mailbox_rx = *rx.downcast::<MailboxReceiver<C>>().unwrap();
-        let mailbox_tx = mailbox_tx.clone();
+        let actor_ref = actor_ref.clone();
         let links = links.clone();
         let args = args_factory.get();
 
@@ -703,15 +710,13 @@ fn new_factory<C: Actor>(
                 // left by a previous supervisor shutdown.
                 inner.parent_shutdown.store(false, Ordering::Release);
             }
-            let prepared = PreparedActor::new_with(actor_id, (mailbox_tx, mailbox_rx), links);
-            let actor_ref = prepared.actor_ref().clone();
+            let prepared = PreparedActor::restart(actor_ref, mailbox_rx);
             if in_thread {
                 prepared.spawn_in_thread(args);
             } else {
                 prepared.spawn(args);
             }
-            Box::new(actor_ref) as BoxActorRef
-        }) as BoxFuture<'static, BoxActorRef>
+        }) as BoxFuture<'static, ()>
     })
 }
 

--- a/tests/supervision_actor_ref.rs
+++ b/tests/supervision_actor_ref.rs
@@ -1,0 +1,368 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use kameo::{
+    error::Infallible,
+    prelude::*,
+    supervision::{RestartPolicy, SupervisionStrategy},
+};
+use tokio::sync::{Mutex, mpsc};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+struct Supervisor;
+
+impl Actor for Supervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(state)
+    }
+}
+
+struct OneForAllSupervisor;
+
+impl Actor for OneForAllSupervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    fn supervision_strategy() -> SupervisionStrategy {
+        SupervisionStrategy::OneForAll
+    }
+
+    async fn on_start(state: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(state)
+    }
+}
+
+#[derive(Clone)]
+struct WorkerArgs {
+    starts: Arc<AtomicUsize>,
+    started_tx: mpsc::UnboundedSender<usize>,
+}
+
+struct Worker {
+    generation: usize,
+}
+
+impl Actor for Worker {
+    type Args = WorkerArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        let generation = args.starts.fetch_add(1, Ordering::SeqCst) + 1;
+        let _ = args.started_tx.send(generation);
+        Ok(Worker { generation })
+    }
+}
+
+struct GetGeneration;
+struct Ping;
+struct Boom;
+struct ContextWeakUpgrades;
+
+impl Message<GetGeneration> for Worker {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _: GetGeneration,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.generation
+    }
+}
+
+impl Message<Ping> for Worker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Ping, _: &mut Context<Self, Self::Reply>) -> Self::Reply {}
+}
+
+impl Message<Boom> for Worker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Boom, _: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        panic!("boom")
+    }
+}
+
+impl Message<ContextWeakUpgrades> for Worker {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        _: ContextWeakUpgrades,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        ctx.actor_ref().downgrade().upgrade().is_some()
+    }
+}
+
+#[derive(Clone)]
+struct SlowStartArgs {
+    starts: Arc<AtomicUsize>,
+    entered_tx: mpsc::UnboundedSender<usize>,
+    ready_tx: mpsc::UnboundedSender<usize>,
+    permits_rx: Arc<Mutex<mpsc::UnboundedReceiver<()>>>,
+}
+
+struct SlowStartWorker {
+    generation: usize,
+}
+
+impl Actor for SlowStartWorker {
+    type Args = SlowStartArgs;
+    type Error = Infallible;
+
+    async fn on_start(args: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        let generation = args.starts.fetch_add(1, Ordering::SeqCst) + 1;
+        let _ = args.entered_tx.send(generation);
+        let _ = args.permits_rx.lock().await.recv().await;
+        let _ = args.ready_tx.send(generation);
+        Ok(SlowStartWorker { generation })
+    }
+}
+
+impl Message<GetGeneration> for SlowStartWorker {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _: GetGeneration,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.generation
+    }
+}
+
+impl Message<Boom> for SlowStartWorker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Boom, _: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        panic!("boom")
+    }
+}
+
+fn worker_args() -> (WorkerArgs, mpsc::UnboundedReceiver<usize>) {
+    let (started_tx, started_rx) = mpsc::unbounded_channel();
+    (
+        WorkerArgs {
+            starts: Arc::new(AtomicUsize::new(0)),
+            started_tx,
+        },
+        started_rx,
+    )
+}
+
+fn slow_start_args() -> (
+    SlowStartArgs,
+    mpsc::UnboundedSender<()>,
+    mpsc::UnboundedReceiver<usize>,
+    mpsc::UnboundedReceiver<usize>,
+) {
+    let (entered_tx, entered_rx) = mpsc::unbounded_channel();
+    let (ready_tx, ready_rx) = mpsc::unbounded_channel();
+    let (permits_tx, permits_rx) = mpsc::unbounded_channel();
+    (
+        SlowStartArgs {
+            starts: Arc::new(AtomicUsize::new(0)),
+            entered_tx,
+            ready_tx,
+            permits_rx: Arc::new(Mutex::new(permits_rx)),
+        },
+        permits_tx,
+        entered_rx,
+        ready_rx,
+    )
+}
+
+async fn recv_start(started_rx: &mut mpsc::UnboundedReceiver<usize>) -> usize {
+    tokio::time::timeout(TIMEOUT, started_rx.recv())
+        .await
+        .expect("timed out waiting for actor startup")
+        .expect("startup channel closed")
+}
+
+async fn spawn_worker(
+    policy: RestartPolicy,
+) -> (
+    ActorRef<Supervisor>,
+    ActorRef<Worker>,
+    mpsc::UnboundedReceiver<usize>,
+) {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (args, started_rx) = worker_args();
+    let worker = Worker::supervise(&supervisor, args)
+        .restart_policy(policy)
+        .restart_limit(10, Duration::from_secs(10))
+        .spawn()
+        .await;
+    (supervisor, worker, started_rx)
+}
+
+async fn spawn_worker_under<S: Actor>(
+    supervisor: &ActorRef<S>,
+) -> (ActorRef<Worker>, mpsc::UnboundedReceiver<usize>) {
+    let (args, started_rx) = worker_args();
+    let worker = Worker::supervise(supervisor, args)
+        .restart_policy(RestartPolicy::Permanent)
+        .restart_limit(10, Duration::from_secs(10))
+        .spawn()
+        .await;
+    (worker, started_rx)
+}
+
+#[tokio::test]
+async fn old_refs_and_recipients_survive_supervised_restart() {
+    let (supervisor, worker, mut started_rx) = spawn_worker(RestartPolicy::Permanent).await;
+    assert_eq!(recv_start(&mut started_rx).await, 1);
+
+    let weak = worker.downgrade();
+    let recipient = worker.clone().recipient::<Ping>();
+
+    let _ = worker.ask(Boom).await;
+    assert_eq!(recv_start(&mut started_rx).await, 2);
+
+    assert_eq!(worker.ask(GetGeneration).await.unwrap(), 2);
+    assert!(weak.upgrade().is_some());
+    weak.upgrade().unwrap().ask(Ping).await.unwrap();
+    recipient.tell(Ping).await.unwrap();
+    assert!(worker.ask(ContextWeakUpgrades).await.unwrap());
+    assert!(worker.get_shutdown_result().is_none());
+
+    worker.kill();
+    assert_eq!(recv_start(&mut started_rx).await, 3);
+    assert_eq!(worker.ask(GetGeneration).await.unwrap(), 3);
+
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}
+
+#[tokio::test]
+async fn supervisor_owns_child_ref_until_terminal_stop() {
+    let (supervisor, worker, mut started_rx) = spawn_worker(RestartPolicy::Never).await;
+    assert_eq!(recv_start(&mut started_rx).await, 1);
+
+    let weak = worker.downgrade();
+    drop(worker);
+
+    let worker = weak
+        .upgrade()
+        .expect("supervisor should own the supervised child ref");
+    worker.ask(Ping).await.unwrap();
+    worker.stop_gracefully().await.unwrap();
+    worker.wait_for_shutdown_result().await.unwrap();
+    drop(worker);
+
+    assert!(weak.upgrade().is_none());
+
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}
+
+#[tokio::test]
+async fn stop_gracefully_is_terminal_under_permanent_policy() {
+    let (supervisor, worker, mut started_rx) = spawn_worker(RestartPolicy::Permanent).await;
+    assert_eq!(recv_start(&mut started_rx).await, 1);
+
+    worker.stop_gracefully().await.unwrap();
+    let reason = worker.wait_for_shutdown_result().await.unwrap();
+    assert!(matches!(reason, ActorStopReason::Shutdown));
+
+    if let Ok(Some(generation)) =
+        tokio::time::timeout(Duration::from_millis(100), started_rx.recv()).await
+    {
+        panic!("worker restarted after graceful shutdown: {generation}");
+    }
+
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}
+
+#[tokio::test]
+async fn coordinated_restart_does_not_publish_terminal_shutdown_result() {
+    let supervisor = OneForAllSupervisor::spawn(OneForAllSupervisor);
+    let (worker1, mut worker1_started_rx) = spawn_worker_under(&supervisor).await;
+    let (worker2, mut worker2_started_rx) = spawn_worker_under(&supervisor).await;
+    assert_eq!(recv_start(&mut worker1_started_rx).await, 1);
+    assert_eq!(recv_start(&mut worker2_started_rx).await, 1);
+
+    let _ = worker1.ask(Boom).await;
+    assert_eq!(recv_start(&mut worker1_started_rx).await, 2);
+    assert_eq!(recv_start(&mut worker2_started_rx).await, 2);
+
+    assert_eq!(worker2.ask(GetGeneration).await.unwrap(), 2);
+    assert!(worker2.get_shutdown_result().is_none());
+
+    worker2.stop_gracefully().await.unwrap();
+    let reason = worker2.wait_for_shutdown_result().await.unwrap();
+    assert!(matches!(reason, ActorStopReason::Shutdown));
+
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}
+
+#[tokio::test]
+async fn wait_for_startup_during_restart_observes_initial_startup_result() {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (args, permits_tx, mut entered_rx, mut ready_rx) = slow_start_args();
+    let worker = SlowStartWorker::supervise(&supervisor, args)
+        .restart_policy(RestartPolicy::Permanent)
+        .restart_limit(10, Duration::from_secs(10))
+        .spawn()
+        .await;
+
+    assert_eq!(recv_start(&mut entered_rx).await, 1);
+    permits_tx.send(()).unwrap();
+    assert_eq!(recv_start(&mut ready_rx).await, 1);
+    worker.wait_for_startup().await;
+
+    let _ = worker.ask(Boom).await;
+    assert_eq!(recv_start(&mut entered_rx).await, 2);
+
+    tokio::time::timeout(Duration::from_millis(100), worker.wait_for_startup())
+        .await
+        .expect("wait_for_startup should observe the initial startup result during restart");
+
+    assert!(worker.get_shutdown_result().is_none());
+    permits_tx.send(()).unwrap();
+    assert_eq!(recv_start(&mut ready_rx).await, 2);
+    assert_eq!(worker.ask(GetGeneration).await.unwrap(), 2);
+
+    worker.stop_gracefully().await.unwrap();
+    worker.wait_for_shutdown_result().await.unwrap();
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}
+
+#[cfg(not(feature = "remote"))]
+#[tokio::test]
+async fn registry_entry_survives_restart_and_is_removed_on_terminal_stop() {
+    let (supervisor, worker, mut started_rx) = spawn_worker(RestartPolicy::Permanent).await;
+    assert_eq!(recv_start(&mut started_rx).await, 1);
+
+    let name = format!("stable-restart-{}", worker.id());
+    worker.register(name.clone()).unwrap();
+
+    let _ = worker.ask(Boom).await;
+    assert_eq!(recv_start(&mut started_rx).await, 2);
+
+    let looked_up = ActorRef::<Worker>::lookup(name.as_str())
+        .unwrap()
+        .expect("registered worker");
+    assert_eq!(looked_up.ask(GetGeneration).await.unwrap(), 2);
+
+    worker.stop_gracefully().await.unwrap();
+    worker.wait_for_shutdown_result().await.unwrap();
+    assert!(ActorRef::<Worker>::lookup(name.as_str()).unwrap().is_none());
+
+    supervisor.stop_gracefully().await.unwrap();
+    supervisor.wait_for_shutdown().await;
+}


### PR DESCRIPTION
## Problem

A supervised restart reused the actor ID, mailbox, and links, but created a
new `ActorRefInner`. Existing `ActorRef`, `WeakActorRef`, and recipient handles
therefore remained attached to the stopped incarnation.

This produced several inconsistent behaviors:

- `kill()` on a handle created before the restart aborted the old task rather
  than the current incarnation.
- weak refs and handle counts tracked the old allocation.
- lifecycle startup/shutdown results belonged to one incarnation rather than
  the logical actor.
- registry and console entries had to be replaced on every restart.
- `stop_gracefully()` produced `ActorStopReason::Normal`, so a child using
  `RestartPolicy::Permanent` was restarted after an explicit graceful stop.

## Fix

`ActorRefInner` now represents the logical actor and remains stable across
supervised restarts. It retains the actor ID, mailbox, links, and a shared
`ActorLifecycle`.

A restart replaces only per-incarnation state:

- abort handle and registration
- startup barrier
- actor task and user state

The supervisor owns the stable child ref through its restart factory. Removing
a terminal child spec releases that ownership.

The public startup result continues to describe the initial startup. Each
restart uses a private startup result to gate mailbox processing until its own
`on_start` completes. The shutdown result is published only when the logical
actor stops terminally.

## Graceful shutdown

Adds `ActorStopReason::Shutdown` for explicit graceful shutdown through
`ActorRef::stop_gracefully()`.

Unlike `ctx.stop()`, which remains `ActorStopReason::Normal` and is still
subject to the configured restart policy, `Shutdown` is terminal under every
policy, including `RestartPolicy::Permanent`.

`Signal::SupervisorRestart` remains distinct and continues to drive coordinated
`OneForAll` and `RestForOne` restarts.

## Behavior changes

- Existing `ActorRef`, `WeakActorRef`, and recipient handles remain valid after
  supervised restart.
- Lifecycle operations such as `kill()` target the current incarnation.
- Registrations survive restart and are removed only on terminal stop.
- `stop_gracefully()` no longer allows a permanent supervisor to bring the
  actor back.
- Supervisors explicitly keep their children alive until terminal removal.

## Breaking change

Adds the `Shutdown` variant to the public exhaustive `ActorStopReason` enum.
Downstream exhaustive matches must handle the new variant.

## Tests

Adds `tests/supervision_actor_ref.rs` covering:

- old strong, weak, and recipient handles after restart
- `kill()` through a handle created before restart
- `Context::actor_ref()` after restart
- supervisor ownership and terminal child cleanup
- registry preservation across restart
- terminal graceful shutdown under `RestartPolicy::Permanent`
- coordinated `OneForAll` restart without publishing a terminal shutdown result
- `wait_for_startup()` while a restarted incarnation is still in `on_start`

Verified with:

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy -p kameo --test supervision_actor_ref -- -D warnings`
- console and remote feature checks
- `cargo semver-checks -p kameo` reports the expected breaking change:
  `ActorStopReason::Shutdown` was added to the exhaustive public enum.
