### PR TITLE
feat(remote): add mutual TLS and pre-shared cluster key authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           # kameo_remote crate (no additional features)
           - package: "kameo_remote"
             features: ""
+          # kameo_remote crate with mutual TLS
+          - package: "kameo_remote"
+            features: "--features tls"
     steps:
       - uses: actions/checkout@v4
 
@@ -156,6 +159,9 @@ jobs:
           # kameo_remote crate (no additional features)
           - package: "kameo_remote"
             features: ""
+          # kameo_remote crate with mutual TLS
+          - package: "kameo_remote"
+            features: "--features tls"
     steps:
       - uses: actions/checkout@v4
 
@@ -234,6 +240,9 @@ jobs:
           # kameo_remote crate (no additional features)
           - package: "kameo_remote"
             features: ""
+          # kameo_remote crate with mutual TLS
+          - package: "kameo_remote"
+            features: "--features tls"
     steps:
       - uses: actions/checkout@v4
 

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -11,22 +11,42 @@ keywords = ["actor", "tokio", "distributed", "gossip", "cluster"]
 categories = ["asynchronous", "concurrency", "network-programming"]
 include = ["/src"]
 
+[features]
+tls = ["dep:rustls", "dep:tokio-rustls", "dep:rustls-pki-types"]
+
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 bytes = "1"
+chacha20poly1305 = "0.10"
 chitchat = "0.11"
 futures.workspace = true
+hkdf = "0.12"
+hmac = "0.12"
 kameo.workspace = true
 rmp-serde = "1.3"
+rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "logging", "std"] }
+rustls-pki-types = { version = "1.10", optional = true, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["ring", "logging"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
+zeroize = "1"
 
 [dev-dependencies]
+rcgen = "0.13"
 tokio = { workspace = true, features = ["io-std", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[[example]]
+name = "secure"
+required-features = ["tls"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/remote/examples/secure.rs
+++ b/remote/examples/secure.rs
@@ -1,0 +1,116 @@
+//! A fully secured two-node cluster: mutual TLS on messaging plus a pre-shared
+//! cluster key for gossip encryption and connection authentication.
+//!
+//! The CA and node certificates are generated in-memory with rcgen for the demo; a
+//! real deployment would provision PEM files and load them with
+//! [`TlsConfig::from_pem_files`], and distribute the cluster key through a secret
+//! manager.
+//!
+//! ```sh
+//! cargo run --example secure --features tls
+//! ```
+
+use kameo::prelude::*;
+use kameo_remote::{
+    ClusterKey, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig, TlsConfig,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Actor)]
+struct Counter {
+    count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inc {
+    amount: i64,
+}
+
+impl Message<Inc> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "example::Inc";
+}
+
+impl RemoteActor for Counter {
+    const REMOTE_ID: &'static str = "example::Counter";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+    }
+}
+
+/// Generates a cluster CA and issues a node certificate signed by it.
+fn issue_node_tls(
+    ca_key: &rcgen::KeyPair,
+    ca_cert: &rcgen::Certificate,
+) -> Result<TlsConfig, Box<dyn std::error::Error>> {
+    let key = rcgen::KeyPair::generate()?;
+    let params = rcgen::CertificateParams::new(vec!["node".to_string()])?;
+    let cert = params.signed_by(&key, ca_cert, ca_key)?;
+    Ok(TlsConfig::from_pem(
+        ca_cert.pem().as_bytes(),
+        cert.pem().as_bytes(),
+        key.serialize_pem().as_bytes(),
+    )?)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("kameo_remote=info")
+        .init();
+
+    // One CA for the cluster; every node gets its own CA-signed certificate.
+    let ca_key = rcgen::KeyPair::generate()?;
+    let mut ca_params = rcgen::CertificateParams::new(Vec::new())?;
+    ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_key)?;
+
+    // One pre-shared key for the cluster, securing gossip and authenticating peers.
+    let cluster_key = ClusterKey::generate();
+
+    let node_a = RemoteNode::bootstrap(
+        RemoteNodeConfig::default()
+            .with_gossip_addr("127.0.0.1:7400".parse()?)
+            .with_messaging_addr("127.0.0.1:7401".parse()?)
+            .with_cluster_key(cluster_key.clone())
+            .with_tls(issue_node_tls(&ca_key, &ca_cert)?),
+    )
+    .await?;
+
+    let node_b = RemoteNode::bootstrap(
+        RemoteNodeConfig::default()
+            .with_gossip_addr("127.0.0.1:7402".parse()?)
+            .with_messaging_addr("127.0.0.1:7403".parse()?)
+            .with_seed_nodes(["127.0.0.1:7400"])
+            .with_cluster_key(cluster_key)
+            .with_tls(issue_node_tls(&ca_key, &ca_cert)?),
+    )
+    .await?;
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await?;
+
+    // Wait for gossip to replicate the registration to node b.
+    let remote = loop {
+        if let Some(remote) = node_b.lookup::<Counter>("counter").await? {
+            break remote;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
+
+    let count = remote.ask(&Inc { amount: 1 }).await?;
+    println!("count over mutual tls: {count}");
+
+    node_b.shutdown().await?;
+    node_a.shutdown().await?;
+    Ok(())
+}

--- a/remote/src/error.rs
+++ b/remote/src/error.rs
@@ -90,6 +90,16 @@ pub enum RemoteSendError<E = Infallible> {
     /// Failed to connect to the remote node.
     #[error("failed to connect to remote node: {0}")]
     Connect(#[source] io::Error),
+    /// The remote node belongs to a different cluster.
+    #[error("cluster id mismatch")]
+    ClusterMismatch,
+    /// Cluster key authentication with the remote node failed: the keys do not match,
+    /// or only one side has a key configured.
+    #[error("cluster authentication failed")]
+    AuthFailed,
+    /// The connection handshake with the remote node failed.
+    #[error("handshake failed: {0}")]
+    Handshake(String),
     /// The connection closed before a reply was received.
     #[error("connection closed before a reply was received")]
     ConnectionClosed,
@@ -126,6 +136,9 @@ impl<E> RemoteSendError<E> {
                 RemoteSendError::DeserializeHandlerError(err)
             }
             RemoteSendError::Connect(err) => RemoteSendError::Connect(err),
+            RemoteSendError::ClusterMismatch => RemoteSendError::ClusterMismatch,
+            RemoteSendError::AuthFailed => RemoteSendError::AuthFailed,
+            RemoteSendError::Handshake(err) => RemoteSendError::Handshake(err),
             RemoteSendError::ConnectionClosed => RemoteSendError::ConnectionClosed,
             RemoteSendError::NodeShutdown => RemoteSendError::NodeShutdown,
         }

--- a/remote/src/gossip.rs
+++ b/remote/src/gossip.rs
@@ -1,0 +1,316 @@
+//! Encrypted UDP transport for gossip.
+//!
+//! Every datagram is sealed with XChaCha20-Poly1305 under a key derived from the
+//! cluster key, with the cluster id as associated data. Packets that fail to
+//! authenticate are dropped, so nodes without the key can neither read the registry
+//! nor inject anything into it.
+//!
+//! Wire format: `[version: 1 byte][nonce: 24 bytes][ciphertext + tag]`. Random
+//! 24-byte nonces stay collision-free without coordination even though every node in
+//! the cluster encrypts under the same key.
+
+use std::{
+    io,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use chacha20poly1305::{
+    KeyInit, XChaCha20Poly1305, XNonce,
+    aead::{Aead, AeadCore, OsRng, Payload},
+};
+use chitchat::{
+    ChitchatMessage, Deserializable, Serializable,
+    transport::{Socket, Transport},
+};
+
+use crate::security::GossipKey;
+
+const WIRE_VERSION: u8 = 1;
+const NONCE_LEN: usize = 24;
+const AAD_PREFIX: &[u8] = b"kameo-remote gossip v1";
+/// The largest payload that fits in a single UDP datagram, mirroring chitchat's
+/// internal constant.
+const MAX_UDP_PAYLOAD: usize = 65_507;
+const RECV_WARN_INTERVAL: Duration = Duration::from_secs(10);
+
+pub(crate) struct EncryptedUdpTransport {
+    key: GossipKey,
+    cluster_id: String,
+}
+
+impl EncryptedUdpTransport {
+    pub(crate) fn new(key: GossipKey, cluster_id: String) -> Self {
+        EncryptedUdpTransport { key, cluster_id }
+    }
+}
+
+#[async_trait]
+impl Transport for EncryptedUdpTransport {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let socket = tokio::net::UdpSocket::bind(listen_addr)
+            .await
+            .with_context(|| format!("failed to bind to {listen_addr}/UDP for gossip"))?;
+        let mut aad = AAD_PREFIX.to_vec();
+        aad.extend_from_slice(self.cluster_id.as_bytes());
+        Ok(Box::new(EncryptedUdpSocket {
+            socket,
+            cipher: XChaCha20Poly1305::new((&self.key.0).into()),
+            aad,
+            buf_send: Vec::with_capacity(MAX_UDP_PAYLOAD),
+            buf_recv: Box::new([0u8; MAX_UDP_PAYLOAD]),
+            last_recv_warn: None,
+        }))
+    }
+}
+
+struct EncryptedUdpSocket {
+    socket: tokio::net::UdpSocket,
+    cipher: XChaCha20Poly1305,
+    aad: Vec<u8>,
+    buf_send: Vec<u8>,
+    buf_recv: Box<[u8; MAX_UDP_PAYLOAD]>,
+    last_recv_warn: Option<Instant>,
+}
+
+#[async_trait]
+impl Socket for EncryptedUdpSocket {
+    async fn send(&mut self, to_addr: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        self.buf_send.clear();
+        message.serialize(&mut self.buf_send);
+        // The 41-byte overhead can push a message chitchat budgeted at exactly the
+        // datagram maximum over the limit; real gossip messages are far smaller.
+        let packet = seal(&self.cipher, &self.aad, &self.buf_send);
+        self.socket
+            .send_to(&packet, to_addr)
+            .await
+            .context("failed to send chitchat message to peer")?;
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        loop {
+            if let Some(message) = self.receive_one().await? {
+                return Ok(message);
+            }
+        }
+    }
+}
+
+impl EncryptedUdpSocket {
+    async fn receive_one(&mut self) -> anyhow::Result<Option<(SocketAddr, ChitchatMessage)>> {
+        let (len, from_addr) = match self.socket.recv_from(&mut self.buf_recv[..]).await {
+            Ok(result) => result,
+            Err(err) if is_transient_io_error(&err) => {
+                tracing::warn!("transient udp recv error: {err}");
+                return Ok(None);
+            }
+            // A recv error ends the gossip server, matching the plaintext transport;
+            // unauthenticated packets below never do.
+            Err(err) => return Err(err).context("fatal udp recv error"),
+        };
+        let Some(plaintext) = open(&self.cipher, &self.aad, &self.buf_recv[..len]) else {
+            self.log_dropped(from_addr);
+            return Ok(None);
+        };
+        let mut buf = plaintext.as_slice();
+        match ChitchatMessage::deserialize(&mut buf) {
+            Ok(message) => Ok(Some((from_addr, message))),
+            Err(err) => {
+                tracing::warn!(from = %from_addr, "invalid gossip payload: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Rate-limited: a peer with the wrong key retries every gossip round, which
+    /// would otherwise flood the log.
+    fn log_dropped(&mut self, from_addr: SocketAddr) {
+        let now = Instant::now();
+        let warn = self
+            .last_recv_warn
+            .is_none_or(|last| now.duration_since(last) >= RECV_WARN_INTERVAL);
+        if warn {
+            self.last_recv_warn = Some(now);
+            tracing::warn!(from = %from_addr, "dropping unauthenticated gossip packet");
+        } else {
+            tracing::debug!(from = %from_addr, "dropping unauthenticated gossip packet");
+        }
+    }
+}
+
+fn is_transient_io_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::OutOfMemory
+            // On Windows, sending to a closed peer causes recv_from to fail
+            // with ConnectionReset (WSAECONNRESET / 10054).
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionRefused
+    )
+}
+
+fn seal(cipher: &XChaCha20Poly1305, aad: &[u8], plaintext: &[u8]) -> Vec<u8> {
+    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .expect("xchacha20poly1305 encryption of an in-memory buffer cannot fail");
+    let mut packet = Vec::with_capacity(1 + NONCE_LEN + ciphertext.len());
+    packet.push(WIRE_VERSION);
+    packet.extend_from_slice(&nonce);
+    packet.extend_from_slice(&ciphertext);
+    packet
+}
+
+fn open(cipher: &XChaCha20Poly1305, aad: &[u8], packet: &[u8]) -> Option<Vec<u8>> {
+    let rest = packet.strip_prefix(&[WIRE_VERSION])?;
+    if rest.len() < NONCE_LEN {
+        return None;
+    }
+    let (nonce, ciphertext) = rest.split_at(NONCE_LEN);
+    cipher
+        .decrypt(
+            XNonce::from_slice(nonce),
+            Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::{ClusterKey, derive_keys};
+
+    fn cipher(key_byte: u8) -> XChaCha20Poly1305 {
+        let (gossip_key, _) = derive_keys(&ClusterKey::new([key_byte; 32]));
+        XChaCha20Poly1305::new((&gossip_key.0).into())
+    }
+
+    #[test]
+    fn seal_open_round_trip() {
+        let cipher = cipher(1);
+        let packet = seal(&cipher, b"aad", b"hello gossip");
+        assert_eq!(open(&cipher, b"aad", &packet).unwrap(), b"hello gossip");
+    }
+
+    #[test]
+    fn tampered_packet_rejected() {
+        let cipher = cipher(1);
+        let mut packet = seal(&cipher, b"aad", b"hello gossip");
+        let last = packet.len() - 1;
+        packet[last] ^= 1;
+        assert!(open(&cipher, b"aad", &packet).is_none());
+    }
+
+    #[test]
+    fn wrong_key_rejected() {
+        let packet = seal(&cipher(1), b"aad", b"hello gossip");
+        assert!(open(&cipher(2), b"aad", &packet).is_none());
+    }
+
+    #[test]
+    fn wrong_cluster_aad_rejected() {
+        let cipher = cipher(1);
+        let packet = seal(&cipher, b"cluster-a", b"hello gossip");
+        assert!(open(&cipher, b"cluster-b", &packet).is_none());
+    }
+
+    #[test]
+    fn wrong_version_rejected() {
+        let cipher = cipher(1);
+        let mut packet = seal(&cipher, b"aad", b"hello gossip");
+        packet[0] = 2;
+        assert!(open(&cipher, b"aad", &packet).is_none());
+    }
+
+    #[test]
+    fn truncated_packet_rejected() {
+        let cipher = cipher(1);
+        let packet = seal(&cipher, b"aad", b"hello gossip");
+        assert!(open(&cipher, b"aad", &packet[..NONCE_LEN]).is_none());
+        assert!(open(&cipher, b"aad", &[]).is_none());
+    }
+
+    fn gossip_key(key_byte: u8) -> GossipKey {
+        derive_keys(&ClusterKey::new([key_byte; 32])).0
+    }
+
+    /// The Socket trait hides the bound address, so reserve an ephemeral port first
+    /// (best-effort, matching how bootstrap allocates ephemeral gossip ports).
+    fn reserve_udp_port() -> SocketAddr {
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        socket.local_addr().unwrap()
+    }
+
+    #[tokio::test]
+    async fn socket_pair_round_trip() {
+        let addr_a = reserve_udp_port();
+        let mut socket_a = EncryptedUdpTransport::new(gossip_key(1), "kameo".to_string())
+            .open(addr_a)
+            .await
+            .unwrap();
+        let mut socket_b = EncryptedUdpTransport::new(gossip_key(1), "kameo".to_string())
+            .open("127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+
+        socket_b
+            .send(addr_a, ChitchatMessage::BadCluster)
+            .await
+            .unwrap();
+        let (_, message) = tokio::time::timeout(Duration::from_secs(5), socket_a.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(message, ChitchatMessage::BadCluster));
+    }
+
+    #[tokio::test]
+    async fn recv_skips_garbage_and_wrong_key_packets() {
+        let addr_a = reserve_udp_port();
+        let mut socket_a = EncryptedUdpTransport::new(gossip_key(1), "kameo".to_string())
+            .open(addr_a)
+            .await
+            .unwrap();
+        let mut wrong_key = EncryptedUdpTransport::new(gossip_key(2), "kameo".to_string())
+            .open("127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+        let mut socket_b = EncryptedUdpTransport::new(gossip_key(1), "kameo".to_string())
+            .open("127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+
+        let raw = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        raw.send_to(b"garbage", addr_a).await.unwrap();
+        wrong_key
+            .send(addr_a, ChitchatMessage::BadCluster)
+            .await
+            .unwrap();
+        socket_b
+            .send(addr_a, ChitchatMessage::BadCluster)
+            .await
+            .unwrap();
+
+        // Only the authentic packet comes through; the garbage and wrong-key packets
+        // are dropped without ending the socket.
+        let (_, message) = tokio::time::timeout(Duration::from_secs(5), socket_a.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(message, ChitchatMessage::BadCluster));
+        let second = tokio::time::timeout(Duration::from_millis(500), socket_a.recv()).await;
+        assert!(second.is_err(), "dropped packets must not be delivered");
+    }
+}

--- a/remote/src/gossip.rs
+++ b/remote/src/gossip.rs
@@ -34,7 +34,7 @@ const AAD_PREFIX: &[u8] = b"kameo-remote gossip v1";
 /// The largest payload that fits in a single UDP datagram, mirroring chitchat's
 /// internal constant.
 const MAX_UDP_PAYLOAD: usize = 65_507;
-const RECV_WARN_INTERVAL: Duration = Duration::from_secs(10);
+const WARN_INTERVAL: Duration = Duration::from_secs(10);
 
 pub(crate) struct EncryptedUdpTransport {
     key: GossipKey,
@@ -62,6 +62,7 @@ impl Transport for EncryptedUdpTransport {
             buf_send: Vec::with_capacity(MAX_UDP_PAYLOAD),
             buf_recv: Box::new([0u8; MAX_UDP_PAYLOAD]),
             last_recv_warn: None,
+            last_send_warn: None,
         }))
     }
 }
@@ -73,6 +74,7 @@ struct EncryptedUdpSocket {
     buf_send: Vec<u8>,
     buf_recv: Box<[u8; MAX_UDP_PAYLOAD]>,
     last_recv_warn: Option<Instant>,
+    last_send_warn: Option<Instant>,
 }
 
 #[async_trait]
@@ -80,9 +82,28 @@ impl Socket for EncryptedUdpSocket {
     async fn send(&mut self, to_addr: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
         self.buf_send.clear();
         message.serialize(&mut self.buf_send);
-        // The 41-byte overhead can push a message chitchat budgeted at exactly the
-        // datagram maximum over the limit; real gossip messages are far smaller.
         let packet = seal(&self.cipher, &self.aad, &self.buf_send);
+        // The 41-byte overhead can push a message chitchat budgeted at the datagram
+        // maximum over the limit. Sending would fail with EMSGSIZE and chitchat would
+        // rebuild the same saturated delta every round, so a peer needing a >~64 KiB
+        // catch-up would stall silently; warn instead so the operator can see it.
+        // Only reachable with an enormous registry state.
+        if packet.len() > MAX_UDP_PAYLOAD {
+            let now = Instant::now();
+            if self
+                .last_send_warn
+                .is_none_or(|last| now.duration_since(last) >= WARN_INTERVAL)
+            {
+                self.last_send_warn = Some(now);
+                tracing::warn!(
+                    to = %to_addr,
+                    len = packet.len(),
+                    "sealed gossip packet exceeds the udp datagram limit and was \
+                     dropped; the peer cannot catch up until registry state shrinks"
+                );
+            }
+            return Ok(());
+        }
         self.socket
             .send_to(&packet, to_addr)
             .await
@@ -131,7 +152,7 @@ impl EncryptedUdpSocket {
         let now = Instant::now();
         let warn = self
             .last_recv_warn
-            .is_none_or(|last| now.duration_since(last) >= RECV_WARN_INTERVAL);
+            .is_none_or(|last| now.duration_since(last) >= WARN_INTERVAL);
         if warn {
             self.last_recv_warn = Some(now);
             tracing::warn!(from = %from_addr, "dropping unauthenticated gossip packet");

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -15,6 +15,32 @@
 //! Nodes join the cluster through seed nodes: a starting node contacts any configured
 //! seed and learns the rest of the membership through gossip.
 //!
+//! # Security
+//!
+//! By default a node is open: anyone who can reach its ports can join the cluster and
+//! send messages. Two independent settings close this, and full security requires
+//! both:
+//!
+//! - [`RemoteNodeConfig::cluster_key`] — a 32-byte pre-shared secret
+//!   ([`ClusterKey`]). Gossip datagrams are encrypted and authenticated with a key
+//!   derived from it, so nodes without the key can neither read nor poison the
+//!   registry. Messaging connections mutually prove possession of it during the
+//!   connection handshake (an HMAC challenge-response; the key never crosses the
+//!   wire). Message payloads themselves are only encrypted when TLS is also enabled.
+//! - `RemoteNodeConfig::tls` (cargo feature `tls`) — mutual TLS for the messaging
+//!   layer via `TlsConfig`: connections are encrypted with TLS 1.3 and both peers
+//!   must present a certificate signed by the cluster CA. Certificates are verified
+//!   against the CA without hostname verification, since nodes are dialed by
+//!   gossip-advertised IPs; possession of a CA-signed certificate is what makes a
+//!   peer a cluster member.
+//!
+//! With only `cluster_key`, membership is authenticated and gossip is confidential,
+//! but message payloads cross the network in plaintext. With only `tls`, messaging is
+//! encrypted but gossip is open, so anyone reaching the gossip port can poison the
+//! registry (a warning is logged at bootstrap). Key and certificate distribution are
+//! up to the application; rotating the cluster key requires a rolling restart, during
+//! which old-key and new-key nodes temporarily cannot see each other.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -72,12 +98,16 @@
 
 mod dispatch;
 mod error;
+mod gossip;
 mod id;
 mod messaging;
 mod node;
 mod registry;
 mod remote_actor;
 mod remote_ref;
+mod security;
+#[cfg(feature = "tls")]
+mod tls;
 
 pub use chitchat::FailureDetectorConfig;
 
@@ -86,3 +116,6 @@ pub use id::{NodeId, RemoteActorId};
 pub use node::{RemoteNode, RemoteNodeConfig};
 pub use remote_actor::{RemoteActor, RemoteMessage, RemoteMessages};
 pub use remote_ref::{RemoteActorRef, RemoteAskRequest, RemoteTellRequest};
+pub use security::ClusterKey;
+#[cfg(feature = "tls")]
+pub use tls::{TlsConfig, TlsError};

--- a/remote/src/messaging/handshake.rs
+++ b/remote/src/messaging/handshake.rs
@@ -1,0 +1,538 @@
+//! The hello exchange every messaging connection performs before carrying requests.
+//!
+//! The handshake pins the protocol version, verifies both peers belong to the same
+//! cluster, and, when a cluster key is configured, mutually proves possession of it
+//! via an HMAC challenge-response — the key itself never crosses the wire.
+//!
+//! ```text
+//! client                                server
+//!   | ClientHello { version, cluster_id,  |
+//!   |               client_nonce }        |
+//!   |------------------------------------>|
+//!   | ServerHello { version,              |  or Reject + close
+//!   |               server_nonce, mac? }  |
+//!   |<------------------------------------|
+//!   | ClientAuth { mac? }                 |
+//!   |------------------------------------>|
+//!   | Accept                              |  or Reject + close
+//!   |<------------------------------------|
+//! ```
+
+use chacha20poly1305::aead::{OsRng, rand_core::RngCore};
+use futures::{SinkExt, StreamExt};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+use sha2::Sha256;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+use crate::security::{ConnSecurity, HandshakeKey};
+
+pub(crate) const PROTOCOL_VERSION: u16 = 1;
+
+const SERVER_MAC_LABEL: &[u8] = b"kameo-remote v1 server";
+const CLIENT_MAC_LABEL: &[u8] = b"kameo-remote v1 client";
+
+#[derive(Debug, Serialize, Deserialize)]
+enum HandshakeFrame {
+    ClientHello(ClientHello),
+    ServerHello(ServerHello),
+    ClientAuth(ClientAuth),
+    Accept,
+    Reject(RejectReason),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClientHello {
+    protocol_version: u16,
+    cluster_id: String,
+    nonce: ByteBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ServerHello {
+    protocol_version: u16,
+    nonce: ByteBuf,
+    /// Present iff the server has a cluster key.
+    mac: Option<ByteBuf>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClientAuth {
+    /// Present iff the client has a cluster key.
+    mac: Option<ByteBuf>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) enum RejectReason {
+    ProtocolVersion { supported: u16 },
+    ClusterMismatch,
+    AuthRequired,
+    AuthFailed,
+}
+
+/// An error which can occur during the connection handshake.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum HandshakeError {
+    #[error("cluster id mismatch")]
+    ClusterMismatch,
+    #[error("peer requires a cluster key")]
+    AuthRequired,
+    #[error("cluster key authentication failed")]
+    AuthFailed,
+    #[error("unsupported protocol version {0}")]
+    ProtocolVersion(u16),
+    #[error("handshake protocol error: {0}")]
+    Protocol(String),
+}
+
+/// The MAC proving key possession, bound to this connection's nonces and cluster.
+/// Direction labels prevent reflecting a peer's MAC back at it; the length-prefixed
+/// cluster id prevents boundary ambiguity with the nonces.
+fn compute_mac(
+    key: &HandshakeKey,
+    label: &[u8],
+    cluster_id: &str,
+    first_nonce: &[u8],
+    second_nonce: &[u8],
+) -> Vec<u8> {
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key.0).expect("hmac accepts any key length");
+    mac.update(label);
+    mac.update(&(cluster_id.len() as u32).to_le_bytes());
+    mac.update(cluster_id.as_bytes());
+    mac.update(first_nonce);
+    mac.update(second_nonce);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Constant-time MAC verification.
+fn verify_mac(
+    key: &HandshakeKey,
+    label: &[u8],
+    cluster_id: &str,
+    first_nonce: &[u8],
+    second_nonce: &[u8],
+    provided: &[u8],
+) -> bool {
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key.0).expect("hmac accepts any key length");
+    mac.update(label);
+    mac.update(&(cluster_id.len() as u32).to_le_bytes());
+    mac.update(cluster_id.as_bytes());
+    mac.update(first_nonce);
+    mac.update(second_nonce);
+    mac.verify_slice(provided).is_ok()
+}
+
+fn nonce() -> ByteBuf {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    ByteBuf::from(bytes.to_vec())
+}
+
+async fn send_frame<S>(
+    framed: &mut Framed<S, LengthDelimitedCodec>,
+    frame: &HandshakeFrame,
+) -> Result<(), HandshakeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let bytes = rmp_serde::to_vec_named(frame)
+        .map_err(|err| HandshakeError::Protocol(format!("encode: {err}")))?;
+    framed
+        .send(bytes.into())
+        .await
+        .map_err(|err| HandshakeError::Protocol(format!("send: {err}")))
+}
+
+async fn recv_frame<S>(
+    framed: &mut Framed<S, LengthDelimitedCodec>,
+) -> Result<HandshakeFrame, HandshakeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let bytes = framed
+        .next()
+        .await
+        .ok_or_else(|| HandshakeError::Protocol("connection closed".to_string()))?
+        .map_err(|err| HandshakeError::Protocol(format!("recv: {err}")))?;
+    rmp_serde::from_slice(&bytes).map_err(|err| HandshakeError::Protocol(format!("decode: {err}")))
+}
+
+impl From<RejectReason> for HandshakeError {
+    fn from(reason: RejectReason) -> Self {
+        match reason {
+            RejectReason::ProtocolVersion { supported } => {
+                HandshakeError::ProtocolVersion(supported)
+            }
+            RejectReason::ClusterMismatch => HandshakeError::ClusterMismatch,
+            RejectReason::AuthRequired => HandshakeError::AuthRequired,
+            RejectReason::AuthFailed => HandshakeError::AuthFailed,
+        }
+    }
+}
+
+/// Runs the dialer's side of the handshake.
+pub(crate) async fn client<S>(
+    framed: &mut Framed<S, LengthDelimitedCodec>,
+    security: &ConnSecurity,
+) -> Result<(), HandshakeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let client_nonce = nonce();
+    send_frame(
+        framed,
+        &HandshakeFrame::ClientHello(ClientHello {
+            protocol_version: PROTOCOL_VERSION,
+            cluster_id: security.cluster_id.clone(),
+            nonce: client_nonce.clone(),
+        }),
+    )
+    .await?;
+
+    let server_hello = match recv_frame(framed).await? {
+        HandshakeFrame::ServerHello(hello) => hello,
+        HandshakeFrame::Reject(reason) => return Err(reason.into()),
+        frame => {
+            return Err(HandshakeError::Protocol(format!(
+                "unexpected frame: {frame:?}"
+            )));
+        }
+    };
+    if server_hello.protocol_version != PROTOCOL_VERSION {
+        return Err(HandshakeError::ProtocolVersion(
+            server_hello.protocol_version,
+        ));
+    }
+
+    // A keyed client only talks to servers that prove key possession; a missing or
+    // bad MAC fails here so a keyless peer cannot downgrade the connection.
+    let client_mac = match &security.handshake_key {
+        Some(key) => {
+            let valid = server_hello.mac.as_ref().is_some_and(|mac| {
+                verify_mac(
+                    key,
+                    SERVER_MAC_LABEL,
+                    &security.cluster_id,
+                    &client_nonce,
+                    &server_hello.nonce,
+                    mac,
+                )
+            });
+            if !valid {
+                return Err(HandshakeError::AuthFailed);
+            }
+            Some(ByteBuf::from(compute_mac(
+                key,
+                CLIENT_MAC_LABEL,
+                &security.cluster_id,
+                &server_hello.nonce,
+                &client_nonce,
+            )))
+        }
+        None => None,
+    };
+
+    send_frame(
+        framed,
+        &HandshakeFrame::ClientAuth(ClientAuth { mac: client_mac }),
+    )
+    .await?;
+
+    match recv_frame(framed).await? {
+        HandshakeFrame::Accept => Ok(()),
+        HandshakeFrame::Reject(reason) => Err(reason.into()),
+        frame => Err(HandshakeError::Protocol(format!(
+            "unexpected frame: {frame:?}"
+        ))),
+    }
+}
+
+/// Runs the accepting side of the handshake. Rejections are sent to the peer
+/// best-effort before returning the error.
+pub(crate) async fn server<S>(
+    framed: &mut Framed<S, LengthDelimitedCodec>,
+    security: &ConnSecurity,
+) -> Result<(), HandshakeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let client_hello = match recv_frame(framed).await? {
+        HandshakeFrame::ClientHello(hello) => hello,
+        frame => {
+            return Err(HandshakeError::Protocol(format!(
+                "unexpected frame: {frame:?}"
+            )));
+        }
+    };
+    if client_hello.protocol_version != PROTOCOL_VERSION {
+        let reason = RejectReason::ProtocolVersion {
+            supported: PROTOCOL_VERSION,
+        };
+        let _ = send_frame(framed, &HandshakeFrame::Reject(reason)).await;
+        return Err(HandshakeError::ProtocolVersion(
+            client_hello.protocol_version,
+        ));
+    }
+    if client_hello.cluster_id != security.cluster_id {
+        let _ = send_frame(
+            framed,
+            &HandshakeFrame::Reject(RejectReason::ClusterMismatch),
+        )
+        .await;
+        return Err(HandshakeError::ClusterMismatch);
+    }
+
+    // Answering with a MAC before the client authenticates reveals nothing useful:
+    // it is an HMAC over random nonces, worthless without the key.
+    let server_nonce = nonce();
+    let server_mac = security.handshake_key.as_ref().map(|key| {
+        ByteBuf::from(compute_mac(
+            key,
+            SERVER_MAC_LABEL,
+            &security.cluster_id,
+            &client_hello.nonce,
+            &server_nonce,
+        ))
+    });
+    send_frame(
+        framed,
+        &HandshakeFrame::ServerHello(ServerHello {
+            protocol_version: PROTOCOL_VERSION,
+            nonce: server_nonce.clone(),
+            mac: server_mac,
+        }),
+    )
+    .await?;
+
+    let client_auth = match recv_frame(framed).await? {
+        HandshakeFrame::ClientAuth(auth) => auth,
+        HandshakeFrame::Reject(reason) => return Err(reason.into()),
+        frame => {
+            return Err(HandshakeError::Protocol(format!(
+                "unexpected frame: {frame:?}"
+            )));
+        }
+    };
+
+    if let Some(key) = &security.handshake_key {
+        let Some(mac) = &client_auth.mac else {
+            let _ = send_frame(framed, &HandshakeFrame::Reject(RejectReason::AuthRequired)).await;
+            return Err(HandshakeError::AuthRequired);
+        };
+        if !verify_mac(
+            key,
+            CLIENT_MAC_LABEL,
+            &security.cluster_id,
+            &server_nonce,
+            &client_hello.nonce,
+            mac,
+        ) {
+            let _ = send_frame(framed, &HandshakeFrame::Reject(RejectReason::AuthFailed)).await;
+            return Err(HandshakeError::AuthFailed);
+        }
+    }
+
+    send_frame(framed, &HandshakeFrame::Accept).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::security::{ClusterKey, derive_keys};
+
+    fn security(cluster_id: &str, key: Option<&ClusterKey>) -> ConnSecurity {
+        ConnSecurity {
+            cluster_id: cluster_id.to_string(),
+            handshake_key: key.map(|key| derive_keys(key).1),
+            #[cfg(feature = "tls")]
+            tls: None,
+        }
+    }
+
+    /// Runs both sides as separate tasks so a side that aborts mid-handshake drops
+    /// its stream, and the other side observes EOF instead of waiting forever.
+    async fn run_handshake(
+        client_security: ConnSecurity,
+        server_security: ConnSecurity,
+    ) -> (Result<(), HandshakeError>, Result<(), HandshakeError>) {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let client_task = tokio::spawn(async move {
+            let mut framed = LengthDelimitedCodec::builder().new_framed(client_io);
+            client(&mut framed, &client_security).await
+        });
+        let server_task = tokio::spawn(async move {
+            let mut framed = LengthDelimitedCodec::builder().new_framed(server_io);
+            server(&mut framed, &server_security).await
+        });
+        (client_task.await.unwrap(), server_task.await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn keyless_peers_connect() {
+        let (client_result, server_result) =
+            run_handshake(security("kameo", None), security("kameo", None)).await;
+        client_result.unwrap();
+        server_result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn matching_keys_connect() {
+        let key = ClusterKey::new([1u8; 32]);
+        let (client_result, server_result) =
+            run_handshake(security("kameo", Some(&key)), security("kameo", Some(&key))).await;
+        client_result.unwrap();
+        server_result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn different_keys_fail() {
+        let key_a = ClusterKey::new([1u8; 32]);
+        let key_b = ClusterKey::new([2u8; 32]);
+        let (client_result, _server_result) = run_handshake(
+            security("kameo", Some(&key_a)),
+            security("kameo", Some(&key_b)),
+        )
+        .await;
+        assert!(matches!(client_result, Err(HandshakeError::AuthFailed)));
+    }
+
+    #[tokio::test]
+    async fn keyed_client_rejects_keyless_server() {
+        let key = ClusterKey::new([1u8; 32]);
+        let (client_result, _server_result) =
+            run_handshake(security("kameo", Some(&key)), security("kameo", None)).await;
+        assert!(matches!(client_result, Err(HandshakeError::AuthFailed)));
+    }
+
+    #[tokio::test]
+    async fn keyed_server_rejects_keyless_client() {
+        let key = ClusterKey::new([1u8; 32]);
+        let (client_result, server_result) =
+            run_handshake(security("kameo", None), security("kameo", Some(&key))).await;
+        assert!(matches!(server_result, Err(HandshakeError::AuthRequired)));
+        assert!(matches!(client_result, Err(HandshakeError::AuthRequired)));
+    }
+
+    #[tokio::test]
+    async fn cluster_mismatch_fails_both_sides() {
+        let (client_result, server_result) =
+            run_handshake(security("kameo-a", None), security("kameo-b", None)).await;
+        assert!(matches!(
+            client_result,
+            Err(HandshakeError::ClusterMismatch)
+        ));
+        assert!(matches!(
+            server_result,
+            Err(HandshakeError::ClusterMismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unsupported_protocol_version_rejected() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let mut client_framed = LengthDelimitedCodec::builder().new_framed(client_io);
+        let mut server_framed = LengthDelimitedCodec::builder().new_framed(server_io);
+        let server_security = security("kameo", None);
+
+        let client = async {
+            send_frame(
+                &mut client_framed,
+                &HandshakeFrame::ClientHello(ClientHello {
+                    protocol_version: 2,
+                    cluster_id: "kameo".to_string(),
+                    nonce: nonce(),
+                }),
+            )
+            .await
+            .unwrap();
+            recv_frame(&mut client_framed).await.unwrap()
+        };
+        let (reply, server_result) =
+            tokio::join!(client, server(&mut server_framed, &server_security));
+        assert!(matches!(
+            reply,
+            HandshakeFrame::Reject(RejectReason::ProtocolVersion { supported: 1 })
+        ));
+        assert!(matches!(
+            server_result,
+            Err(HandshakeError::ProtocolVersion(2))
+        ));
+    }
+
+    #[tokio::test]
+    async fn garbage_first_frame_fails() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let mut client_framed = LengthDelimitedCodec::builder().new_framed(client_io);
+        let mut server_framed = LengthDelimitedCodec::builder().new_framed(server_io);
+        let server_security = security("kameo", None);
+
+        let client = async {
+            client_framed
+                .send(Bytes::from_static(b"not a handshake frame"))
+                .await
+                .unwrap();
+        };
+        let (_, server_result) = tokio::join!(client, server(&mut server_framed, &server_security));
+        assert!(matches!(server_result, Err(HandshakeError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn tampered_client_mac_rejected() {
+        let key = ClusterKey::new([1u8; 32]);
+        let client_security = security("kameo", Some(&key));
+        let server_security = security("kameo", Some(&key));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let mut client_framed = LengthDelimitedCodec::builder().new_framed(client_io);
+        let mut server_framed = LengthDelimitedCodec::builder().new_framed(server_io);
+
+        // A hand-driven client that authenticates with a corrupted MAC.
+        let client = async {
+            let client_nonce = nonce();
+            send_frame(
+                &mut client_framed,
+                &HandshakeFrame::ClientHello(ClientHello {
+                    protocol_version: PROTOCOL_VERSION,
+                    cluster_id: client_security.cluster_id.clone(),
+                    nonce: client_nonce.clone(),
+                }),
+            )
+            .await
+            .unwrap();
+            let HandshakeFrame::ServerHello(server_hello) =
+                recv_frame(&mut client_framed).await.unwrap()
+            else {
+                panic!("expected server hello");
+            };
+            let mut mac = compute_mac(
+                client_security.handshake_key.as_ref().unwrap(),
+                CLIENT_MAC_LABEL,
+                &client_security.cluster_id,
+                &server_hello.nonce,
+                &client_nonce,
+            );
+            mac[0] ^= 1;
+            send_frame(
+                &mut client_framed,
+                &HandshakeFrame::ClientAuth(ClientAuth {
+                    mac: Some(ByteBuf::from(mac)),
+                }),
+            )
+            .await
+            .unwrap();
+            recv_frame(&mut client_framed).await.unwrap()
+        };
+        let (reply, server_result) =
+            tokio::join!(client, server(&mut server_framed, &server_security));
+        assert!(matches!(
+            reply,
+            HandshakeFrame::Reject(RejectReason::AuthFailed)
+        ));
+        assert!(matches!(server_result, Err(HandshakeError::AuthFailed)));
+    }
+}

--- a/remote/src/messaging/handshake.rs
+++ b/remote/src/messaging/handshake.rs
@@ -87,9 +87,25 @@ pub(crate) enum HandshakeError {
     Protocol(String),
 }
 
-/// The MAC proving key possession, bound to this connection's nonces and cluster.
-/// Direction labels prevent reflecting a peer's MAC back at it; the length-prefixed
-/// cluster id prevents boundary ambiguity with the nonces.
+/// The MAC transcript proving key possession, bound to this connection's nonces and
+/// cluster. Direction labels prevent reflecting a peer's MAC back at it; the
+/// length-prefixed cluster id prevents boundary ambiguity with the nonces.
+fn mac_transcript(
+    key: &HandshakeKey,
+    label: &[u8],
+    cluster_id: &str,
+    first_nonce: &[u8],
+    second_nonce: &[u8],
+) -> Hmac<Sha256> {
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key.0).expect("hmac accepts any key length");
+    mac.update(label);
+    mac.update(&(cluster_id.len() as u32).to_le_bytes());
+    mac.update(cluster_id.as_bytes());
+    mac.update(first_nonce);
+    mac.update(second_nonce);
+    mac
+}
+
 fn compute_mac(
     key: &HandshakeKey,
     label: &[u8],
@@ -97,13 +113,10 @@ fn compute_mac(
     first_nonce: &[u8],
     second_nonce: &[u8],
 ) -> Vec<u8> {
-    let mut mac = Hmac::<Sha256>::new_from_slice(&key.0).expect("hmac accepts any key length");
-    mac.update(label);
-    mac.update(&(cluster_id.len() as u32).to_le_bytes());
-    mac.update(cluster_id.as_bytes());
-    mac.update(first_nonce);
-    mac.update(second_nonce);
-    mac.finalize().into_bytes().to_vec()
+    mac_transcript(key, label, cluster_id, first_nonce, second_nonce)
+        .finalize()
+        .into_bytes()
+        .to_vec()
 }
 
 /// Constant-time MAC verification.
@@ -115,13 +128,9 @@ fn verify_mac(
     second_nonce: &[u8],
     provided: &[u8],
 ) -> bool {
-    let mut mac = Hmac::<Sha256>::new_from_slice(&key.0).expect("hmac accepts any key length");
-    mac.update(label);
-    mac.update(&(cluster_id.len() as u32).to_le_bytes());
-    mac.update(cluster_id.as_bytes());
-    mac.update(first_nonce);
-    mac.update(second_nonce);
-    mac.verify_slice(provided).is_ok()
+    mac_transcript(key, label, cluster_id, first_nonce, second_nonce)
+        .verify_slice(provided)
+        .is_ok()
 }
 
 fn nonce() -> ByteBuf {
@@ -284,8 +293,10 @@ where
         return Err(HandshakeError::ClusterMismatch);
     }
 
-    // Answering with a MAC before the client authenticates reveals nothing useful:
-    // it is an HMAC over random nonces, worthless without the key.
+    // Answering with a MAC before the client authenticates is safe for a
+    // full-entropy key: an HMAC over random nonces cannot be inverted. It does hand
+    // an unauthenticated prober material for offline brute-force of a guessable key,
+    // which is why ClusterKey requires uniformly random bytes.
     let server_nonce = nonce();
     let server_mac = security.handshake_key.as_ref().map(|key| {
         ByteBuf::from(compute_mac(

--- a/remote/src/messaging/mod.rs
+++ b/remote/src/messaging/mod.rs
@@ -1,4 +1,5 @@
 //! TCP messaging between nodes.
 
+pub(crate) mod handshake;
 pub(crate) mod protocol;
 pub(crate) mod transport;

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -15,20 +15,29 @@ use bytes::Bytes;
 use futures::{FutureExt, SinkExt, StreamExt};
 use serde_bytes::ByteBuf;
 use tokio::{
+    io::{AsyncRead, AsyncWrite},
     net::{TcpListener, TcpStream},
     sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot},
 };
-use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
+use tokio_util::{
+    codec::{Framed, LengthDelimitedCodec},
+    sync::CancellationToken,
+};
 
 use crate::{
     dispatch::{DispatchTable, DynHandler, InboundKind},
-    messaging::protocol::{self, Frame, RequestFrame, RequestKind, ResponseFrame, WireError},
+    messaging::{
+        handshake::{self, HandshakeError},
+        protocol::{self, Frame, RequestFrame, RequestKind, ResponseFrame, WireError},
+    },
+    security::ConnSecurity,
 };
 
 /// An error which can occur when sending a request over the transport.
 #[derive(Debug)]
 pub(crate) enum TransportError {
     Connect(io::Error),
+    Handshake(HandshakeError),
     ConnectionClosed,
     NodeShutdown,
     ReplyTimeout,
@@ -54,6 +63,7 @@ struct PoolInner {
     connect_timeout: Duration,
     default_reply_timeout: Duration,
     max_frame_len: usize,
+    security: Arc<ConnSecurity>,
 }
 
 #[derive(Clone)]
@@ -69,6 +79,7 @@ impl ConnectionPool {
         connect_timeout: Duration,
         default_reply_timeout: Duration,
         max_frame_len: usize,
+        security: Arc<ConnSecurity>,
     ) -> Self {
         ConnectionPool {
             inner: Arc::new(PoolInner {
@@ -77,6 +88,7 @@ impl ConnectionPool {
                 connect_timeout,
                 default_reply_timeout,
                 max_frame_len,
+                security,
             }),
         }
     }
@@ -161,7 +173,27 @@ impl ConnectionPool {
     }
 
     async fn connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
-        let stream = tokio::time::timeout(self.inner.connect_timeout, TcpStream::connect(addr))
+        let connect = async {
+            let stream = TcpStream::connect(addr)
+                .await
+                .map_err(TransportError::Connect)?;
+            stream.set_nodelay(true).map_err(TransportError::Connect)?;
+            #[cfg(feature = "tls")]
+            if let Some(tls) = &self.inner.security.tls {
+                // The name is required by the API but ignored by the verifier, which
+                // checks the cert chain against the cluster CA instead.
+                let server_name = rustls_pki_types::ServerName::IpAddress(addr.ip().into());
+                let stream = tls
+                    .connector()
+                    .connect(server_name, stream)
+                    .await
+                    .map_err(TransportError::Connect)?;
+                return self.establish(stream).await;
+            }
+            self.establish(stream).await
+        };
+        // The timeout covers dial to ready: TCP connect, TLS, and the hello exchange.
+        tokio::time::timeout(self.inner.connect_timeout, connect)
             .await
             .map_err(|_| {
                 TransportError::Connect(io::Error::new(
@@ -169,12 +201,18 @@ impl ConnectionPool {
                     "connect timed out",
                 ))
             })?
-            .map_err(TransportError::Connect)?;
-        stream.set_nodelay(true).map_err(TransportError::Connect)?;
+    }
 
-        let framed = LengthDelimitedCodec::builder()
+    async fn establish<S>(&self, stream: S) -> Result<Connection, TransportError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let mut framed = LengthDelimitedCodec::builder()
             .max_frame_length(self.inner.max_frame_len)
             .new_framed(stream);
+        handshake::client(&mut framed, &self.inner.security)
+            .await
+            .map_err(TransportError::Handshake)?;
         let (mut sink, mut stream) = framed.split();
 
         let (outbound_tx, mut outbound_rx) = mpsc::channel::<Frame>(1024);
@@ -243,26 +281,27 @@ impl ConnectionPool {
     }
 }
 
+/// Everything the messaging server needs to accept and serve connections.
+pub(crate) struct ServerContext {
+    pub(crate) dispatch: Arc<DispatchTable>,
+    pub(crate) security: Arc<ConnSecurity>,
+    pub(crate) max_frame_len: usize,
+    pub(crate) max_concurrent_requests: usize,
+    pub(crate) handshake_timeout: Duration,
+}
+
 /// Accepts inbound connections and dispatches their requests until cancelled.
 pub(crate) async fn run_server(
     listener: TcpListener,
-    dispatch: Arc<DispatchTable>,
+    ctx: Arc<ServerContext>,
     cancel: CancellationToken,
-    max_frame_len: usize,
-    max_concurrent_requests: usize,
 ) {
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
             result = listener.accept() => match result {
                 Ok((stream, _)) => {
-                    tokio::spawn(handle_conn(
-                        stream,
-                        dispatch.clone(),
-                        cancel.child_token(),
-                        max_frame_len,
-                        max_concurrent_requests,
-                    ));
+                    tokio::spawn(handle_conn(stream, ctx.clone(), cancel.child_token()));
                 }
                 Err(err) => tracing::warn!("failed to accept connection: {err}"),
             }
@@ -270,19 +309,66 @@ pub(crate) async fn run_server(
     }
 }
 
-async fn handle_conn(
-    stream: TcpStream,
-    dispatch: Arc<DispatchTable>,
-    cancel: CancellationToken,
-    max_frame_len: usize,
-    max_concurrent_requests: usize,
-) {
+async fn handle_conn(stream: TcpStream, ctx: Arc<ServerContext>, cancel: CancellationToken) {
+    let peer_addr = stream.peer_addr().ok();
     if let Err(err) = stream.set_nodelay(true) {
         tracing::debug!("failed to set nodelay: {err}");
     }
-    let framed = LengthDelimitedCodec::builder()
-        .max_frame_length(max_frame_len)
+    // The timeout covers TLS and the hello exchange, so a connect-and-stall client
+    // cannot hold the socket open indefinitely.
+    #[cfg(feature = "tls")]
+    if let Some(tls) = ctx.security.tls.clone() {
+        let accept = async {
+            let stream = tls
+                .acceptor()
+                .accept(stream)
+                .await
+                .map_err(|err| HandshakeError::Protocol(format!("tls accept: {err}")))?;
+            accept_handshake(stream, &ctx).await
+        };
+        match tokio::time::timeout(ctx.handshake_timeout, accept).await {
+            Ok(Ok(framed)) => serve_conn(framed, ctx, cancel).await,
+            Ok(Err(err)) => tracing::warn!(?peer_addr, "handshake failed: {err}"),
+            Err(_) => tracing::warn!(?peer_addr, "handshake timed out"),
+        }
+        return;
+    }
+    match tokio::time::timeout(ctx.handshake_timeout, accept_handshake(stream, &ctx)).await {
+        Ok(Ok(framed)) => serve_conn(framed, ctx, cancel).await,
+        Ok(Err(err)) => tracing::warn!(?peer_addr, "handshake failed: {err}"),
+        Err(_) => tracing::warn!(?peer_addr, "handshake timed out"),
+    }
+}
+
+/// Frames the stream and runs the server side of the hello exchange.
+async fn accept_handshake<S>(
+    stream: S,
+    ctx: &ServerContext,
+) -> Result<Framed<S, LengthDelimitedCodec>, HandshakeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut framed = LengthDelimitedCodec::builder()
+        .max_frame_length(ctx.max_frame_len)
         .new_framed(stream);
+    handshake::server(&mut framed, &ctx.security).await?;
+    Ok(framed)
+}
+
+/// Serves a handshaken connection's requests until it closes or the node shuts down.
+async fn serve_conn<S>(
+    framed: Framed<S, LengthDelimitedCodec>,
+    ctx: Arc<ServerContext>,
+    cancel: CancellationToken,
+) where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let ServerContext {
+        dispatch,
+        max_concurrent_requests,
+        ..
+    } = &*ctx;
+    let max_concurrent_requests = *max_concurrent_requests;
     let (mut sink, mut stream) = framed.split();
 
     // Replies come from concurrently spawned request tasks, so they are funnelled

--- a/remote/src/messaging/transport.rs
+++ b/remote/src/messaging/transport.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    future::Future,
     io,
     net::SocketAddr,
     sync::{
@@ -183,11 +184,17 @@ impl ConnectionPool {
                 // The name is required by the API but ignored by the verifier, which
                 // checks the cert chain against the cluster CA instead.
                 let server_name = rustls_pki_types::ServerName::IpAddress(addr.ip().into());
+                // A handshake error, not a connect error: the peer is reachable but
+                // rejected us (or presented a bad cert), so retrying won't help.
                 let stream = tls
                     .connector()
                     .connect(server_name, stream)
                     .await
-                    .map_err(TransportError::Connect)?;
+                    .map_err(|err| {
+                        TransportError::Handshake(HandshakeError::Protocol(format!(
+                            "tls connect: {err}"
+                        )))
+                    })?;
                 return self.establish(stream).await;
             }
             self.establish(stream).await
@@ -314,26 +321,45 @@ async fn handle_conn(stream: TcpStream, ctx: Arc<ServerContext>, cancel: Cancell
     if let Err(err) = stream.set_nodelay(true) {
         tracing::debug!("failed to set nodelay: {err}");
     }
-    // The timeout covers TLS and the hello exchange, so a connect-and-stall client
-    // cannot hold the socket open indefinitely.
     #[cfg(feature = "tls")]
     if let Some(tls) = ctx.security.tls.clone() {
-        let accept = async {
-            let stream = tls
-                .acceptor()
-                .accept(stream)
-                .await
-                .map_err(|err| HandshakeError::Protocol(format!("tls accept: {err}")))?;
-            accept_handshake(stream, &ctx).await
+        let handshake = {
+            let ctx = ctx.clone();
+            async move {
+                let stream = tls
+                    .acceptor()
+                    .accept(stream)
+                    .await
+                    .map_err(|err| HandshakeError::Protocol(format!("tls accept: {err}")))?;
+                accept_handshake(stream, &ctx).await
+            }
         };
-        match tokio::time::timeout(ctx.handshake_timeout, accept).await {
-            Ok(Ok(framed)) => serve_conn(framed, ctx, cancel).await,
-            Ok(Err(err)) => tracing::warn!(?peer_addr, "handshake failed: {err}"),
-            Err(_) => tracing::warn!(?peer_addr, "handshake timed out"),
-        }
+        handshake_and_serve(handshake, ctx, cancel, peer_addr).await;
         return;
     }
-    match tokio::time::timeout(ctx.handshake_timeout, accept_handshake(stream, &ctx)).await {
+    let handshake = {
+        let ctx = ctx.clone();
+        async move { accept_handshake(stream, &ctx).await }
+    };
+    handshake_and_serve(handshake, ctx, cancel, peer_addr).await;
+}
+
+/// Runs a handshake future under the handshake timeout and node cancellation, then
+/// serves the connection. The timeout covers TLS and the hello exchange, so a
+/// connect-and-stall client cannot hold the socket open indefinitely.
+async fn handshake_and_serve<S>(
+    handshake: impl Future<Output = Result<Framed<S, LengthDelimitedCodec>, HandshakeError>>,
+    ctx: Arc<ServerContext>,
+    cancel: CancellationToken,
+    peer_addr: Option<SocketAddr>,
+) where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let result = tokio::select! {
+        _ = cancel.cancelled() => return,
+        result = tokio::time::timeout(ctx.handshake_timeout, handshake) => result,
+    };
+    match result {
         Ok(Ok(framed)) => serve_conn(framed, ctx, cancel).await,
         Ok(Err(err)) => tracing::warn!(?peer_addr, "handshake failed: {err}"),
         Err(_) => tracing::warn!(?peer_addr, "handshake timed out"),

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -54,7 +54,8 @@ pub struct RemoteNodeConfig {
     pub failure_detector_config: FailureDetectorConfig,
     /// Grace period before deleted registry keys are garbage collected. Default: 1h.
     pub marked_for_deletion_grace_period: Duration,
-    /// TCP connect timeout. Default: 10s.
+    /// Timeout for establishing a ready outbound connection: TCP connect, TLS when
+    /// enabled, and the connection handshake. Default: 10s.
     pub connect_timeout: Duration,
     /// Default ask reply timeout when not set per-request. Default: 30s.
     pub default_reply_timeout: Duration,

--- a/remote/src/node.rs
+++ b/remote/src/node.rs
@@ -21,11 +21,13 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     dispatch::DispatchTable,
     error::{BootstrapError, RegistryError, ShutdownError},
+    gossip::EncryptedUdpTransport,
     id::NodeId,
-    messaging::transport::{ConnectionPool, run_server},
+    messaging::transport::{ConnectionPool, ServerContext, run_server},
     registry::{self, RegistrationValue},
     remote_actor::{RemoteActor, RemoteMessages},
     remote_ref::RemoteActorRef,
+    security::{ClusterKey, ConnSecurity},
 };
 
 /// Configuration for a [`RemoteNode`].
@@ -62,6 +64,17 @@ pub struct RemoteNodeConfig {
     /// is reached, further frames are not read, propagating backpressure over TCP.
     /// Default: 512.
     pub max_concurrent_requests: usize,
+    /// Pre-shared cluster key: encrypts and authenticates gossip, and authenticates
+    /// messaging connections. Nodes with a different key (or none) cannot join or
+    /// message this node. Default: `None` (open cluster, trusted networks only).
+    pub cluster_key: Option<ClusterKey>,
+    /// Server-side timeout for a new connection to complete the handshake (including
+    /// TLS when enabled). Default: 10s.
+    pub handshake_timeout: Duration,
+    /// Mutual TLS for the messaging layer: encrypts connections and authenticates
+    /// both peers against the cluster CA. Default: `None` (plaintext).
+    #[cfg(feature = "tls")]
+    pub tls: Option<crate::tls::TlsConfig>,
 }
 
 impl Default for RemoteNodeConfig {
@@ -81,6 +94,10 @@ impl Default for RemoteNodeConfig {
             default_reply_timeout: Duration::from_secs(30),
             max_frame_len: 16 * 1024 * 1024,
             max_concurrent_requests: 512,
+            cluster_key: None,
+            handshake_timeout: Duration::from_secs(10),
+            #[cfg(feature = "tls")]
+            tls: None,
         }
     }
 }
@@ -118,6 +135,19 @@ impl RemoteNodeConfig {
         self.seed_nodes = seed_nodes.into_iter().map(Into::into).collect();
         self
     }
+
+    /// Sets the pre-shared cluster key.
+    pub fn with_cluster_key(mut self, cluster_key: impl Into<ClusterKey>) -> Self {
+        self.cluster_key = Some(cluster_key.into());
+        self
+    }
+
+    /// Sets the mutual TLS configuration for the messaging layer.
+    #[cfg(feature = "tls")]
+    pub fn with_tls(mut self, tls: crate::tls::TlsConfig) -> Self {
+        self.tls = Some(tls);
+        self
+    }
 }
 
 /// A node in a kameo cluster.
@@ -151,6 +181,8 @@ pub(crate) struct RemoteNodeInner {
 impl RemoteNode {
     /// Starts a node: binds the gossip and messaging listeners and joins the cluster.
     pub async fn bootstrap(config: RemoteNodeConfig) -> Result<Self, BootstrapError> {
+        #[cfg(feature = "tls")]
+        let tls = config.tls.clone();
         let RemoteNodeConfig {
             cluster_id,
             node_name,
@@ -166,7 +198,31 @@ impl RemoteNode {
             default_reply_timeout,
             max_frame_len,
             max_concurrent_requests,
+            cluster_key,
+            handshake_timeout,
+            ..
         } = config;
+
+        #[cfg(feature = "tls")]
+        if tls.is_some() && cluster_key.is_none() {
+            tracing::warn!(
+                "tls is enabled but no cluster_key is set; gossip is unauthenticated and \
+                 the registry can be poisoned by anyone who can reach the gossip port"
+            );
+        }
+        let (gossip_key, handshake_key) = match &cluster_key {
+            Some(key) => {
+                let (gossip_key, handshake_key) = crate::security::derive_keys(key);
+                (Some(gossip_key), Some(handshake_key))
+            }
+            None => (None, None),
+        };
+        let security = Arc::new(ConnSecurity {
+            cluster_id: cluster_id.clone(),
+            handshake_key,
+            #[cfg(feature = "tls")]
+            tls,
+        });
 
         let node_name =
             node_name.unwrap_or_else(|| format!("node-{}", uuid::Uuid::new_v4().simple()));
@@ -222,27 +278,43 @@ impl RemoteNode {
             catchup_callback: None,
             extra_liveness_predicate: None,
         };
+        let gossip_transport: Box<dyn chitchat::transport::Transport> = match gossip_key {
+            Some(gossip_key) => Box::new(EncryptedUdpTransport::new(
+                gossip_key,
+                security.cluster_id.clone(),
+            )),
+            None => Box::new(UdpTransport),
+        };
         let handle = spawn_chitchat(
             chitchat_config,
             vec![(
                 "kameo:messaging_addr".to_string(),
                 messaging_advertise_addr.to_string(),
             )],
-            &UdpTransport,
+            &*gossip_transport,
         )
         .await
         .map_err(BootstrapError::Chitchat)?;
 
         let chitchat = handle.chitchat();
         let dispatch = Arc::new(DispatchTable::new(generation_id));
-        let pool = ConnectionPool::new(connect_timeout, default_reply_timeout, max_frame_len);
+        let pool = ConnectionPool::new(
+            connect_timeout,
+            default_reply_timeout,
+            max_frame_len,
+            security.clone(),
+        );
         let cancel = CancellationToken::new();
         let server_task = tokio::spawn(run_server(
             listener,
-            dispatch.clone(),
+            Arc::new(ServerContext {
+                dispatch: dispatch.clone(),
+                security,
+                max_frame_len,
+                max_concurrent_requests,
+                handshake_timeout,
+            }),
             cancel.child_token(),
-            max_frame_len,
-            max_concurrent_requests,
         ));
 
         Ok(RemoteNode {

--- a/remote/src/remote_ref.rs
+++ b/remote/src/remote_ref.rs
@@ -12,6 +12,7 @@ use crate::{
     error::RemoteSendError,
     id::{NodeId, RemoteActorId},
     messaging::{
+        handshake::HandshakeError,
         protocol::{RequestFrame, RequestKind, WireError},
         transport::{ConnectionPool, TransportError},
     },
@@ -356,6 +357,15 @@ fn map_transport_error<E>(
 ) -> RemoteSendError<E> {
     match err {
         TransportError::Connect(err) => RemoteSendError::Connect(err),
+        TransportError::Handshake(err) => match err {
+            HandshakeError::ClusterMismatch => RemoteSendError::ClusterMismatch,
+            // Both mean the keys don't match between the two nodes; the rejecting
+            // side's log carries the precise reason.
+            HandshakeError::AuthRequired | HandshakeError::AuthFailed => {
+                RemoteSendError::AuthFailed
+            }
+            err => RemoteSendError::Handshake(err.to_string()),
+        },
         TransportError::ConnectionClosed => RemoteSendError::ConnectionClosed,
         TransportError::NodeShutdown => RemoteSendError::NodeShutdown,
         TransportError::ReplyTimeout => RemoteSendError::ReplyTimeout,

--- a/remote/src/security.rs
+++ b/remote/src/security.rs
@@ -1,0 +1,137 @@
+//! The pre-shared cluster key and the subkeys derived from it.
+
+use std::fmt;
+
+use chacha20poly1305::aead::{OsRng, rand_core::RngCore};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use zeroize::Zeroize;
+
+/// HKDF salt and MAC label prefix; bump together with the wire protocol version.
+const KDF_SALT: &[u8] = b"kameo-remote v1";
+
+/// A 32-byte pre-shared cluster secret.
+///
+/// Nodes configured with the same key form a closed cluster: gossip datagrams are
+/// encrypted and authenticated with a key derived from it, and messaging connections
+/// prove possession of it during the handshake without ever sending it over the wire.
+///
+/// The key is redacted from `Debug` output and zeroed on drop. Distributing it to
+/// nodes (environment, secret manager, ...) is up to the application.
+#[derive(Clone)]
+pub struct ClusterKey([u8; 32]);
+
+impl ClusterKey {
+    /// Creates a key from 32 raw bytes.
+    pub fn new(key: [u8; 32]) -> Self {
+        ClusterKey(key)
+    }
+
+    /// Generates a random key, for provisioning new clusters.
+    pub fn generate() -> Self {
+        let mut key = [0u8; 32];
+        OsRng.fill_bytes(&mut key);
+        ClusterKey(key)
+    }
+}
+
+impl From<[u8; 32]> for ClusterKey {
+    fn from(key: [u8; 32]) -> Self {
+        ClusterKey(key)
+    }
+}
+
+impl fmt::Debug for ClusterKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ClusterKey(..)")
+    }
+}
+
+impl Drop for ClusterKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// The subkey encrypting gossip datagrams.
+pub(crate) struct GossipKey(pub(crate) [u8; 32]);
+
+/// The subkey authenticating messaging handshakes.
+pub(crate) struct HandshakeKey(pub(crate) [u8; 32]);
+
+impl Drop for GossipKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl Drop for HandshakeKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Derives independent subkeys from the cluster key, so gossip ciphertexts and
+/// handshake MACs can never be confused for one another.
+pub(crate) fn derive_keys(key: &ClusterKey) -> (GossipKey, HandshakeKey) {
+    let hkdf = Hkdf::<Sha256>::new(Some(KDF_SALT), &key.0);
+    let mut gossip = [0u8; 32];
+    hkdf.expand(b"gossip aead", &mut gossip)
+        .expect("32 bytes is a valid hkdf-sha256 output length");
+    let mut handshake = [0u8; 32];
+    hkdf.expand(b"messaging handshake mac", &mut handshake)
+        .expect("32 bytes is a valid hkdf-sha256 output length");
+    (GossipKey(gossip), HandshakeKey(handshake))
+}
+
+/// Everything a messaging connection (either direction) needs to secure itself.
+pub(crate) struct ConnSecurity {
+    pub(crate) cluster_id: String,
+    pub(crate) handshake_key: Option<HandshakeKey>,
+    #[cfg(feature = "tls")]
+    pub(crate) tls: Option<crate::tls::TlsConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derivation_is_deterministic() {
+        let key = ClusterKey::new([7u8; 32]);
+        let (gossip_a, handshake_a) = derive_keys(&key);
+        let (gossip_b, handshake_b) = derive_keys(&key);
+        assert_eq!(gossip_a.0, gossip_b.0);
+        assert_eq!(handshake_a.0, handshake_b.0);
+    }
+
+    #[test]
+    fn subkeys_are_independent() {
+        let key = ClusterKey::new([7u8; 32]);
+        let (gossip, handshake) = derive_keys(&key);
+        assert_ne!(gossip.0, handshake.0);
+        assert_ne!(gossip.0, [7u8; 32]);
+        assert_ne!(handshake.0, [7u8; 32]);
+    }
+
+    #[test]
+    fn different_keys_derive_different_subkeys() {
+        let (gossip_a, _) = derive_keys(&ClusterKey::new([1u8; 32]));
+        let (gossip_b, _) = derive_keys(&ClusterKey::new([2u8; 32]));
+        assert_ne!(gossip_a.0, gossip_b.0);
+    }
+
+    #[test]
+    fn debug_redacts_key_bytes() {
+        let key = ClusterKey::new([0xAB; 32]);
+        let output = format!("{key:?}");
+        assert_eq!(output, "ClusterKey(..)");
+    }
+
+    #[test]
+    fn generate_produces_distinct_keys() {
+        let a = ClusterKey::generate();
+        let b = ClusterKey::generate();
+        assert_ne!(a.0, b.0);
+    }
+}

--- a/remote/src/security.rs
+++ b/remote/src/security.rs
@@ -16,6 +16,12 @@ const KDF_SALT: &[u8] = b"kameo-remote v1";
 /// encrypted and authenticated with a key derived from it, and messaging connections
 /// prove possession of it during the handshake without ever sending it over the wire.
 ///
+/// The key must be 32 uniformly random bytes (from [`generate`](ClusterKey::generate)
+/// or a secret manager's random generator), not a passphrase: handshake MACs and
+/// gossip packets are observable by anyone on the network, so a guessable key can be
+/// brute-forced offline. If a passphrase is all you have, run it through a password
+/// KDF (argon2, scrypt) first.
+///
 /// The key is redacted from `Debug` output and zeroed on drop. Distributing it to
 /// nodes (environment, secret manager, ...) is up to the application.
 #[derive(Clone)]

--- a/remote/src/tls.rs
+++ b/remote/src/tls.rs
@@ -1,0 +1,260 @@
+//! Mutual TLS for the messaging layer.
+//!
+//! Both sides of every connection authenticate against a cluster CA: the server
+//! requires a CA-signed client certificate, and the client verifies the server's
+//! chain against the same CA. Hostname verification is intentionally skipped, since
+//! nodes are dialed by gossip-advertised IPs; possession of a CA-signed certificate
+//! is what makes a peer a cluster member. Use [`TlsConfig::from_rustls`] to bring a
+//! standard verifier if certificates carry IP SANs and stricter checking is wanted.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use rustls::{
+    ClientConfig, DigitallySignedStruct, RootCertStore, ServerConfig, SignatureScheme,
+    client::{
+        danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        verify_server_cert_signed_by_trust_anchor,
+    },
+    crypto::{WebPkiSupportedAlgorithms, ring, verify_tls13_signature},
+    server::{ParsedCertificate, VerifierBuilderError, WebPkiClientVerifier},
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime, pem::PemObject};
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+/// An error which can occur when building a [`TlsConfig`].
+#[derive(Debug, thiserror::Error)]
+pub enum TlsError {
+    /// Failed to read a certificate or key file.
+    #[error("failed to read {path}: {source}")]
+    Io {
+        /// The file that could not be read.
+        path: PathBuf,
+        /// The underlying io error.
+        source: io::Error,
+    },
+    /// Failed to parse PEM data.
+    #[error("invalid pem: {0}")]
+    Pem(#[from] rustls_pki_types::pem::Error),
+    /// The PEM data contained no certificates.
+    #[error("no certificates found in pem")]
+    NoCertificates,
+    /// The TLS configuration is invalid (bad certificate, key mismatch, ...).
+    #[error("tls: {0}")]
+    Rustls(#[from] rustls::Error),
+    /// The client certificate verifier could not be built.
+    #[error("verifier: {0}")]
+    Verifier(#[from] VerifierBuilderError),
+}
+
+/// Mutual TLS configuration for the messaging layer.
+///
+/// Built from a cluster CA plus this node's certificate and key: connections are
+/// encrypted with TLS 1.3 and both peers must present a certificate signed by the
+/// CA. See the module docs for the verification model.
+#[derive(Clone)]
+pub struct TlsConfig {
+    acceptor: TlsAcceptor,
+    connector: TlsConnector,
+}
+
+impl std::fmt::Debug for TlsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TlsConfig { .. }")
+    }
+}
+
+impl TlsConfig {
+    /// Builds a config from PEM data: the cluster CA certificate(s), this node's
+    /// certificate chain, and its private key.
+    pub fn from_pem(ca_pem: &[u8], cert_pem: &[u8], key_pem: &[u8]) -> Result<Self, TlsError> {
+        let ca_certs = CertificateDer::pem_slice_iter(ca_pem).collect::<Result<Vec<_>, _>>()?;
+        if ca_certs.is_empty() {
+            return Err(TlsError::NoCertificates);
+        }
+        let cert_chain = CertificateDer::pem_slice_iter(cert_pem).collect::<Result<Vec<_>, _>>()?;
+        if cert_chain.is_empty() {
+            return Err(TlsError::NoCertificates);
+        }
+        let key = PrivateKeyDer::from_pem_slice(key_pem)?;
+
+        let mut roots = RootCertStore::empty();
+        for cert in ca_certs {
+            roots.add(cert)?;
+        }
+        let roots = Arc::new(roots);
+        // An explicit provider, so nothing here depends on (or conflicts with) the
+        // process-level default the host application may install.
+        let provider = Arc::new(ring::default_provider());
+
+        let client_verifier =
+            WebPkiClientVerifier::builder_with_provider(roots.clone(), provider.clone()).build()?;
+        let server_config = ServerConfig::builder_with_provider(provider.clone())
+            .with_protocol_versions(&[&rustls::version::TLS13])?
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(cert_chain.clone(), key.clone_key())?;
+
+        let server_verifier = Arc::new(NoHostnameVerifier {
+            roots,
+            supported_algs: provider.signature_verification_algorithms,
+        });
+        let client_config = ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])?
+            .dangerous()
+            .with_custom_certificate_verifier(server_verifier)
+            .with_client_auth_cert(cert_chain, key)?;
+
+        Ok(TlsConfig::from_rustls(
+            Arc::new(server_config),
+            Arc::new(client_config),
+        ))
+    }
+
+    /// Builds a config from PEM files; see [`from_pem`](TlsConfig::from_pem).
+    pub fn from_pem_files(
+        ca: impl AsRef<Path>,
+        cert: impl AsRef<Path>,
+        key: impl AsRef<Path>,
+    ) -> Result<Self, TlsError> {
+        let read = |path: &Path| {
+            std::fs::read(path).map_err(|source| TlsError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        };
+        let ca_pem = read(ca.as_ref())?;
+        let cert_pem = read(cert.as_ref())?;
+        let key_pem = read(key.as_ref())?;
+        TlsConfig::from_pem(&ca_pem, &cert_pem, &key_pem)
+    }
+
+    /// Builds a config from raw rustls configs, for full control over verification,
+    /// revocation, providers, or certificate resolution.
+    ///
+    /// The server config is used for inbound connections and the client config for
+    /// outbound ones. For a closed cluster the server should require client
+    /// certificates and the client should verify the server, otherwise inbound
+    /// connections are effectively unauthenticated.
+    pub fn from_rustls(server: Arc<ServerConfig>, client: Arc<ClientConfig>) -> Self {
+        TlsConfig {
+            acceptor: TlsAcceptor::from(server),
+            connector: TlsConnector::from(client),
+        }
+    }
+
+    pub(crate) fn acceptor(&self) -> &TlsAcceptor {
+        &self.acceptor
+    }
+
+    pub(crate) fn connector(&self) -> &TlsConnector {
+        &self.connector
+    }
+}
+
+/// Verifies the server's chain and validity against the cluster CA, skipping
+/// hostname verification: nodes are dialed by gossip-advertised IPs, and a CA-signed
+/// certificate is what proves cluster membership.
+#[derive(Debug)]
+struct NoHostnameVerifier {
+    roots: Arc<RootCertStore>,
+    supported_algs: WebPkiSupportedAlgorithms,
+}
+
+impl ServerCertVerifier for NoHostnameVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let cert = ParsedCertificate::try_from(end_entity)?;
+        verify_server_cert_signed_by_trust_anchor(
+            &cert,
+            &self.roots,
+            intermediates,
+            now,
+            self.supported_algs.all,
+        )?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        // Unreachable: the configs are TLS 1.3 only.
+        Err(rustls::Error::General("tls 1.2 is not supported".into()))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_algs.supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cluster_pems() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let key = rcgen::KeyPair::generate().unwrap();
+        let params = rcgen::CertificateParams::new(vec!["node".to_string()]).unwrap();
+        let cert = params.signed_by(&key, &ca_cert, &ca_key).unwrap();
+
+        (
+            ca_cert.pem().into_bytes(),
+            cert.pem().into_bytes(),
+            key.serialize_pem().into_bytes(),
+        )
+    }
+
+    #[test]
+    fn from_pem_accepts_ca_signed_cert() {
+        let (ca, cert, key) = cluster_pems();
+        TlsConfig::from_pem(&ca, &cert, &key).unwrap();
+    }
+
+    #[test]
+    fn from_pem_rejects_garbage() {
+        let err = TlsConfig::from_pem(b"garbage", b"garbage", b"garbage").unwrap_err();
+        assert!(matches!(err, TlsError::Pem(_) | TlsError::NoCertificates));
+    }
+
+    #[test]
+    fn from_pem_rejects_missing_key() {
+        let (ca, cert, _) = cluster_pems();
+        let err = TlsConfig::from_pem(&ca, &cert, b"").unwrap_err();
+        assert!(matches!(err, TlsError::Pem(_)));
+    }
+
+    #[test]
+    fn from_pem_files_reports_missing_file() {
+        let err = TlsConfig::from_pem_files(
+            "/nonexistent/ca.pem",
+            "/nonexistent/cert.pem",
+            "/nonexistent/key.pem",
+        )
+        .unwrap_err();
+        assert!(matches!(err, TlsError::Io { .. }));
+    }
+}

--- a/remote/tests/cluster.rs
+++ b/remote/tests/cluster.rs
@@ -1,72 +1,18 @@
-use std::time::{Duration, Instant};
+mod common;
 
-use futures::{Future, StreamExt};
+use std::time::Duration;
+
+use common::{
+    Counter, DEATH_DEADLINE, Fail, GOSSIP_DEADLINE, Get, Inc, TestError, eventually,
+    spawn_test_cluster, spawn_test_node, test_config,
+};
+use futures::StreamExt;
 use kameo::prelude::*;
 use kameo_remote::{
     FailureDetectorConfig, RegistryError, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode,
-    RemoteNodeConfig, RemoteSendError,
+    RemoteSendError,
 };
 use serde::{Deserialize, Serialize};
-
-#[derive(Actor)]
-struct Counter {
-    count: i64,
-}
-
-#[derive(Serialize, Deserialize)]
-struct Inc {
-    amount: i64,
-}
-
-impl Message<Inc> for Counter {
-    type Reply = i64;
-
-    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
-        self.count += msg.amount;
-        self.count
-    }
-}
-
-impl RemoteMessage for Inc {
-    const REMOTE_ID: &'static str = "test::Inc";
-}
-
-#[derive(Serialize, Deserialize)]
-struct Get;
-
-impl Message<Get> for Counter {
-    type Reply = i64;
-
-    async fn handle(&mut self, _: Get, _: &mut Context<Self, Self::Reply>) -> i64 {
-        self.count
-    }
-}
-
-impl RemoteMessage for Get {
-    const REMOTE_ID: &'static str = "test::Get";
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct TestError(String);
-
-#[derive(Serialize, Deserialize)]
-struct Fail;
-
-impl Message<Fail> for Counter {
-    type Reply = Result<i64, TestError>;
-
-    async fn handle(
-        &mut self,
-        _: Fail,
-        _: &mut Context<Self, Self::Reply>,
-    ) -> Result<i64, TestError> {
-        Err(TestError("boom".to_string()))
-    }
-}
-
-impl RemoteMessage for Fail {
-    const REMOTE_ID: &'static str = "test::Fail";
-}
 
 /// Handled by `Counter`, but deliberately not declared in `remote_messages`.
 #[derive(Serialize, Deserialize)]
@@ -80,16 +26,6 @@ impl Message<Undeclared> for Counter {
 
 impl RemoteMessage for Undeclared {
     const REMOTE_ID: &'static str = "test::Undeclared";
-}
-
-impl RemoteActor for Counter {
-    const REMOTE_ID: &'static str = "test::Counter";
-
-    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
-        handlers.add::<Inc>();
-        handlers.add::<Get>();
-        handlers.add::<Fail>();
-    }
 }
 
 #[derive(Actor)]
@@ -144,57 +80,6 @@ impl RemoteActor for Sequencer {
         handlers.add::<GetAll>();
     }
 }
-
-fn test_config(seed_nodes: Vec<String>) -> RemoteNodeConfig {
-    RemoteNodeConfig {
-        cluster_id: "kameo-test".to_string(),
-        gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
-        messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
-        seed_nodes,
-        gossip_interval: Duration::from_millis(50),
-        failure_detector_config: FailureDetectorConfig {
-            phi_threshold: 8.0,
-            sampling_window_size: 1000,
-            max_interval: Duration::from_millis(500),
-            initial_interval: Duration::from_millis(100),
-            dead_node_grace_period: Duration::from_secs(20),
-        },
-        ..Default::default()
-    }
-}
-
-async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
-    RemoteNode::bootstrap(test_config(seed_nodes))
-        .await
-        .unwrap()
-}
-
-/// Spawns two nodes, with the second seeded off the first.
-async fn spawn_test_cluster() -> (RemoteNode, RemoteNode) {
-    let node_a = spawn_test_node(vec![]).await;
-    let node_b = spawn_test_node(vec![node_a.gossip_addr().to_string()]).await;
-    (node_a, node_b)
-}
-
-async fn eventually<T, F, Fut>(deadline: Duration, mut condition: F) -> T
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Option<T>>,
-{
-    let start = Instant::now();
-    loop {
-        if let Some(value) = condition().await {
-            return value;
-        }
-        if start.elapsed() > deadline {
-            panic!("condition not met within {deadline:?}");
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-}
-
-const GOSSIP_DEADLINE: Duration = Duration::from_secs(10);
-const DEATH_DEADLINE: Duration = Duration::from_secs(30);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn register_and_lookup() {

--- a/remote/tests/common/mod.rs
+++ b/remote/tests/common/mod.rs
@@ -1,0 +1,132 @@
+//! Helpers shared by the integration test crates.
+#![allow(dead_code)] // Each test crate uses a different subset.
+
+use std::time::{Duration, Instant};
+
+use futures::Future;
+use kameo::prelude::*;
+use kameo_remote::{
+    FailureDetectorConfig, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode, RemoteNodeConfig,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Actor)]
+pub struct Counter {
+    pub count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Inc {
+    pub amount: i64,
+}
+
+impl Message<Inc> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "test::Inc";
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Get;
+
+impl Message<Get> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, _: Get, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count
+    }
+}
+
+impl RemoteMessage for Get {
+    const REMOTE_ID: &'static str = "test::Get";
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestError(pub String);
+
+#[derive(Serialize, Deserialize)]
+pub struct Fail;
+
+impl Message<Fail> for Counter {
+    type Reply = Result<i64, TestError>;
+
+    async fn handle(
+        &mut self,
+        _: Fail,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Result<i64, TestError> {
+        Err(TestError("boom".to_string()))
+    }
+}
+
+impl RemoteMessage for Fail {
+    const REMOTE_ID: &'static str = "test::Fail";
+}
+
+impl RemoteActor for Counter {
+    const REMOTE_ID: &'static str = "test::Counter";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+        handlers.add::<Get>();
+        handlers.add::<Fail>();
+    }
+}
+
+pub fn test_config(seed_nodes: Vec<String>) -> RemoteNodeConfig {
+    RemoteNodeConfig {
+        cluster_id: "kameo-test".to_string(),
+        gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        seed_nodes,
+        gossip_interval: Duration::from_millis(50),
+        failure_detector_config: FailureDetectorConfig {
+            phi_threshold: 8.0,
+            sampling_window_size: 1000,
+            max_interval: Duration::from_millis(500),
+            initial_interval: Duration::from_millis(100),
+            dead_node_grace_period: Duration::from_secs(20),
+        },
+        ..Default::default()
+    }
+}
+
+pub async fn spawn_test_node(seed_nodes: Vec<String>) -> RemoteNode {
+    RemoteNode::bootstrap(test_config(seed_nodes))
+        .await
+        .unwrap()
+}
+
+/// Spawns two nodes, with the second seeded off the first.
+pub async fn spawn_test_cluster() -> (RemoteNode, RemoteNode) {
+    let node_a = spawn_test_node(vec![]).await;
+    let node_b = spawn_test_node(vec![node_a.gossip_addr().to_string()]).await;
+    (node_a, node_b)
+}
+
+pub async fn eventually<T, F, Fut>(deadline: Duration, mut condition: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let start = Instant::now();
+    loop {
+        if let Some(value) = condition().await {
+            return value;
+        }
+        if start.elapsed() > deadline {
+            panic!("condition not met within {deadline:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub const GOSSIP_DEADLINE: Duration = Duration::from_secs(10);
+pub const DEATH_DEADLINE: Duration = Duration::from_secs(30);

--- a/remote/tests/security.rs
+++ b/remote/tests/security.rs
@@ -1,82 +1,18 @@
-use std::time::{Duration, Instant};
+mod common;
 
-use futures::Future;
+use std::time::Duration;
+
+use common::{Counter, GOSSIP_DEADLINE, Inc, eventually};
 use kameo::prelude::*;
-use kameo_remote::{
-    ClusterKey, FailureDetectorConfig, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode,
-    RemoteNodeConfig,
-};
-use serde::{Deserialize, Serialize};
+use kameo_remote::{ClusterKey, RemoteNode, RemoteNodeConfig};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-#[derive(Actor)]
-struct Counter {
-    count: i64,
-}
-
-#[derive(Serialize, Deserialize)]
-struct Inc {
-    amount: i64,
-}
-
-impl Message<Inc> for Counter {
-    type Reply = i64;
-
-    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
-        self.count += msg.amount;
-        self.count
-    }
-}
-
-impl RemoteMessage for Inc {
-    const REMOTE_ID: &'static str = "test::Inc";
-}
-
-impl RemoteActor for Counter {
-    const REMOTE_ID: &'static str = "test::Counter";
-
-    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
-        handlers.add::<Inc>();
-    }
-}
 
 fn test_config(seed_nodes: Vec<String>, cluster_key: Option<ClusterKey>) -> RemoteNodeConfig {
     RemoteNodeConfig {
-        cluster_id: "kameo-test".to_string(),
-        gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
-        messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
-        seed_nodes,
-        gossip_interval: Duration::from_millis(50),
-        failure_detector_config: FailureDetectorConfig {
-            phi_threshold: 8.0,
-            sampling_window_size: 1000,
-            max_interval: Duration::from_millis(500),
-            initial_interval: Duration::from_millis(100),
-            dead_node_grace_period: Duration::from_secs(20),
-        },
         cluster_key,
-        ..Default::default()
+        ..common::test_config(seed_nodes)
     }
 }
-
-async fn eventually<T, F, Fut>(deadline: Duration, mut condition: F) -> T
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Option<T>>,
-{
-    let start = Instant::now();
-    loop {
-        if let Some(value) = condition().await {
-            return value;
-        }
-        if start.elapsed() > deadline {
-            panic!("condition not met within {deadline:?}");
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-}
-
-const GOSSIP_DEADLINE: Duration = Duration::from_secs(10);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn psk_cluster_end_to_end() {

--- a/remote/tests/security.rs
+++ b/remote/tests/security.rs
@@ -1,0 +1,313 @@
+use std::time::{Duration, Instant};
+
+use futures::Future;
+use kameo::prelude::*;
+use kameo_remote::{
+    ClusterKey, FailureDetectorConfig, RemoteActor, RemoteMessage, RemoteMessages, RemoteNode,
+    RemoteNodeConfig,
+};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Actor)]
+struct Counter {
+    count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Inc {
+    amount: i64,
+}
+
+impl Message<Inc> for Counter {
+    type Reply = i64;
+
+    async fn handle(&mut self, msg: Inc, _: &mut Context<Self, Self::Reply>) -> i64 {
+        self.count += msg.amount;
+        self.count
+    }
+}
+
+impl RemoteMessage for Inc {
+    const REMOTE_ID: &'static str = "test::Inc";
+}
+
+impl RemoteActor for Counter {
+    const REMOTE_ID: &'static str = "test::Counter";
+
+    fn remote_messages(handlers: &mut RemoteMessages<Self>) {
+        handlers.add::<Inc>();
+    }
+}
+
+fn test_config(seed_nodes: Vec<String>, cluster_key: Option<ClusterKey>) -> RemoteNodeConfig {
+    RemoteNodeConfig {
+        cluster_id: "kameo-test".to_string(),
+        gossip_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        messaging_listen_addr: "127.0.0.1:0".parse().unwrap(),
+        seed_nodes,
+        gossip_interval: Duration::from_millis(50),
+        failure_detector_config: FailureDetectorConfig {
+            phi_threshold: 8.0,
+            sampling_window_size: 1000,
+            max_interval: Duration::from_millis(500),
+            initial_interval: Duration::from_millis(100),
+            dead_node_grace_period: Duration::from_secs(20),
+        },
+        cluster_key,
+        ..Default::default()
+    }
+}
+
+async fn eventually<T, F, Fut>(deadline: Duration, mut condition: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let start = Instant::now();
+    loop {
+        if let Some(value) = condition().await {
+            return value;
+        }
+        if start.elapsed() > deadline {
+            panic!("condition not met within {deadline:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+const GOSSIP_DEADLINE: Duration = Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn psk_cluster_end_to_end() {
+    let key = ClusterKey::generate();
+    let node_a = RemoteNode::bootstrap(test_config(vec![], Some(key.clone())))
+        .await
+        .unwrap();
+    let node_b = RemoteNode::bootstrap(test_config(
+        vec![node_a.gossip_addr().to_string()],
+        Some(key),
+    ))
+    .await
+    .unwrap();
+
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+    assert_eq!(remote.ask(&Inc { amount: 2 }).await.unwrap(), 2);
+    remote.tell(&Inc { amount: 3 }).await.unwrap();
+    assert_eq!(remote.ask(&Inc { amount: 0 }).await.unwrap(), 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn wrong_key_nodes_never_join() {
+    let node_a = RemoteNode::bootstrap(test_config(vec![], Some(ClusterKey::generate())))
+        .await
+        .unwrap();
+    let _node_b = RemoteNode::bootstrap(test_config(
+        vec![node_a.gossip_addr().to_string()],
+        Some(ClusterKey::generate()),
+    ))
+    .await
+    .unwrap();
+
+    // At a 50ms gossip interval, 3s is dozens of rejected rounds.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(node_a.live_nodes().await.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn keyless_node_never_joins_keyed_cluster() {
+    let node_a = RemoteNode::bootstrap(test_config(vec![], Some(ClusterKey::generate())))
+        .await
+        .unwrap();
+    let _node_b = RemoteNode::bootstrap(test_config(vec![node_a.gossip_addr().to_string()], None))
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(node_a.live_nodes().await.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn server_survives_garbage_connection() {
+    let key = ClusterKey::generate();
+    let node_a = RemoteNode::bootstrap(test_config(vec![], Some(key.clone())))
+        .await
+        .unwrap();
+    let node_b = RemoteNode::bootstrap(test_config(
+        vec![node_a.gossip_addr().to_string()],
+        Some(key),
+    ))
+    .await
+    .unwrap();
+
+    // A garbage framed blob must get the connection closed, not crash the server.
+    let mut stream = tokio::net::TcpStream::connect(node_a.messaging_addr())
+        .await
+        .unwrap();
+    let garbage = b"not a handshake frame";
+    stream
+        .write_all(&(garbage.len() as u32).to_be_bytes())
+        .await
+        .unwrap();
+    stream.write_all(garbage).await.unwrap();
+    let mut buf = [0u8; 64];
+    let read = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .expect("server should close the connection")
+        .unwrap();
+    assert_eq!(read, 0, "server should send nothing and close");
+
+    // The cluster still works afterwards.
+    let counter = Counter::spawn(Counter { count: 0 });
+    node_a.register(&counter, "counter").await.unwrap();
+    let remote = eventually(GOSSIP_DEADLINE, || async {
+        node_b.lookup::<Counter>("counter").await.unwrap()
+    })
+    .await;
+    assert_eq!(remote.ask(&Inc { amount: 1 }).await.unwrap(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stalled_handshake_times_out() {
+    let config = RemoteNodeConfig {
+        handshake_timeout: Duration::from_millis(200),
+        ..test_config(vec![], None)
+    };
+    let node = RemoteNode::bootstrap(config).await.unwrap();
+
+    let mut stream = tokio::net::TcpStream::connect(node.messaging_addr())
+        .await
+        .unwrap();
+    let mut buf = [0u8; 64];
+    let read = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut buf))
+        .await
+        .expect("server should close a stalled connection")
+        .unwrap();
+    assert_eq!(read, 0);
+}
+
+#[cfg(feature = "tls")]
+mod tls {
+    use kameo_remote::{RemoteSendError, TlsConfig};
+
+    use super::*;
+
+    struct TestCa {
+        key: rcgen::KeyPair,
+        cert: rcgen::Certificate,
+    }
+
+    impl TestCa {
+        fn generate() -> Self {
+            let key = rcgen::KeyPair::generate().unwrap();
+            let mut params = rcgen::CertificateParams::new(Vec::new()).unwrap();
+            params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+            let cert = params.self_signed(&key).unwrap();
+            TestCa { key, cert }
+        }
+
+        /// Issues a node certificate and builds a [`TlsConfig`] trusting this CA.
+        fn node_tls_config(&self) -> TlsConfig {
+            let key = rcgen::KeyPair::generate().unwrap();
+            let params = rcgen::CertificateParams::new(vec!["node".to_string()]).unwrap();
+            let cert = params.signed_by(&key, &self.cert, &self.key).unwrap();
+            TlsConfig::from_pem(
+                self.cert.pem().as_bytes(),
+                cert.pem().as_bytes(),
+                key.serialize_pem().as_bytes(),
+            )
+            .unwrap()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_psk_cluster_end_to_end() {
+        let ca = TestCa::generate();
+        let key = ClusterKey::generate();
+
+        let config_a = test_config(vec![], Some(key.clone())).with_tls(ca.node_tls_config());
+        let node_a = RemoteNode::bootstrap(config_a).await.unwrap();
+        let config_b = test_config(vec![node_a.gossip_addr().to_string()], Some(key))
+            .with_tls(ca.node_tls_config());
+        let node_b = RemoteNode::bootstrap(config_b).await.unwrap();
+
+        let counter = Counter::spawn(Counter { count: 0 });
+        node_a.register(&counter, "counter").await.unwrap();
+
+        let remote = eventually(GOSSIP_DEADLINE, || async {
+            node_b.lookup::<Counter>("counter").await.unwrap()
+        })
+        .await;
+        assert_eq!(remote.ask(&Inc { amount: 2 }).await.unwrap(), 2);
+        remote.tell(&Inc { amount: 3 }).await.unwrap();
+        assert_eq!(remote.ask(&Inc { amount: 0 }).await.unwrap(), 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_rejects_plaintext_peer() {
+        let ca = TestCa::generate();
+
+        // Both keyless so gossip converges; only node A requires TLS on messaging.
+        let config_a = test_config(vec![], None).with_tls(ca.node_tls_config());
+        let node_a = RemoteNode::bootstrap(config_a).await.unwrap();
+        let node_b =
+            RemoteNode::bootstrap(test_config(vec![node_a.gossip_addr().to_string()], None))
+                .await
+                .unwrap();
+
+        let counter = Counter::spawn(Counter { count: 0 });
+        node_a.register(&counter, "counter").await.unwrap();
+
+        let remote = eventually(GOSSIP_DEADLINE, || async {
+            node_b.lookup::<Counter>("counter").await.unwrap()
+        })
+        .await;
+        let err = remote.ask(&Inc { amount: 1 }).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                RemoteSendError::Connect(_)
+                    | RemoteSendError::ConnectionClosed
+                    | RemoteSendError::Handshake(_)
+            ),
+            "expected a connection-level failure, got: {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_rejects_untrusted_ca() {
+        let ca_a = TestCa::generate();
+        let ca_b = TestCa::generate();
+
+        let config_a = test_config(vec![], None).with_tls(ca_a.node_tls_config());
+        let node_a = RemoteNode::bootstrap(config_a).await.unwrap();
+        // Node B trusts and presents certs from a different CA.
+        let config_b = test_config(vec![node_a.gossip_addr().to_string()], None)
+            .with_tls(ca_b.node_tls_config());
+        let node_b = RemoteNode::bootstrap(config_b).await.unwrap();
+
+        let counter = Counter::spawn(Counter { count: 0 });
+        node_a.register(&counter, "counter").await.unwrap();
+
+        let remote = eventually(GOSSIP_DEADLINE, || async {
+            node_b.lookup::<Counter>("counter").await.unwrap()
+        })
+        .await;
+        let err = remote.ask(&Inc { amount: 1 }).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                RemoteSendError::Connect(_)
+                    | RemoteSendError::ConnectionClosed
+                    | RemoteSendError::Handshake(_)
+            ),
+            "expected a connection-level failure, got: {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
This closes the main gap noted in #373: previously anyone who could reach a node's ports could join the cluster and send messages. It adds two independent security settings to `RemoteNodeConfig`. Full security requires both; with neither, behavior is as before (trusted networks only).

## Cluster key

`cluster_key: Option<ClusterKey>` is a 32-byte pre-shared secret, always compiled (pure Rust, audited RustCrypto crates: chacha20poly1305, hkdf, hmac, sha2). Two independent subkeys are derived from it with HKDF-SHA256:

- **Gossip encryption.** A custom chitchat transport seals every UDP datagram with XChaCha20-Poly1305, with the cluster id as associated data. Wire format: `[version][24-byte random nonce][ciphertext + tag]`. Random 24-byte nonces stay collision-free without coordination even though all nodes encrypt under the same key. Packets that fail to authenticate are dropped (rate-limited warn), so nodes without the key can neither read the registry nor poison it, and garbage packets cannot kill the gossip loop. The 41-byte overhead can in theory push a datagram chitchat budgeted at exactly 65,507 bytes over the limit; real gossip messages are far smaller, documented rather than solved.
- **Messaging authentication.** Connections mutually prove key possession with an HMAC-SHA256 challenge-response during the handshake. The key never crosses the wire, so this holds even on plaintext TCP. Direction labels prevent reflecting a peer's MAC back at it, fresh nonces prevent replay, and a keyed client refuses to talk to a keyless server (and vice versa), so the connection cannot be downgraded.

## Mutual TLS

`tls: Option<TlsConfig>` (cargo feature `tls`, off by default) encrypts the messaging layer with TLS 1.3 via tokio-rustls. `TlsConfig::from_pem` takes the cluster CA, the node's certificate chain, and its key; the server requires CA-signed client certificates and the client verifies the server's chain against the same CA. Hostname verification is intentionally skipped, since nodes are dialed by gossip-advertised IPs; possession of a CA-signed certificate is what makes a peer a cluster member. `TlsConfig::from_rustls` is the escape hatch for custom verification, revocation, or a different crypto provider. The built-in constructors pin the ring provider explicitly, so nothing conflicts with a process-level default the host application may install.

TLS without a cluster key leaves gossip open, so the registry can still be poisoned; bootstrap logs a warning for that combination.

## Connection handshake

Every messaging connection now starts with a hello exchange before any request frames, whether or not security is configured: `ClientHello` (protocol version, cluster id, nonce), `ServerHello` (nonce, MAC when keyed), `ClientAuth` (MAC when keyed), then `Accept` or `Reject`. This is a wire-breaking change to the unreleased crate. It buys protocol versioning, a clear `ClusterMismatch` error instead of silent misrouting, and a place for the auth exchange. Failures surface as new `RemoteSendError::{ClusterMismatch, AuthFailed, Handshake}` variants on the dialing side and a warn plus close on the accepting side. A new `handshake_timeout` (default 10s) covers TLS and the hello exchange on the server, so a client that connects and stalls cannot hold a socket open. `connect_timeout` now covers dial to ready: TCP connect, TLS, and the handshake.

## Not in scope

- [ ] Key rotation without downtime. Rotating the cluster key is a rolling restart, during which old-key and new-key nodes temporarily cannot see each other. Multi-key acceptance (memberlist style) can be added later without a wire break.
- [ ] Certificate hot-reload. Changing certificates requires a restart, or `from_rustls` with a custom cert resolver.
- [ ] Passphrase-derived keys. `ClusterKey` takes 32 raw bytes; bring your own KDF.

## Testing

- 8 new integration tests: PSK cluster end to end (encrypted gossip plus authenticated messaging carrying register/lookup/ask/tell), wrong-key and keyless nodes never joining a keyed cluster, a garbage TCP connection being closed without affecting the cluster, stalled handshakes timing out, TLS+PSK end to end, TLS rejecting plaintext peers, and TLS rejecting certificates from an untrusted CA.
- 12 new unit tests for the handshake state machine over an in-memory duplex (key matrix, downgrade attempts, tampered MAC, cluster mismatch, bad version, garbage frames), 8 for the gossip AEAD (round trip, tamper, wrong key, wrong cluster AAD, truncation, live socket pair, recv surviving garbage), plus key derivation and PEM parsing tests.
- The existing 19 cluster tests pass unchanged, now exercising the keyless handshake on every connection.
- Verified end to end with the new `secure` example: two nodes with mutual TLS and a shared cluster key register, look up, and ask across nodes.
- CI runs the remote crate with and without the `tls` feature in the build, test, and clippy matrices.