### PR TITLE
fix(supervision): serialize supervised restarts

### DIFF
--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -285,12 +285,6 @@ where
                     }
                 }
 
-                actor_ref
-                    .links
-                    .lock()
-                    .await
-                    .notify_links(id, reason.clone(), mailbox_rx);
-
                 log_actor_stop_reason(id, name, &reason);
                 let on_stop_res =
                     AssertUnwindSafe(actor.on_stop(actor_ref.clone(), reason.clone()))
@@ -324,6 +318,12 @@ where
                     }
                 }
 
+                actor_ref
+                    .links
+                    .lock()
+                    .await
+                    .notify_links(id, reason.clone(), mailbox_rx);
+
                 Ok((actor, reason))
             }
             Err(err) => {
@@ -332,7 +332,7 @@ where
                     .set(Err(err.clone()))
                     .expect("nothing should set the startup result");
 
-                let reason = ActorStopReason::Panicked(err);
+                let reason = ActorStopReason::Panicked(err.clone());
                 log_actor_stop_reason(id, name, &reason);
 
                 actor_ref.links.set_children_parent_shutdown().await;
@@ -340,25 +340,22 @@ where
                 // startup failed; the supervisor may still restart us per policy
                 let is_restarting = actor_ref.links.lock().await.will_restart(&reason);
                 drain_until_children_closed(&actor_ref.links, &mut mailbox_rx, is_restarting).await;
-                actor_ref
-                    .links
-                    .lock()
-                    .await
-                    .notify_links(id, reason.clone(), mailbox_rx);
 
                 #[cfg(feature = "console")]
                 monitor.set_stopped(&reason);
 
                 unregister_actor(&id).await;
 
-                let ActorStopReason::Panicked(err) = reason else {
-                    unreachable!()
-                };
-
                 actor_ref
                     .shutdown_result
                     .set(Err(err.clone()))
                     .expect("nothing should set the startup result");
+
+                actor_ref
+                    .links
+                    .lock()
+                    .await
+                    .notify_links(id, reason, mailbox_rx);
 
                 Err(err)
             }

--- a/tests/supervision_lifecycle.rs
+++ b/tests/supervision_lifecycle.rs
@@ -1,0 +1,103 @@
+use std::time::Duration;
+
+use kameo::{error::Infallible, prelude::*, supervision::RestartPolicy};
+use tokio::sync::mpsc;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+const ON_STOP_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Event {
+    Started,
+    Stopping,
+    Stopped,
+}
+
+struct Supervisor;
+
+impl Actor for Supervisor {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(this)
+    }
+}
+
+#[derive(Clone)]
+struct Worker {
+    events: mpsc::UnboundedSender<Event>,
+}
+
+impl Actor for Worker {
+    type Args = Self;
+    type Error = Infallible;
+
+    async fn on_start(this: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
+        this.events.send(Event::Started).unwrap();
+        Ok(this)
+    }
+
+    async fn on_stop(
+        &mut self,
+        _: WeakActorRef<Self>,
+        _: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        self.events.send(Event::Stopping).unwrap();
+        tokio::time::sleep(ON_STOP_DELAY).await;
+        self.events.send(Event::Stopped).unwrap();
+        Ok(())
+    }
+}
+
+struct Stop;
+
+impl Message<Stop> for Worker {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Stop, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        ctx.stop();
+    }
+}
+
+async fn recv_event(events: &mut mpsc::UnboundedReceiver<Event>, expected: &str) -> Event {
+    match tokio::time::timeout(TIMEOUT, events.recv()).await {
+        Ok(Some(event)) => event,
+        Ok(None) => panic!("lifecycle event channel closed before {expected}"),
+        Err(_) => panic!("timed out waiting for {expected}"),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn supervised_restart_waits_for_previous_on_stop() {
+    let supervisor = Supervisor::spawn(Supervisor);
+    let (events_tx, mut events) = mpsc::unbounded_channel();
+    let worker = Worker::supervise(&supervisor, Worker { events: events_tx })
+        .restart_policy(RestartPolicy::Permanent)
+        .spawn()
+        .await;
+
+    assert_eq!(
+        recv_event(&mut events, "initial startup").await,
+        Event::Started
+    );
+
+    worker.tell(Stop).await.unwrap();
+
+    let actual = [
+        recv_event(&mut events, "on_stop start").await,
+        recv_event(&mut events, "on_stop completion").await,
+        recv_event(&mut events, "restart startup").await,
+    ];
+
+    assert_eq!(
+        actual,
+        [Event::Stopping, Event::Stopped, Event::Started],
+        "next incarnation started before previous on_stop completed"
+    );
+
+    supervisor.kill();
+    tokio::time::timeout(TIMEOUT, supervisor.wait_for_shutdown())
+        .await
+        .expect("timed out waiting for supervisor shutdown");
+}


### PR DESCRIPTION
## Problem

A supervised restart could hand the child mailbox back to the supervisor before the previous incarnation finished local teardown.

That allowed the next incarnation to run `on_start` while the previous incarnation was still inside `on_stop`.

## Fix

Delay notifying linked actors until after local shutdown finalization has completed.

For successfully started actors, `notify_links` now runs after `on_stop`, monitor/registry cleanup, and shutdown result publication. Startup failure follows the same ordering after child shutdown, monitor/registry cleanup, and shutdown result publication.

## Tests

Adds `tests/supervision_lifecycle.rs`, which verifies a permanently supervised child observes:

- previous `on_stop` starts
- previous `on_stop` completes
- next `on_start` runs

Verified with:

- `rtk cargo fmt --check`
- `rtk cargo test -p kameo --tests`
- `rtk cargo clippy -p kameo --test supervision_lifecycle -- -D warnings`
- `rtk git diff --check`