### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3](https://github.com/tqwewe/kameo/compare/v0.22.2...v0.22.3) - 2026-07-21
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo_macros [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.22.2](https://github.com/tqwewe/kameo/compare/v0.22.1...v0.22.2) - 2026-07-17
 
 ### <!-- 3 -->Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "actors", "console", "macros"]
 
 [workspace.dependencies]
-kameo = { path = ".", version = "0.22.2" }
+kameo = { path = ".", version = "0.22.3" }
 
 futures = "0.3"
 tokio = "1.47"
@@ -18,7 +18,7 @@ all-features = true
 
 [package]
 name = "kameo"
-version = "0.22.2"
+version = "0.22.3"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Fault-tolerant Async Actors Built on Tokio"
@@ -47,7 +47,7 @@ metrics = ["dep:metrics"]
 hotpath = ["dep:hotpath", "hotpath/hotpath"]
 
 [dependencies]
-kameo_macros = { version = "0.21.1", path = "./macros", optional = true }
+kameo_macros = { version = "0.21.2", path = "./macros", optional = true }
 
 const-fnv1a-hash = { version = "1.1.0", optional = true }
 const-str = { version = "1.1", features = ["proc"], optional = true }

--- a/actors/CHANGELOG.md
+++ b/actors/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2](https://github.com/tqwewe/kameo/compare/actors-v0.8.1...actors-v0.8.2) - 2026-07-21
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.8.1](https://github.com/tqwewe/kameo/compare/actors-v0.8.0...actors-v0.8.1) - 2026-07-17
 
 ### <!-- 0 -->Added

--- a/actors/Cargo.toml
+++ b/actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_actors"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Utility actors for kameo"

--- a/console/CHANGELOG.md
+++ b/console/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5](https://github.com/tqwewe/kameo/compare/console-v0.1.4...console-v0.1.5) - 2026-07-21
+
+### <!-- 5 -->Misc
+
+- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
+
+
 ## [0.1.4](https://github.com/tqwewe/kameo/compare/console-v0.1.3...console-v0.1.4) - 2026-07-17
 
 ### <!-- 5 -->Misc

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_console"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal UI for monitoring a running kameo actor system"

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2](https://github.com/tqwewe/kameo/compare/macros-v0.21.1...macros-v0.21.2) - 2026-07-21
+
+### <!-- 5 -->Misc
+
+- Update syn requirement from 2.0.52 to 3.0.2 ([#383](https://github.com/tqwewe/kameo/pull/383)) [</>](https://github.com/tqwewe/kameo/commit/b4aaee797cc3fd12e8194db406d9d73a6bc021ce)
+
+
 ## [0.21.1](https://github.com/tqwewe/kameo/compare/macros-v0.21.0...macros-v0.21.1) - 2026-07-05
 
 ### <!-- 4 -->Documentation

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kameo_macros"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Fault-tolerant Async Actors Built on Tokio macros"


### PR DESCRIPTION



## 🤖 New release

* `kameo_macros`: 0.21.1 -> 0.21.2
* `kameo`: 0.22.2 -> 0.22.3 (✓ API compatible changes)
* `kameo_actors`: 0.8.1 -> 0.8.2
* `kameo_console`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `kameo_macros`

<blockquote>

## [0.21.2](https://github.com/tqwewe/kameo/compare/macros-v0.21.1...macros-v0.21.2) - 2026-09-13

### <!-- 5 -->Misc

- Update syn requirement from 2.0.52 to 3.0.2 ([#383](https://github.com/tqwewe/kameo/pull/383)) [</>](https://github.com/tqwewe/kameo/commit/b4aaee797cc3fd12e8194db406d9d73a6bc021ce)
</blockquote>

## `kameo`

<blockquote>

## [0.22.3](https://github.com/tqwewe/kameo/compare/v0.22.2...v0.22.3) - 2026-09-13

### <!-- 1 -->Changed

- Update libp2p to 0.57.0 ([#403](https://github.com/tqwewe/kameo/pull/403)) [</>](https://github.com/tqwewe/kameo/commit/90751f0f982331fba97ca8ef343d99f0cc60d07b)

### <!-- 3 -->Fixed

- Serialize supervised restarts ([#387](https://github.com/tqwewe/kameo/pull/387)) [</>](https://github.com/tqwewe/kameo/commit/1b6bffb6d0fdc05492349c08cd3727621a810ed7)

### <!-- 5 -->Misc

- Update syn requirement from 2.0.52 to 3.0.2 ([#383](https://github.com/tqwewe/kameo/pull/383)) [</>](https://github.com/tqwewe/kameo/commit/b4aaee797cc3fd12e8194db406d9d73a6bc021ce)
</blockquote>

## `kameo_actors`

<blockquote>

## [0.8.2](https://github.com/tqwewe/kameo/compare/actors-v0.8.1...actors-v0.8.2) - 2026-09-13

### <!-- 5 -->Misc

- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
</blockquote>

## `kameo_console`

<blockquote>

## [0.1.5](https://github.com/tqwewe/kameo/compare/console-v0.1.4...console-v0.1.5) - 2026-09-13

### <!-- 5 -->Misc

- Updated the following local packages: kameo [</>](https://github.com/tqwewe/kameo/commit/0000000)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).